### PR TITLE
Make sure a config value can override the default value of a writeOnce attribute

### DIFF
--- a/src/ui/react/src/oop/attribute.js
+++ b/src/ui/react/src/oop/attribute.js
@@ -137,10 +137,10 @@
             // else if the attribute has writeOnce value, set it from the passed configuration or from the
             // default value, in this order. Otherwise, return miserable.
             else if (currentAttr.writeOnce) {
-                if (hasDefaultValue) {
-                    value = currentAttr.value;
-                } else if (hasPassedValueViaConfig) {
+                if (hasPassedValueViaConfig) {
                     value = this.__config__[attr];
+                } else if (hasDefaultValue) {
+                    value = currentAttr.value;
                 } else {
                     return;
                 }

--- a/src/ui/react/test/attribute.js
+++ b/src/ui/react/test/attribute.js
@@ -252,17 +252,16 @@
             Clazz.ATTRS = {
                 attr1: {
                     writeOnce: true,
-                    value: 'val1'
                 }
             };
 
             Clazz = AlloyEditor.OOP.extend(Clazz, AlloyEditor.Attribute);
 
             var inst = new Clazz({
-                attr1: 'val2'
+                attr1: 'val1'
             });
 
-            inst.set('attr1', 'val3');
+            inst.set('attr1', 'val2');
 
             assert.strictEqual('val1', inst.get('attr1'));
         });
@@ -274,7 +273,8 @@
 
             Clazz.ATTRS = {
                 attr1: {
-                    writeOnce: true
+                    writeOnce: true,
+                    value: 'val1'
                 }
             };
 


### PR DESCRIPTION
Fixes #294

Before this patch, the default value of a `writeOnce` attribute could not be overriden with a config value. The tests were expecting such behaviour.