### PR TITLE
Allow changing props in all cases

### DIFF
--- a/src/ui/react/src/components/base/toolbar-buttons.js
+++ b/src/ui/react/src/components/base/toolbar-buttons.js
@@ -47,8 +47,10 @@
                     props = this.mergeDropdownProps(props, button.key);
 
                     if (additionalProps) {
-                        props = CKEDITOR.tools.merge(props, additionalProps, buttonProps[button.key]);
+                        props = CKEDITOR.tools.merge(props, additionalProps);
                     }
+                    
+                    props = CKEDITOR.tools.merge(props, buttonProps[button.key]);
 
                     return React.createElement(button, props);
                 }, this);


### PR DESCRIPTION
This change allows changing props for the toolbar buttons, even when there's no additionalProps passed to the function.

This allows, for example, changing the default table attributes in the "add" toolbar.