### PR TITLE
Do not prevent plugin from being created if original CKEditor one exists

### DIFF
--- a/src/plugins/dragresize.js
+++ b/src/plugins/dragresize.js
@@ -9,7 +9,7 @@
 (function() {
     'use strict';
 
-    if (CKEDITOR.plugins.get('dragresize') || CKEDITOR.plugins.get('ae_dragresize')) {
+    if (CKEDITOR.plugins.get('ae_dragresize')) {
         return;
     }
 

--- a/src/plugins/tableresize.js
+++ b/src/plugins/tableresize.js
@@ -6,7 +6,7 @@
 (function() {
     'use strict';
 
-    if (CKEDITOR.plugins.get('tableresize') || CKEDITOR.plugins.get('ae_tableresize')) {
+    if (CKEDITOR.plugins.get('ae_tableresize')) {
         return;
     }
 

--- a/src/plugins/tabletools.js
+++ b/src/plugins/tabletools.js
@@ -6,12 +6,8 @@
 ( function() {
 	'use strict';
 
-    if (CKEDITOR.plugins.get('tabletools') || CKEDITOR.plugins.get('ae_tabletools')){
-       if (!CKEDITOR.plugins.get('ae_tabletools')) {
-            CKEDITOR.plugins.add('ae_tabletools', {});
-
-            return;
-        }
+    if (CKEDITOR.plugins.get('ae_tabletools')){
+		return;
     }
 
 	var cellNodeRegex = /^(?:td|th)$/;


### PR DESCRIPTION
Hey @ipeychev this fixes #379.

I tested this using a custom build of CKEditor with all of the default plugins. To be able to create proper tests, we'd have to commit that one and use it as part of the test process, so we'd have to keep two copies of CKEditor in our repo. 

Do you think it is worth keeping it for this, or future testing purposes?

