### PR TITLE
Fire editorUpdate event when UI state is updated

### DIFF
--- a/src/ui/react/src/components/main.jsx
+++ b/src/ui/react/src/components/main.jsx
@@ -117,11 +117,20 @@
         componentDidUpdate: function (prevProps, prevState) {
             var domNode = React.findDOMNode(this);
 
+            var editor = this.props.editor.get('nativeEditor');
+
             if (domNode) {
-                this.props.editor.get('nativeEditor').fire('ariaUpdate', {
+                editor.fire('ariaUpdate', {
                     message: this._getAvailableToolbarsMessage(domNode)
                 });
             }
+
+            editor.fire('editorUpdate', {
+                prevProps: prevProps,
+                prevState: prevState,
+                props: this.props,
+                state: this.state
+            });
         },
 
         _getAriaUpdateTemplate: function(ariaUpdate) {

--- a/src/ui/react/test/alloy-editor.js
+++ b/src/ui/react/test/alloy-editor.js
@@ -119,6 +119,34 @@
             });
         });
 
+        describe('UI component integration', function() {
+            beforeEach(function(done) {
+                initEditor.call(this, done);
+            });
+
+            afterEach(function() {
+                cleanUpEditor.call(this);
+            });
+
+            it('should fire an editorUpdate event when the component state changes', function(done) {
+                var onEditorUpdate = sinon.stub();
+
+                var alloyEditor = this.alloyEditor;
+
+                var nativeEditor = alloyEditor.get('nativeEditor');
+
+                nativeEditor.on('editorUpdate', onEditorUpdate);
+
+                nativeEditor.on('uiReady', function() {
+                    alloyEditor._mainUI.setState({hidden: true});
+
+                    assert.ok(onEditorUpdate.calledOnce);
+
+                    done();
+                });
+            });
+        });
+
         it('should create an instance when the passed srcNode is a DOM element', function(done) {
             var el = document.createElement('div');
             el.setAttribute('id', 'editable1');


### PR DESCRIPTION
Hey @ipeychev, what do you think about this? Do you think firing on `componentDidUpdate` could cause some performance impact? Should we have an attribute to control wether we fire the event or not?

In addition... I think it's time we get some event emitter in there so we can start firing events from the AlloyEditor instance instead of CKEditor. What do you think?