### PR TITLE
Fixed variable hoisting to prevent React from always being undefined.

### DIFF
--- a/src/ui/react/template/alloy-editor-core.template
+++ b/src/ui/react/template/alloy-editor-core.template
@@ -12,7 +12,7 @@
     <%= main %>
 
     if (typeof React === 'undefined') {
-    	var React = AlloyEditor.React;
+        React = AlloyEditor.React;
     }
 
     if (typeof window !== 'undefined') {

--- a/src/ui/react/template/alloy-editor.template
+++ b/src/ui/react/template/alloy-editor.template
@@ -22,7 +22,7 @@
     <%= react %>
 
     if (typeof React === 'undefined' && typeof AlloyEditor !== 'undefined') {
-        var React = AlloyEditor.React;
+        React = AlloyEditor.React;
     }
 
     if (typeof window !== 'undefined') {


### PR DESCRIPTION
Having a `var React` statement in these lines will always cause `React` to be undefined in the same scope, due to javascript variable hoisting.

This should fix the issue when trying to use alloy with react already present on the page and should also be an intermediate fix for #240.
Please check with other occurences, I only found these two occurences but there might be more.