### PR TITLE
Moved the contenteditable test to the selection test method

### DIFF
--- a/src/core/table.js
+++ b/src/core/table.js
@@ -1,6 +1,18 @@
 (function() {
     'use strict';
 
+    var IE_BUGGY_EDITABLE_ELEMENT = {
+        "table": 1,
+        "col": 1,
+        "colgroup": 1,
+        "tbody": 1,
+        "td": 1,
+        "tfoot": 1,
+        "th": 1,
+        "thead": 1,
+        "tr": 1
+    };
+
     /**
      * Table class utility. Provides methods for create, delete and update tables.
      *
@@ -92,6 +104,29 @@
             }
 
             return table;
+        },
+
+        /**
+         * Checks if the given table can be considered as editable. This method
+         * method is there to workaround a limitation of IE where for some
+         * elements (like table), `isContentEditable` is always false because IE
+         * does not support contenteditable on such elements but that does not
+         * really mean the content of such elements can not be edited.
+         *
+         * See https://msdn.microsoft.com/en-us/library/ms537837%28v=VS.85%29.aspx
+         *
+         * @method isEditable
+         * @param {CKEDITOR.dom.element} el the table element to test
+         * @return {Boolean}
+         */
+        isEditable: function (el) {
+            if ( !CKEDITOR.env.ie || !el.is(IE_BUGGY_EDITABLE_ELEMENT) ) {
+                return !el.isReadOnly();
+            }
+            if ( el.hasAttribute('contenteditable') ) {
+                return (el.getAttribute('contenteditable') !== 'false');
+            }
+            return this.isEditable(el.getParent());
         },
 
         /**

--- a/src/ui/react/src/components/toolbars/toolbar-styles.jsx
+++ b/src/ui/react/src/components/toolbars/toolbar-styles.jsx
@@ -121,10 +121,6 @@
          * @return {Object|null} The content which should be rendered.
          */
         render: function() {
-            if (this.props.editorEvent && !this.props.editorEvent.data.nativeEvent.target.isContentEditable) {
-                return null;
-            }
-
             var currentSelection = this._getCurrentSelection();
 
             if (currentSelection) {

--- a/src/ui/react/src/selections/selection-test.js
+++ b/src/ui/react/src/selections/selection-test.js
@@ -3,11 +3,11 @@
 
     var linkSelectionTest = function(payload) {
         var nativeEditor = payload.editor.get('nativeEditor'),
-            element = (new CKEDITOR.Link(nativeEditor)).getFromSelection();
+            element;
 
         return !!(
             !nativeEditor.isSelectionEmpty() &&
-            element &&
+            (element = (new CKEDITOR.Link(nativeEditor)).getFromSelection()) &&
             !element.isReadOnly()
         );
     };
@@ -26,14 +26,14 @@
         var nativeEditor = payload.editor.get('nativeEditor');
 
         var selectionEmpty = nativeEditor.isSelectionEmpty();
-        var selectionElement = nativeEditor.getSelection().getCommonAncestor();
+
         var selectionData = payload.data.selectionData;
 
         return !!(
             !selectionData.element &&
             selectionData.region &&
             !selectionEmpty &&
-            !selectionElement.isReadOnly()
+            !nativeEditor.getSelection().getCommonAncestor().isReadOnly()
         );
     };
 

--- a/src/ui/react/src/selections/selection-test.js
+++ b/src/ui/react/src/selections/selection-test.js
@@ -39,9 +39,10 @@
 
     var tableSelectionTest = function(payload) {
         var nativeEditor = payload.editor.get('nativeEditor'),
-            element = (new CKEDITOR.Table(nativeEditor)).getFromSelection();
+            table = new CKEDITOR.Table(nativeEditor),
+            element = table.getFromSelection();
 
-        return !!(element && !element.isReadOnly());
+        return !!(element && table.isEditable(element));
     };
 
     AlloyEditor.SelectionTest = {

--- a/src/ui/react/src/selections/selection-test.js
+++ b/src/ui/react/src/selections/selection-test.js
@@ -2,31 +2,46 @@
     'use strict';
 
     var linkSelectionTest = function(payload) {
-        var nativeEditor = payload.editor.get('nativeEditor');
+        var nativeEditor = payload.editor.get('nativeEditor'),
+            element = (new CKEDITOR.Link(nativeEditor)).getFromSelection();
 
-        return !nativeEditor.isSelectionEmpty() && (new CKEDITOR.Link(nativeEditor).getFromSelection());
+        return !!(
+            !nativeEditor.isSelectionEmpty() &&
+            element &&
+            !element.isReadOnly()
+        );
     };
 
     var imageSelectionTest = function(payload) {
         var selectionData = payload.data.selectionData;
 
-        return (selectionData.element && selectionData.element.getName() === 'img');
+        return !!(
+            selectionData.element &&
+            selectionData.element.getName() === 'img' &&
+            !selectionData.element.isReadOnly()
+        );
     };
 
     var textSelectionTest = function(payload) {
         var nativeEditor = payload.editor.get('nativeEditor');
 
         var selectionEmpty = nativeEditor.isSelectionEmpty();
-
+        var selectionElement = nativeEditor.getSelection().getCommonAncestor();
         var selectionData = payload.data.selectionData;
 
-        return (!selectionData.element && selectionData.region && !selectionEmpty);
+        return !!(
+            !selectionData.element &&
+            selectionData.region &&
+            !selectionEmpty &&
+            !selectionElement.isReadOnly()
+        );
     };
 
     var tableSelectionTest = function(payload) {
-        var nativeEditor = payload.editor.get('nativeEditor');
+        var nativeEditor = payload.editor.get('nativeEditor'),
+            element = (new CKEDITOR.Table(nativeEditor)).getFromSelection();
 
-        return !!(new CKEDITOR.Table(nativeEditor).getFromSelection());
+        return !!(element && !element.isReadOnly());
     };
 
     AlloyEditor.SelectionTest = {

--- a/src/ui/react/test/selection-test.js
+++ b/src/ui/react/test/selection-test.js
@@ -164,8 +164,8 @@
 
                 nativeEditor = this.editor.get('nativeEditor');
                 content = '<table id="editable"><tr><td>Editable</td></tr><table>';
-                content += '<table id="not-editable" contenteditable="false"><tr><td>Editable</td></tr><table>';
-                content += '<p id="not-table">Not an image</p>';
+                content += '<table id="not-editable" contenteditable="false"><tr><td>Not editable</td></tr><table>';
+                content += '<p id="not-table">Not a table</p>';
                 nativeEditor.setData(content);
             });
 

--- a/src/ui/react/test/selection-test.js
+++ b/src/ui/react/test/selection-test.js
@@ -1,0 +1,197 @@
+(function() {
+    'use strict';
+
+    var assert = chai.assert;
+
+    describe('SelectionTest', function() {
+        var getPayload = function(element, region) {
+                return {
+                    editor: this.editor,
+                    data: {
+                        selectionData: {
+                            element: element,
+                            region: region
+                        }
+                    }
+                };
+            };
+
+        before(Utils.createAlloyEditor);
+
+        after(Utils.destroyAlloyEditor);
+
+        beforeEach(Utils.beforeEach);
+
+        afterEach(Utils.afterEach);
+
+        describe('link', function() {
+            var linkTest = AlloyEditor.SelectionTest.link,
+                nativeEditor;
+
+            beforeEach(function() {
+                var content;
+
+                nativeEditor = this.editor.get('nativeEditor');
+                content = '<p><a href="#" id="editable">Link</a></p>';
+                content += '<p contenteditable="false"><a href="#" id="not-editable">Link</a></p>';
+                content += '<p id="not-link">Not link</p>';
+                nativeEditor.setData(content);
+            });
+
+            it('should handle empty selection', function() {
+                var payload = getPayload.call(this, nativeEditor.element.findOne('#editable'));
+
+                assert.isFalse(linkTest(payload));
+            });
+
+            it('should handle selection that is not a link', function() {
+                var notLink = nativeEditor.element.findOne('#not-link'),
+                    payload = getPayload.call(this, notLink);
+
+                nativeEditor.getSelection().selectElement(notLink);
+                assert.isFalse(linkTest(payload));
+            });
+
+            it('should detect the link', function() {
+                var editable = nativeEditor.element.findOne('#editable'),
+                    payload = getPayload.call(this, editable);
+
+                nativeEditor.getSelection().selectElement(editable);
+                assert.isTrue(linkTest(payload));
+            });
+
+            it('should handle non editable link', function() {
+                var notEditable = nativeEditor.element.findOne('#not-editable'),
+                    payload = getPayload.call(this, notEditable);
+
+                nativeEditor.getSelection().selectElement(notEditable);
+                assert.isFalse(linkTest(payload));
+            });
+        });
+
+        describe('image', function() {
+            var imageTest = AlloyEditor.SelectionTest.image,
+                nativeEditor;
+
+            beforeEach(function() {
+                var content;
+
+                nativeEditor = this.editor.get('nativeEditor');
+                content = '<img id="editable" src="data:image/gif;base64,R0lGODlhAQABAAAAACw=">';
+                content += '<img id="noneditable" contenteditable="false"' +
+                    'src="data:image/gif;base64,R0lGODlhAQABAAAAACw=">';
+                content += '<p id="not-image">Not an image</p>';
+                nativeEditor.setData(content);
+            });
+
+            it('should detect an image selection', function() {
+                var payload = getPayload.call(this, nativeEditor.element.findOne('#editable'));
+
+                assert.isTrue(imageTest(payload));
+            });
+
+            it('should handle selection without element', function() {
+                var payload = getPayload.call(this, null);
+
+                assert.isFalse(imageTest(payload));
+            });
+
+            it('should handle not image selection', function() {
+                var payload = getPayload.call(this, nativeEditor.element.findOne('#not-image'));
+                assert.isFalse(imageTest(payload));
+            });
+
+            it('should check whether is editable', function() {
+                var payload = getPayload.call(this, nativeEditor.element.findOne('#not-editable'));
+
+                assert.isFalse(imageTest(payload));
+            });
+        });
+
+        describe('text', function() {
+            var textTest = AlloyEditor.SelectionTest.text,
+                nativeEditor;
+
+            beforeEach(function() {
+                var content;
+
+                nativeEditor = this.editor.get('nativeEditor');
+                content = '<p><span id="editable">Some editable text</span></p>';
+                content += '<p contenteditable="false"><span id="not-editable">Non editable</span></p>';
+                nativeEditor.setData(content);
+            });
+
+            it('should detect an editable text selection', function() {
+                var editable = nativeEditor.element.findOne('#editable'),
+                    region = [],
+                    payload = getPayload.call(this, null, region);
+
+                nativeEditor.getSelection().selectElement(editable);
+                assert.isTrue(textTest(payload));
+            });
+
+            it('should detect a non editable text selection', function() {
+                var notEditable = nativeEditor.element.findOne('#not-editable'),
+                    region = [],
+                    payload = getPayload.call(this, null, region);
+
+                nativeEditor.getSelection().selectElement(notEditable);
+                assert.isFalse(textTest(payload));
+            });
+
+            it('should handle a selected element', function () {
+                var editable = nativeEditor.element.findOne('#editable'),
+                    region = [],
+                    payload = getPayload.call(this, editable, region);
+
+                nativeEditor.getSelection().selectElement(editable);
+                assert.isFalse(textTest(payload));
+            });
+
+            it('should handle an empty selection', function () {
+                var payload = getPayload.call(this, null, []);
+
+                assert.isFalse(textTest(payload));
+            });
+        });
+
+        describe('table', function() {
+            var tableTest = AlloyEditor.SelectionTest.table,
+                nativeEditor;
+
+            beforeEach(function() {
+                var content;
+
+                nativeEditor = this.editor.get('nativeEditor');
+                content = '<table id="editable"><tr><td>Editable</td></tr><table>';
+                content += '<table id="not-editable" contenteditable="false"><tr><td>Editable</td></tr><table>';
+                content += '<p id="not-table">Not an image</p>';
+                nativeEditor.setData(content);
+            });
+
+            it('should detect a table', function() {
+                var editable = nativeEditor.element.findOne('#editable'),
+                    payload = getPayload.call(this, editable);
+
+                nativeEditor.getSelection().selectElement(editable);
+                assert.isTrue(tableTest(payload));
+            });
+
+            it('should handle non editable table', function() {
+                var notEditable = nativeEditor.element.findOne('#not-editable'),
+                    payload = getPayload.call(this, notEditable);
+
+                nativeEditor.getSelection().selectElement(notEditable);
+                assert.isFalse(tableTest(payload));
+            });
+
+            it('should handle not table selection', function() {
+                var notTable = nativeEditor.element.findOne('#not-table'),
+                    payload = getPayload.call(this, notTable);
+
+                nativeEditor.getSelection().selectElement(notTable);
+                assert.isFalse(tableTest(payload));
+            });
+        });
+    });
+}());

--- a/src/ui/react/test/toolbar-styles.jsx
+++ b/src/ui/react/test/toolbar-styles.jsx
@@ -14,22 +14,6 @@
 
         afterEach(Utils.afterEach);
 
-        it('should not render when user interacts with a non-editable node', function() {
-            var editorEvent = {
-                data: {
-                    nativeEvent: {
-                        target: {
-                            isContentEditable: false
-                        }
-                    }
-                }
-            };
-
-            var toolbarStyles = React.render(<AlloyEditor.ToolbarStyles editor={this.editor} editorEvent={editorEvent}/>, this.container);
-
-            assert.isNull(React.findDOMNode(toolbarStyles));
-        });
-
         it('should constrain the toolbar\'s position', function() {
             var toolbarStyles = React.render(<AlloyEditor.ToolbarStyles editor={this.editor}/>, this.container);
 

--- a/test/core/test/fixtures/editable_by_parent_nested_tables.html
+++ b/test/core/test/fixtures/editable_by_parent_nested_tables.html
@@ -1,0 +1,17 @@
+<div contenteditable="true">
+<table>
+    <tbody>
+        <tr>
+            <td>
+                <table id="deep">
+                    <tbody>
+                    <tr>
+                        <td>&nbsp;</td>
+                    </tr>
+                    </tbody>
+                </table>
+            </td>
+        </tr>
+    </tbody>
+</table>
+</div>

--- a/test/core/test/fixtures/editable_by_parent_table.html
+++ b/test/core/test/fixtures/editable_by_parent_table.html
@@ -1,0 +1,9 @@
+<div contenteditable="true">
+<table>
+    <tbody>
+        <tr>
+            <td>&nbsp;</td>
+        </tr>
+    </tbody>
+</table>
+</div>

--- a/test/core/test/fixtures/not_editable_attribute_table.html
+++ b/test/core/test/fixtures/not_editable_attribute_table.html
@@ -1,0 +1,18 @@
+<div contenteditable="true">
+<table contenteditable="false" id="not-editable">
+    <tbody>
+        <tr>
+            <td>&nbsp;</td>
+        </tr>
+    </tbody>
+</table>
+</div>
+<div contenteditable="false">
+<table contenteditable="true" id="editable">
+    <tbody>
+        <tr>
+            <td>&nbsp;</td>
+        </tr>
+    </tbody>
+</table>
+</div>

--- a/test/core/test/fixtures/not_editable_by_parent_table.html
+++ b/test/core/test/fixtures/not_editable_by_parent_table.html
@@ -1,0 +1,9 @@
+<div contenteditable="false">
+<table>
+    <tbody>
+        <tr>
+            <td>&nbsp;</td>
+        </tr>
+    </tbody>
+</table>
+</div>

--- a/test/core/test/table.js
+++ b/test/core/test/table.js
@@ -393,5 +393,47 @@
 
             assert.isUndefined(table);
         });
+
+
+        it('should consider the table as editable', function() {
+            var initialFixture = getFixture('editable_by_parent_table.html');
+
+            bender.tools.selection.setWithHtml(this.nativeEditor, initialFixture);
+
+            var tableUtils = new CKEDITOR.Table(this.nativeEditor);
+
+            assert.isTrue(tableUtils.isEditable(this.nativeEditor.element.findOne('table')));
+        });
+
+        it('should take parent contenteditable into account', function() {
+            var initialFixture = getFixture('not_editable_by_parent_table.html');
+
+            bender.tools.selection.setWithHtml(this.nativeEditor, initialFixture);
+
+            var tableUtils = new CKEDITOR.Table(this.nativeEditor);
+
+            assert.isFalse(tableUtils.isEditable(this.nativeEditor.element.findOne('table')));
+        });
+
+        it('should take table contenteditable attribute into account', function () {
+            var initialFixture = getFixture('not_editable_attribute_table.html');
+
+            bender.tools.selection.setWithHtml(this.nativeEditor, initialFixture);
+
+            var tableUtils = new CKEDITOR.Table(this.nativeEditor);
+
+            assert.isFalse(tableUtils.isEditable(this.nativeEditor.element.findOne('#not-editable')));
+            assert.isTrue(tableUtils.isEditable(this.nativeEditor.element.findOne('#editable')));
+        });
+
+        it('should handle nested table', function() {
+            var initialFixture = getFixture('editable_by_parent_nested_tables.html');
+
+            bender.tools.selection.setWithHtml(this.nativeEditor, initialFixture);
+
+            var tableUtils = new CKEDITOR.Table(this.nativeEditor);
+
+            assert.isTrue(tableUtils.isEditable(this.nativeEditor.element.findOne('#deep')));
+        });
     });
 }());


### PR DESCRIPTION
A check against the `isContentEditable` property of the target element was added in the Styles toolbar render method to avoid letting the user style a non editable element. In most cases that's perfectly fine but if you use the widget CKEditor plugin this becomes a problem because this plugin wraps the widget HTML element in a non editable element while you might still want to be able to style the widget with some (custom) buttons.

~~To workaround this problem, this patch adds the support for an optional `canStyleElement` config property in the Styles toolbar so that it's possible to pass a custom function to decide whether the element can be styled or not.~~

~~This does not break any tests and if the approach is OK, I'll of course add some unit tests for that feature.~~

The new version of this patch moves the content editable check to the selection test methods.