### PR TITLE
Always render the toolbar when in exclusive mode (Fixes #466)

### DIFF
--- a/src/ui/react/src/components/toolbars/toolbar-add.jsx
+++ b/src/ui/react/src/components/toolbars/toolbar-add.jsx
@@ -138,15 +138,9 @@
          * @return {Object|null} The content which should be rendered.
          */
         render: function() {
-            var isNotElementContentEditable = this.props.editorEvent && this.props.editorEvent.data.nativeEvent.target
-                && !this.props.editorEvent.data.nativeEvent.target.isContentEditable;
-
-            // Some plugins like ae_placeholder doesnt keep editorEvent updated
-            if ( isNotElementContentEditable && document.contains(this.props.editorEvent.data.nativeEvent.target)) {
+            if (this.props.editorEvent && this.props.editorEvent.data.nativeEvent.target && !this.props.editorEvent.data.nativeEvent.target.isContentEditable) {
                 return null;
             }
-
-
 
             var buttons = this._getButtons();
             var className = this._getToolbarClassName();

--- a/src/ui/react/src/components/toolbars/toolbar-add.jsx
+++ b/src/ui/react/src/components/toolbars/toolbar-add.jsx
@@ -138,7 +138,17 @@
          * @return {Object|null} The content which should be rendered.
          */
         render: function() {
-            if (this.props.editorEvent && this.props.editorEvent.data.nativeEvent.target && !this.props.editorEvent.data.nativeEvent.target.isContentEditable) {
+            // Some operations such as requestExclusive may cause editor blurs which invalidate the props.editorEvent
+            // stored value without causing a props change. This is the case, for example, with the ae_placeholder
+            // plugin, which in case the editor is empty will actually remove the target from the DOM causing the
+            // add toolbar to stop rendering.
+            //
+            // It should be safe to assume that if you have been able to render the toolbar and request the exclusive
+            // mode, then you can go ahead and keep rendering until the exclusive mode is left.
+            if (!this.state.itemExclusive &&
+                    this.props.editorEvent &&
+                    this.props.editorEvent.data.nativeEvent.target &&
+                    !this.props.editorEvent.data.nativeEvent.target.isContentEditable) {
                 return null;
             }
 

--- a/src/ui/react/src/components/toolbars/toolbar-add.jsx
+++ b/src/ui/react/src/components/toolbars/toolbar-add.jsx
@@ -138,9 +138,15 @@
          * @return {Object|null} The content which should be rendered.
          */
         render: function() {
-            if (this.props.editorEvent && this.props.editorEvent.data.nativeEvent.target && !this.props.editorEvent.data.nativeEvent.target.isContentEditable) {
+            var isNotElementContentEditable = this.props.editorEvent && this.props.editorEvent.data.nativeEvent.target
+                && !this.props.editorEvent.data.nativeEvent.target.isContentEditable;
+
+            // Some plugins like ae_placeholder doesnt keep editorEvent updated
+            if ( isNotElementContentEditable && document.contains(this.props.editorEvent.data.nativeEvent.target)) {
                 return null;
             }
+
+
 
             var buttons = this._getButtons();
             var className = this._getToolbarClassName();


### PR DESCRIPTION
Hey Iliyan,

This is a possible fix for #466. This is quite a tricky issue. It can be reproduced easily in our local demo by trying to add a table to the first editor while keeping it empty.

The logic sequence of problem is the following:

1. We render the add toolbar based on some `editorInteraction` event (which has the sole editor `<p>` target in it)
2. The table button will request exclusive mode causing a state update on the toolbar add (props won't change)
3. At the same time, a blur event will be triggered causing the `ae_placeholder` plugin to do `setHTML('')`, removing the `<p>` element from DOM
4. ToolbarAdd will try to render again, but since `editorEvent` wasn't updated to reflect the new state, and the `<p>` target it contains is now not in the DOM, it won't be editable.

We've considered several options for a fix:

- Prevent the editor `blur` event for these actions, pretty much as we do in [`_setUIHidden`](https://github.com/liferay/alloy-editor/blob/master/src/ui/react/src/components/main.jsx#L314). This has the drawback that it's hard to trigger following blur events, since it won't happen natively.
- Trigger some event to force a toolbar re-render. This should be imho the most consistent approach but since the editor is now blurred, we have no selection, causing all sorts of problems along the line :cry: 
- Check that the `nativeEvent.target` element is in the DOM. This was our initial fix, but now it feels kinda magic...
- Check that we are in exclusive mode to force the toolbar render. This is what I ended up sending.

What do you tihink?