### PR TITLE
Use focus event instead of contentDOM to make sure initialization always runs

### DIFF
--- a/src/ui/react/src/adapter/alloy-editor.js
+++ b/src/ui/react/src/adapter/alloy-editor.js
@@ -43,7 +43,7 @@
 
             AlloyEditor.Lang.mix(editor.config, config);
 
-            editor.once('contentDom', function() {
+            editor.once('focus', function() {
                 editor.editable().addClass('ae-editable');
             });
 

--- a/src/ui/react/src/components/main.jsx
+++ b/src/ui/react/src/components/main.jsx
@@ -102,7 +102,7 @@
                 this._setUIHidden(document.activeElement);
             }, this.props.eventsDelay, this);
 
-            editor.once('contentDom', function() {
+            editor.once('focus', function() {
                 document.addEventListener('mousedown', this._mousedownListener);
                 document.addEventListener('keydown', this._keyDownListener);
             }.bind(this));


### PR DESCRIPTION
Hey @ipeychev, this is the fix for #371.

I've been fighting to get a proper test for a while and I can't spend much more time on it. On one side, `React.TestUtils` can't simulate pure DOM events, so we have to use CKEditor jquery or add something else.

Also, for some reason, I was observing a weird initialization order when destroying and recreating an AlloyEditor instance, which prevented me from covering the use case where we destroy and recreate the editor.