### PR TITLE
Clicking on Add image button should only accept images, not any other file types

### DIFF
--- a/src/ui/react/src/components/buttons/button-image.jsx
+++ b/src/ui/react/src/components/buttons/button-image.jsx
@@ -59,7 +59,7 @@
                         <span className="ae-icon-image"></span>
                     </button>
 
-                    <input onChange={this._onInputChange} ref="fileInput" style={inputSyle} type="file" />
+                    <input onChange={this._onInputChange} ref="fileInput" style={inputSyle} type="file" accept="image/*"/>
                 </div>
             );
         },


### PR DESCRIPTION
Hey @ipeychev 
I think the input element in button-image.jsx should only accept image type files. So i added accept attribute to file type input for 'Image Button'.