### PR TITLE
Make ButtonStyle.isActive() work if there is no selection.

### DIFF
--- a/src/ui/react/src/components/base/button-style.js
+++ b/src/ui/react/src/components/base/button-style.js
@@ -58,6 +58,9 @@
             var editor = this.props.editor.get('nativeEditor');
 
             var elementPath = editor.elementPath();
+            if (!elementPath) {
+                return false;
+            }
 
             result = this.getStyle().checkActive(elementPath, editor);
 

--- a/src/ui/react/src/components/buttons/button-styles.jsx
+++ b/src/ui/react/src/components/buttons/button-styles.jsx
@@ -121,13 +121,18 @@
         _checkActive: function(styleConfig) {
             var nativeEditor = this.props.editor.get('nativeEditor');
 
+            var elementPath = nativeEditor.elementPath();
+            if (!elementPath) {
+                return false;
+            }
+
             // Styles with wildcard element (*) won't be considered active by CKEditor. Defaulting
             // to a 'span' element works for most of those cases with no defined element.
             styleConfig = CKEDITOR.tools.merge({element: 'span'}, styleConfig);
 
             var style = new CKEDITOR.style(styleConfig);
 
-            return style.checkActive(nativeEditor.elementPath(), nativeEditor);
+            return style.checkActive(elementPath, nativeEditor);
         },
 
         /**


### PR DESCRIPTION
This makes it possible to create style buttons in a toolbar that is always visible, rather than the default toolbars that only appear when you select something.