### PR TITLE
ButtonKeystroke (#417, #141)

### DIFF
--- a/src/ui/react/src/components/base/button-keystroke.js
+++ b/src/ui/react/src/components/base/button-keystroke.js
@@ -1,0 +1,69 @@
+(function() {
+    'use strict';
+
+    /**
+     * ButtonKeystroke is a mixin that provides a `keystroke` prop that allows configuring
+     * a function of the instance to be invoked upon the keystroke activation.
+     *
+     * @class ButtonKeystroke
+     */
+    var ButtonKeystroke = {
+        // Allows validating props being passed to the component.
+        propTypes: {
+            /**
+             * The keystroke definition. An object with the following properties:
+             * - fn: The function to be executed
+             * - keys: The keystroke definition, as expected by http://docs.ckeditor.com/#!/api/CKEDITOR.editor-method-setKeystroke
+             * - name: The name for the CKEditor command that will be created. If empty,
+             * a random name will be created on the fly
+             *
+             * @type {Object}
+             */
+            keystroke: React.PropTypes.object.isRequired
+        },
+
+        /**
+         * Lifecycle. Invoked once, both on the client and server, immediately before the initial rendering occurs.
+         *
+         * @method componentWillMount
+         */
+        componentWillMount: function() {
+            var nativeEditor = this.props.editor.get('nativeEditor');
+            var keystroke = this.props.keystroke;
+
+            var commandName = keystroke.name || ((Math.random() * 1e9) >>> 0).toString();
+
+            var command = nativeEditor.getCommand(commandName);
+
+            if (!command) {
+                command = new CKEDITOR.command(nativeEditor, {
+                    exec: function(editor) {
+                            var keystrokeFn = keystroke.fn;
+
+                            if (AlloyEditor.Lang.isString(keystrokeFn)) {
+                                this[keystrokeFn].call(this, editor);
+                            } else if (AlloyEditor.Lang.isFunction(keystrokeFn)) {
+                                keystrokeFn.call(this, editor);
+                            }
+                        }.bind(this)
+                    }
+                );
+
+                nativeEditor.addCommand(commandName, command);
+            }
+
+            nativeEditor.setKeystroke(keystroke.keys, commandName);
+        },
+
+        /**
+         * Lifecycle. Invoked immediately before a component is unmounted from the DOM.
+         *
+         * @method componentWillUnmount
+         */
+        componentWillUnmount: function() {
+            this.props.editor.get('nativeEditor').setKeystroke(this.props.keystroke.keys);
+        }
+    };
+
+    AlloyEditor.ButtonKeystroke = ButtonKeystroke;
+}());

--- a/src/ui/react/src/components/buttons/button-bold.jsx
+++ b/src/ui/react/src/components/buttons/button-bold.jsx
@@ -5,13 +5,14 @@
      * The ButtonBold class provides functionality for styling an selection with strong (bold) style.
      *
      * @uses ButtonCommand
+     * @uses ButtonKeystroke
      * @uses ButtonStateClasses
      * @uses ButtonStyle
      *
      * @class ButtonBold
      */
     var ButtonBold = React.createClass({
-        mixins: [AlloyEditor.ButtonStyle, AlloyEditor.ButtonStateClasses, AlloyEditor.ButtonCommand],
+        mixins: [AlloyEditor.ButtonStyle, AlloyEditor.ButtonStateClasses, AlloyEditor.ButtonCommand, AlloyEditor.ButtonKeystroke],
 
         // Allows validating props being passed to the component.
         propTypes: {
@@ -59,6 +60,10 @@
         getDefaultProps: function() {
             return {
                 command: 'bold',
+                keystroke: {
+                    fn: 'execCommand',
+                    keys: CKEDITOR.CTRL + 66 /*B*/
+                },
                 style: {
                     element: 'strong'
                 }

--- a/src/ui/react/src/components/buttons/button-italic.jsx
+++ b/src/ui/react/src/components/buttons/button-italic.jsx
@@ -5,13 +5,14 @@
      * The ButtonItalic class provides functionality for styling an selection with italic (em) style.
      *
      * @uses ButtonCommand
+     * @uses ButtonKeystroke
      * @uses ButtonStateClasses
      * @uses ButtonStyle
      *
      * @class ButtonItalic
      */
     var ButtonItalic = React.createClass({
-        mixins: [AlloyEditor.ButtonStyle, AlloyEditor.ButtonStateClasses, AlloyEditor.ButtonCommand],
+        mixins: [AlloyEditor.ButtonStyle, AlloyEditor.ButtonStateClasses, AlloyEditor.ButtonCommand, AlloyEditor.ButtonKeystroke],
 
         // Allows validating props being passed to the component.
         propTypes: {
@@ -59,6 +60,10 @@
         getDefaultProps: function() {
             return {
                 command: 'italic',
+                keystroke: {
+                    fn: 'execCommand',
+                    keys: CKEDITOR.CTRL + 73 /*I*/
+                },
                 style: {
                     element: 'em'
                 }

--- a/src/ui/react/src/components/buttons/button-link.jsx
+++ b/src/ui/react/src/components/buttons/button-link.jsx
@@ -8,12 +8,13 @@
      * - Normal: Just a button that allows to switch to the edition mode
      * - Exclusive: The ButtonLinkEdit UI with all the link edition controls.
      *
+     * @uses ButtonKeystroke
      * @uses ButtonStateClasses
      *
      * @class ButtonLink
      */
     var ButtonLink = React.createClass({
-        mixins: [AlloyEditor.ButtonStateClasses],
+        mixins: [AlloyEditor.ButtonKeystroke, AlloyEditor.ButtonStateClasses],
 
         // Allows validating props being passed to the component.
         propTypes: {
@@ -53,6 +54,21 @@
         },
 
         /**
+         * Lifecycle. Returns the default values of the properties used in the widget.
+         *
+         * @method getDefaultProps
+         * @return {Object} The default properties.
+         */
+        getDefaultProps: function() {
+            return {
+                keystroke: {
+                    fn: '_requestExclusive',
+                    keys: CKEDITOR.CTRL + 76 /*L*/
+                }
+            };
+        },
+
+        /**
          * Checks if the current selection is contained within a link.
          *
          * @method isActive
@@ -77,11 +93,21 @@
                 );
             } else {
                 return (
-                    <button aria-label={AlloyEditor.Strings.link} className={cssClass} data-type="button-link" onClick={this.props.requestExclusive.bind(ButtonLink.key)} tabIndex={this.props.tabIndex} title={AlloyEditor.Strings.link}>
+                    <button aria-label={AlloyEditor.Strings.link} className={cssClass} data-type="button-link" onClick={this._requestExclusive} tabIndex={this.props.tabIndex} title={AlloyEditor.Strings.link}>
                         <span className="ae-icon-link"></span>
                     </button>
                 );
             }
+        },
+
+        /**
+         * Requests the link button to be rendered in exclusive mode to allow the creation of a link.
+         *
+         * @protected
+         * @method _requestExclusive
+         */
+        _requestExclusive: function() {
+            this.props.requestExclusive(ButtonLink.key);
         }
     });
 

--- a/src/ui/react/src/components/buttons/button-underline.jsx
+++ b/src/ui/react/src/components/buttons/button-underline.jsx
@@ -5,13 +5,14 @@
      * The ButtonUnderline class provides functionality for underlying a text selection.
      *
      * @uses ButtonCommand
+     * @uses ButtonKeystroke
      * @uses ButtonStateClasses
      * @uses ButtonStyle
      *
      * @class ButtonUnderline
      */
     var ButtonUnderline = React.createClass({
-        mixins: [AlloyEditor.ButtonStyle, AlloyEditor.ButtonStateClasses, AlloyEditor.ButtonCommand],
+        mixins: [AlloyEditor.ButtonStyle, AlloyEditor.ButtonStateClasses, AlloyEditor.ButtonCommand, AlloyEditor.ButtonKeystroke],
 
         // Allows validating props being passed to the component.
         propTypes: {
@@ -59,6 +60,10 @@
         getDefaultProps: function() {
             return {
                 command: 'underline',
+                keystroke: {
+                    fn: 'execCommand',
+                    keys: CKEDITOR.CTRL + 85 /*U*/
+                },
                 style: {
                     element: 'u'
                 }

--- a/src/ui/react/test/button-bold.jsx
+++ b/src/ui/react/test/button-bold.jsx
@@ -4,6 +4,8 @@
     var assert = chai.assert;
     var Simulate = React.addons.TestUtils.Simulate;
 
+    var KEY_B = 66;
+
     describe('ButtonBold', function() {
         this.timeout(35000);
 
@@ -15,12 +17,30 @@
 
         afterEach(Utils.afterEach);
 
-        it('should make a text selection bold', function() {
+        it('should make a text selection bold on click', function() {
             bender.tools.selection.setWithHtml(this.nativeEditor, 'There should be a {selection} made bold.');
 
             var buttonBold = ReactDOM.render(<AlloyEditor.ButtonBold editor={this.editor} />, this.container);
 
             Simulate.click(ReactDOM.findDOMNode(buttonBold));
+
+            var data = bender.tools.getData(this.nativeEditor, {
+                fixHtml: false,
+                compatHtml: true
+            });
+
+            assert.strictEqual(data, '<p>There should be a <strong>selection</strong> made bold.</p>');
+        });
+
+        it('should make a text selection bold on [Ctrl|Cmd] + B', function() {
+            bender.tools.selection.setWithHtml(this.nativeEditor, 'There should be a {selection} made bold.');
+
+            var buttonBold = ReactDOM.render(<AlloyEditor.ButtonBold editor={this.editor} />, this.container);
+
+            happen.keydown(this._editable, {
+                ctrlKey: true,
+                keyCode: KEY_B
+            });
 
             var data = bender.tools.getData(this.nativeEditor, {
                 fixHtml: false,

--- a/src/ui/react/test/button-code.jsx
+++ b/src/ui/react/test/button-code.jsx
@@ -1,0 +1,43 @@
+(function() {
+    'use strict';
+
+    var assert = chai.assert;
+    var Simulate = React.addons.TestUtils.Simulate;
+
+    describe('ButtonCode', function() {
+        this.timeout(35000);
+
+        before(Utils.createAlloyEditor);
+
+        after(Utils.destroyAlloyEditor);
+
+        beforeEach(Utils.beforeEach);
+
+        afterEach(Utils.afterEach);
+
+        it('should make a text selection code on click', function() {
+            bender.tools.selection.setWithHtml(this.nativeEditor, 'There should be a {selection} made code.');
+
+            var buttonCode = ReactDOM.render(<AlloyEditor.ButtonCode editor={this.editor} />, this.container);
+
+            Simulate.click(ReactDOM.findDOMNode(buttonCode));
+
+            var data = bender.tools.getData(this.nativeEditor, {
+                fixHtml: false,
+                compatHtml: true
+            });
+
+            assert.strictEqual(data, '<pre>There should be a selection made code.</pre>');
+        });
+
+        it('should add class which represents pressed button', function() {
+            bender.tools.selection.setWithHtml(this.nativeEditor, '<pre>A {selection} made code.</pre>');
+
+            var buttonCode = ReactDOM.render(<AlloyEditor.ButtonCode editor={this.editor} />, this.container);
+
+            var buttonDOMNode = ReactDOM.findDOMNode(buttonCode);
+
+            assert.strictEqual($(buttonDOMNode).hasClass('ae-button-pressed'), true);
+        });
+    });
+}());

--- a/src/ui/react/test/button-h1.jsx
+++ b/src/ui/react/test/button-h1.jsx
@@ -1,0 +1,43 @@
+(function() {
+    'use strict';
+
+    var assert = chai.assert;
+    var Simulate = React.addons.TestUtils.Simulate;
+
+    describe('ButtonH1', function() {
+        this.timeout(35000);
+
+        before(Utils.createAlloyEditor);
+
+        after(Utils.destroyAlloyEditor);
+
+        beforeEach(Utils.beforeEach);
+
+        afterEach(Utils.afterEach);
+
+        it('should make a text selection h1 on click', function() {
+            bender.tools.selection.setWithHtml(this.nativeEditor, 'There should be a {selection} made h1.');
+
+            var buttonH1 = ReactDOM.render(<AlloyEditor.ButtonH1 editor={this.editor} />, this.container);
+
+            Simulate.click(ReactDOM.findDOMNode(buttonH1));
+
+            var data = bender.tools.getData(this.nativeEditor, {
+                fixHtml: false,
+                compatHtml: true
+            });
+
+            assert.strictEqual(data, '<h1>There should be a selection made h1.</h1>');
+        });
+
+        it('should add class which represents pressed button', function() {
+            bender.tools.selection.setWithHtml(this.nativeEditor, '<h1>A {selection} made h1.</h1>');
+
+            var buttonH1 = ReactDOM.render(<AlloyEditor.ButtonH1 editor={this.editor} />, this.container);
+
+            var buttonDOMNode = ReactDOM.findDOMNode(buttonH1);
+
+            assert.strictEqual($(buttonDOMNode).hasClass('ae-button-pressed'), true);
+        });
+    });
+}());

--- a/src/ui/react/test/button-h2.jsx
+++ b/src/ui/react/test/button-h2.jsx
@@ -1,0 +1,43 @@
+(function() {
+    'use strict';
+
+    var assert = chai.assert;
+    var Simulate = React.addons.TestUtils.Simulate;
+
+    describe('ButtonH2', function() {
+        this.timeout(35000);
+
+        before(Utils.createAlloyEditor);
+
+        after(Utils.destroyAlloyEditor);
+
+        beforeEach(Utils.beforeEach);
+
+        afterEach(Utils.afterEach);
+
+        it('should make a text selection h2 on click', function() {
+            bender.tools.selection.setWithHtml(this.nativeEditor, 'There should be a {selection} made h2.');
+
+            var buttonH2 = ReactDOM.render(<AlloyEditor.ButtonH2 editor={this.editor} />, this.container);
+
+            Simulate.click(ReactDOM.findDOMNode(buttonH2));
+
+            var data = bender.tools.getData(this.nativeEditor, {
+                fixHtml: false,
+                compatHtml: true
+            });
+
+            assert.strictEqual(data, '<h2>There should be a selection made h2.</h2>');
+        });
+
+        it('should add class which represents pressed button', function() {
+            bender.tools.selection.setWithHtml(this.nativeEditor, '<h2>A {selection} made h2.</h2>');
+
+            var buttonH2 = ReactDOM.render(<AlloyEditor.ButtonH2 editor={this.editor} />, this.container);
+
+            var buttonDOMNode = ReactDOM.findDOMNode(buttonH2);
+
+            assert.strictEqual($(buttonDOMNode).hasClass('ae-button-pressed'), true);
+        });
+    });
+}());

--- a/src/ui/react/test/button-italic.jsx
+++ b/src/ui/react/test/button-italic.jsx
@@ -1,0 +1,63 @@
+(function() {
+    'use strict';
+
+    var assert = chai.assert;
+    var Simulate = React.addons.TestUtils.Simulate;
+
+    var KEY_I = 73;
+
+    describe('ButtonItalic', function() {
+        this.timeout(35000);
+
+        before(Utils.createAlloyEditor);
+
+        after(Utils.destroyAlloyEditor);
+
+        beforeEach(Utils.beforeEach);
+
+        afterEach(Utils.afterEach);
+
+        it('should make a text selection italic on click', function() {
+            bender.tools.selection.setWithHtml(this.nativeEditor, 'There should be a {selection} made italic.');
+
+            var buttonItalic = ReactDOM.render(<AlloyEditor.ButtonItalic editor={this.editor} />, this.container);
+
+            Simulate.click(ReactDOM.findDOMNode(buttonItalic));
+
+            var data = bender.tools.getData(this.nativeEditor, {
+                fixHtml: false,
+                compatHtml: true
+            });
+
+            assert.strictEqual(data, '<p>There should be a <em>selection</em> made italic.</p>');
+        });
+
+        it('should make a text selection italic on [Ctrl|Cmd] + I', function() {
+            bender.tools.selection.setWithHtml(this.nativeEditor, 'There should be a {selection} made italic.');
+
+            var buttonItalic = ReactDOM.render(<AlloyEditor.ButtonItalic editor={this.editor} />, this.container);
+
+            happen.keydown(this._editable, {
+                ctrlKey: true,
+                keyCode: KEY_I
+            });
+
+            var data = bender.tools.getData(this.nativeEditor, {
+                fixHtml: false,
+                compatHtml: true
+            });
+
+            assert.strictEqual(data, '<p>There should be a <em>selection</em> made italic.</p>');
+        });
+
+        it('should add class which represents pressed button', function() {
+            bender.tools.selection.setWithHtml(this.nativeEditor, 'A <em>{selection}</em> made italic.');
+
+            var buttonItalic = ReactDOM.render(<AlloyEditor.ButtonItalic editor={this.editor} />, this.container);
+
+            var buttonDOMNode = ReactDOM.findDOMNode(buttonItalic);
+
+            assert.strictEqual($(buttonDOMNode).hasClass('ae-button-pressed'), true);
+        });
+    });
+}());

--- a/src/ui/react/test/button-link.jsx
+++ b/src/ui/react/test/button-link.jsx
@@ -1,0 +1,43 @@
+(function() {
+    'use strict';
+
+    var assert = chai.assert;
+    var Simulate = React.addons.TestUtils.Simulate;
+
+    var KEY_L = 76;
+
+    describe('ButtonLink', function() {
+        this.timeout(35000);
+
+        before(Utils.createAlloyEditor);
+
+        after(Utils.destroyAlloyEditor);
+
+        beforeEach(Utils.beforeEach);
+
+        afterEach(Utils.afterEach);
+
+        it('should invoke requestExclusive when clicking on the button', function() {
+            var requestExclusiveListener = sinon.stub();
+
+            var buttonLink = ReactDOM.render(<AlloyEditor.ButtonLink editor={this.editor} requestExclusive={requestExclusiveListener} />, this.container);
+
+            Simulate.click(ReactDOM.findDOMNode(buttonLink));
+
+            assert.isTrue(requestExclusiveListener.calledOnce);
+        });
+
+        it('should invoke requestExclusive when pressing the keystroke [Ctrl|Cmd]+L', function() {
+            var requestExclusiveListener = sinon.stub();
+
+            ReactDOM.render(<AlloyEditor.ButtonLink editor={this.editor} requestExclusive={requestExclusiveListener} />, this.container);
+
+            happen.keydown(this._editable, {
+                ctrlKey: true,
+                keyCode: KEY_L
+            });
+
+            assert.isTrue(requestExclusiveListener.calledOnce);
+        });
+    });
+}());

--- a/src/ui/react/test/button-ol.jsx
+++ b/src/ui/react/test/button-ol.jsx
@@ -1,0 +1,43 @@
+(function() {
+    'use strict';
+
+    var assert = chai.assert;
+    var Simulate = React.addons.TestUtils.Simulate;
+
+    describe('ButtonOrderedList', function() {
+        this.timeout(35000);
+
+        before(Utils.createAlloyEditor);
+
+        after(Utils.destroyAlloyEditor);
+
+        beforeEach(Utils.beforeEach);
+
+        afterEach(Utils.afterEach);
+
+        it('should make a text selection an ordered list on click', function() {
+            bender.tools.selection.setWithHtml(this.nativeEditor, '<p>There should be a {selection made...</p><p>An ordereed} list.</p>');
+
+            var buttonOrderedlist = ReactDOM.render(<AlloyEditor.ButtonOrderedList editor={this.editor} />, this.container);
+
+            Simulate.click(ReactDOM.findDOMNode(buttonOrderedlist));
+
+            var data = bender.tools.getData(this.nativeEditor, {
+                fixHtml: false,
+                compatHtml: true
+            });
+
+            assert.strictEqual(data, '<ol><li>There should be a selection made...</li><li>An ordereed list.</li></ol>');
+        });
+
+        it('should add class which represents pressed button', function() {
+            bender.tools.selection.setWithHtml(this.nativeEditor, '<ol><li>A {selection made...</li><li>An ordereed} list.</li></ol>');
+
+            var buttonOrderedlist = ReactDOM.render(<AlloyEditor.ButtonOrderedList editor={this.editor} />, this.container);
+
+            var buttonDOMNode = ReactDOM.findDOMNode(buttonOrderedlist);
+
+            assert.strictEqual($(buttonDOMNode).hasClass('ae-button-pressed'), true);
+        });
+    });
+}());

--- a/src/ui/react/test/button-quote.jsx
+++ b/src/ui/react/test/button-quote.jsx
@@ -1,0 +1,43 @@
+(function() {
+    'use strict';
+
+    var assert = chai.assert;
+    var Simulate = React.addons.TestUtils.Simulate;
+
+    describe('ButtonQuote', function() {
+        this.timeout(35000);
+
+        before(Utils.createAlloyEditor);
+
+        after(Utils.destroyAlloyEditor);
+
+        beforeEach(Utils.beforeEach);
+
+        afterEach(Utils.afterEach);
+
+        it('should make a text selection quote on click', function() {
+            bender.tools.selection.setWithHtml(this.nativeEditor, 'There should be a {selection} made quote.');
+
+            var buttonQuote = ReactDOM.render(<AlloyEditor.ButtonQuote editor={this.editor} />, this.container);
+
+            Simulate.click(ReactDOM.findDOMNode(buttonQuote));
+
+            var data = bender.tools.getData(this.nativeEditor, {
+                fixHtml: false,
+                compatHtml: true
+            });
+
+            assert.strictEqual(data, '<blockquote><p>There should be a selection made quote.</p></blockquote>');
+        });
+
+        it('should add class which represents pressed button', function() {
+            bender.tools.selection.setWithHtml(this.nativeEditor, '<blockquote>A {selection} made quote.</blockquote>');
+
+            var buttonQuote = ReactDOM.render(<AlloyEditor.ButtonQuote editor={this.editor} />, this.container);
+
+            var buttonDOMNode = ReactDOM.findDOMNode(buttonQuote);
+
+            assert.strictEqual($(buttonDOMNode).hasClass('ae-button-pressed'), true);
+        });
+    });
+}());

--- a/src/ui/react/test/button-strike.jsx
+++ b/src/ui/react/test/button-strike.jsx
@@ -1,0 +1,43 @@
+(function() {
+    'use strict';
+
+    var assert = chai.assert;
+    var Simulate = React.addons.TestUtils.Simulate;
+
+    describe('ButtonStrike', function() {
+        this.timeout(35000);
+
+        before(Utils.createAlloyEditor);
+
+        after(Utils.destroyAlloyEditor);
+
+        beforeEach(Utils.beforeEach);
+
+        afterEach(Utils.afterEach);
+
+        it('should make a text selection strike on click', function() {
+            bender.tools.selection.setWithHtml(this.nativeEditor, 'There should be a {selection} made strike.');
+
+            var buttonStrike = ReactDOM.render(<AlloyEditor.ButtonStrike editor={this.editor} />, this.container);
+
+            Simulate.click(ReactDOM.findDOMNode(buttonStrike));
+
+            var data = bender.tools.getData(this.nativeEditor, {
+                fixHtml: false,
+                compatHtml: true
+            });
+
+            assert.strictEqual(data, '<p>There should be a <s>selection</s> made strike.</p>');
+        });
+
+        it('should add class which represents pressed button', function() {
+            bender.tools.selection.setWithHtml(this.nativeEditor, 'A <s>{selection}</s> made strike.');
+
+            var buttonStrike = ReactDOM.render(<AlloyEditor.ButtonStrike editor={this.editor} />, this.container);
+
+            var buttonDOMNode = ReactDOM.findDOMNode(buttonStrike);
+
+            assert.strictEqual($(buttonDOMNode).hasClass('ae-button-pressed'), true);
+        });
+    });
+}());

--- a/src/ui/react/test/button-subscript.jsx
+++ b/src/ui/react/test/button-subscript.jsx
@@ -1,0 +1,43 @@
+(function() {
+    'use strict';
+
+    var assert = chai.assert;
+    var Simulate = React.addons.TestUtils.Simulate;
+
+    describe('ButtonSubscript', function() {
+        this.timeout(35000);
+
+        before(Utils.createAlloyEditor);
+
+        after(Utils.destroyAlloyEditor);
+
+        beforeEach(Utils.beforeEach);
+
+        afterEach(Utils.afterEach);
+
+        it('should make a text selection subscript on click', function() {
+            bender.tools.selection.setWithHtml(this.nativeEditor, 'There should be a {selection} made subscript.');
+
+            var buttonSubscript = ReactDOM.render(<AlloyEditor.ButtonSubscript editor={this.editor} />, this.container);
+
+            Simulate.click(ReactDOM.findDOMNode(buttonSubscript));
+
+            var data = bender.tools.getData(this.nativeEditor, {
+                fixHtml: false,
+                compatHtml: true
+            });
+
+            assert.strictEqual(data, '<p>There should be a <sub>selection</sub> made subscript.</p>');
+        });
+
+        it('should add class which represents pressed button', function() {
+            bender.tools.selection.setWithHtml(this.nativeEditor, 'A <sub>{selection}</sub> made subscript.');
+
+            var buttonSubscript = ReactDOM.render(<AlloyEditor.ButtonSubscript editor={this.editor} />, this.container);
+
+            var buttonDOMNode = ReactDOM.findDOMNode(buttonSubscript);
+
+            assert.strictEqual($(buttonDOMNode).hasClass('ae-button-pressed'), true);
+        });
+    });
+}());

--- a/src/ui/react/test/button-superscript.jsx
+++ b/src/ui/react/test/button-superscript.jsx
@@ -1,0 +1,43 @@
+(function() {
+    'use strict';
+
+    var assert = chai.assert;
+    var Simulate = React.addons.TestUtils.Simulate;
+
+    describe('ButtonSuperscript', function() {
+        this.timeout(35000);
+
+        before(Utils.createAlloyEditor);
+
+        after(Utils.destroyAlloyEditor);
+
+        beforeEach(Utils.beforeEach);
+
+        afterEach(Utils.afterEach);
+
+        it('should make a text selection superscript on click', function() {
+            bender.tools.selection.setWithHtml(this.nativeEditor, 'There should be a {selection} made superscript.');
+
+            var buttonSuperscript = ReactDOM.render(<AlloyEditor.ButtonSuperscript editor={this.editor} />, this.container);
+
+            Simulate.click(ReactDOM.findDOMNode(buttonSuperscript));
+
+            var data = bender.tools.getData(this.nativeEditor, {
+                fixHtml: false,
+                compatHtml: true
+            });
+
+            assert.strictEqual(data, '<p>There should be a <sup>selection</sup> made superscript.</p>');
+        });
+
+        it('should add class which represents pressed button', function() {
+            bender.tools.selection.setWithHtml(this.nativeEditor, 'A <sup>{selection}</sup> made superscript.');
+
+            var buttonSuperscript = ReactDOM.render(<AlloyEditor.ButtonSuperscript editor={this.editor} />, this.container);
+
+            var buttonDOMNode = ReactDOM.findDOMNode(buttonSuperscript);
+
+            assert.strictEqual($(buttonDOMNode).hasClass('ae-button-pressed'), true);
+        });
+    });
+}());

--- a/src/ui/react/test/button-ul.jsx
+++ b/src/ui/react/test/button-ul.jsx
@@ -1,0 +1,43 @@
+(function() {
+    'use strict';
+
+    var assert = chai.assert;
+    var Simulate = React.addons.TestUtils.Simulate;
+
+    describe('ButtonUnorderedlist', function() {
+        this.timeout(35000);
+
+        before(Utils.createAlloyEditor);
+
+        after(Utils.destroyAlloyEditor);
+
+        beforeEach(Utils.beforeEach);
+
+        afterEach(Utils.afterEach);
+
+        it('should make a text selection an unordered list on click', function() {
+            bender.tools.selection.setWithHtml(this.nativeEditor, '<p>There should be a {selection made...</p><p>An unordered} list.</p>');
+
+            var buttonUnorderedlist = ReactDOM.render(<AlloyEditor.ButtonUnorderedlist editor={this.editor} />, this.container);
+
+            Simulate.click(ReactDOM.findDOMNode(buttonUnorderedlist));
+
+            var data = bender.tools.getData(this.nativeEditor, {
+                fixHtml: false,
+                compatHtml: true
+            });
+
+            assert.strictEqual(data, '<ul><li>There should be a selection made...</li><li>An unordered list.</li></ul>');
+        });
+
+        it('should add class which represents pressed button', function() {
+            bender.tools.selection.setWithHtml(this.nativeEditor, '<ul><li>A {selection made...</li><li>An unordered} list.</li></ul>');
+
+            var buttonUnorderedlist = ReactDOM.render(<AlloyEditor.ButtonUnorderedlist editor={this.editor} />, this.container);
+
+            var buttonDOMNode = ReactDOM.findDOMNode(buttonUnorderedlist);
+
+            assert.strictEqual($(buttonDOMNode).hasClass('ae-button-pressed'), true);
+        });
+    });
+}());

--- a/src/ui/react/test/button-underline.jsx
+++ b/src/ui/react/test/button-underline.jsx
@@ -1,0 +1,63 @@
+(function() {
+    'use strict';
+
+    var assert = chai.assert;
+    var Simulate = React.addons.TestUtils.Simulate;
+
+    var KEY_U = 85;
+
+    describe('ButtonUnderline', function() {
+        this.timeout(35000);
+
+        before(Utils.createAlloyEditor);
+
+        after(Utils.destroyAlloyEditor);
+
+        beforeEach(Utils.beforeEach);
+
+        afterEach(Utils.afterEach);
+
+        it('should make a text selection underline on click', function() {
+            bender.tools.selection.setWithHtml(this.nativeEditor, 'There should be a {selection} made underline.');
+
+            var buttonUnderline = ReactDOM.render(<AlloyEditor.ButtonUnderline editor={this.editor} />, this.container);
+
+            Simulate.click(ReactDOM.findDOMNode(buttonUnderline));
+
+            var data = bender.tools.getData(this.nativeEditor, {
+                fixHtml: false,
+                compatHtml: true
+            });
+
+            assert.strictEqual(data, '<p>There should be a <u>selection</u> made underline.</p>');
+        });
+
+        it('should make a text selection underline on [Ctrl|Cmd] + I', function() {
+            bender.tools.selection.setWithHtml(this.nativeEditor, 'There should be a {selection} made underline.');
+
+            var buttonUnderline = ReactDOM.render(<AlloyEditor.ButtonUnderline editor={this.editor} />, this.container);
+
+            happen.keydown(this._editable, {
+                ctrlKey: true,
+                keyCode: KEY_U
+            });
+
+            var data = bender.tools.getData(this.nativeEditor, {
+                fixHtml: false,
+                compatHtml: true
+            });
+
+            assert.strictEqual(data, '<p>There should be a <u>selection</u> made underline.</p>');
+        });
+
+        it('should add class which represents pressed button', function() {
+            bender.tools.selection.setWithHtml(this.nativeEditor, 'A <u>{selection}</u> made underline.');
+
+            var buttonUnderline = ReactDOM.render(<AlloyEditor.ButtonUnderline editor={this.editor} />, this.container);
+
+            var buttonDOMNode = ReactDOM.findDOMNode(buttonUnderline);
+
+            assert.strictEqual($(buttonDOMNode).hasClass('ae-button-pressed'), true);
+        });
+    });
+}());


### PR DESCRIPTION
Hey @ipeychev, this adds the requested feature in #417. As a bonus, I've applied the mixin to the `bold`, `italic` and `underline` buttons to fix #141.

I'm from home now, so I've only been able to verify that the tests pass on Chrome and Firefox...

What do you think?