### PR TITLE
Set contenteditable=false on editor destroy() when enableContentEditable is true

### DIFF
--- a/src/ui/react/src/adapter/alloy-editor.js
+++ b/src/ui/react/src/adapter/alloy-editor.js
@@ -71,6 +71,9 @@
                 var editable = nativeEditor.editable();
                 if (editable) {
                     editable.removeClass('ae-editable');
+                    if (this.get('enableContentEditable')) {
+                        this.get('srcNode').setAttribute('contenteditable', 'false');
+                    }
                 }
 
                 nativeEditor.destroy();


### PR DESCRIPTION
This complements the [behavior](https://github.com/liferay/alloy-editor/blob/master/src/ui/react/src/adapter/alloy-editor.js#L27-L29) on editor creation.