### PR TITLE
Use liferay-gulp-tasks to get maven-related tasks

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -2,9 +2,12 @@
 
 var argv = require('yargs').argv,
 	gulp = require('gulp'),
+    liferayGulpTasks = require('liferay-gulp-tasks'),
 	path = require('path'),
     requireDir = require('require-dir'),
     ui = argv.ui || 'react';
+
+liferayGulpTasks.registerTasks();
 
 requireDir(path.join(__dirname, 'gulp-tasks'));
 requireDir(path.join(__dirname, 'src', 'ui', ui, 'gulp-tasks'));

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "karma-safari-launcher": "^0.1.1",
     "karma-sauce-launcher": "^0.3.0",
     "karma-sinon": "^1.0.4",
+    "liferay-gulp-tasks": "^0.2.1",
     "lodash": "^3.10.0",
     "mkdirp": "^0.5.1",
     "mocha": "^2.2.5",


### PR DESCRIPTION
Hey Iliyan, this brings in some tasks to be able to publish this as a webjar to our nexus maven server.

I haven't attached it to the `release` process for now, since it requires special permissions. I'll just run that command after every release to get the artifacts published.

Thanks!
