### PR TITLE
Pass correct anchor for all autolinkAdd events.

### DIFF
--- a/src/plugins/autolink.js
+++ b/src/plugins/autolink.js
@@ -201,8 +201,8 @@
                 ckLink.create(content);
                 this._ckLink = ckLink;
 
-                var linkNode = this._startContainer.getNext() || this._startContainer;
-                editor.fire('autolinkAdd', linkNode.getParent());
+                var linkNode = ckLink.getFromSelection();
+                editor.fire('autolinkAdd', linkNode);
 
                 this._subscribeToKeyEvent(editor);
 


### PR DESCRIPTION
The previous code failed on mid-paragraph anchors.
Using the method from ckLink seems to be more robust.