### PR TITLE
Add support for vertically scrollable ButtonDropdown.

### DIFF
--- a/src/ui/react/src/components/buttons/button-dropdown.jsx
+++ b/src/ui/react/src/components/buttons/button-dropdown.jsx
@@ -17,6 +17,7 @@
          */
         getDefaultProps: function() {
             return {
+                height: 0,
                 circular: false,
                 descendants: '.ae-toolbar-element',
                 keys: {
@@ -48,8 +49,17 @@
          * @return {Object} The content which should be rendered.
          */
         render: function() {
+            var style = {},
+                onFocus = this.focus;
+            if (!!this.props.height && !isNaN(this.props.height)) {
+                style = {
+                    overflowY: 'scroll',
+                    height: this.props.height
+                }
+                onFocus = false;
+            }
             return (
-                <div className="ae-dropdown ae-arrow-box ae-arrow-box-top-left" onFocus={this.focus} onKeyDown={this.handleKey} tabIndex="0">
+                <div className="ae-dropdown ae-arrow-box ae-arrow-box-top-left" onFocus={onFocus} style={style} onKeyDown={this.handleKey} tabIndex="0">
                     <ul className="ae-listbox" role="listbox">
                         {this.props.children}
                     </ul>


### PR DESCRIPTION
Components that use this drop down can add a height property set to any value above 0.
When set, the drop down will be limited to that height in pixels and will scroll vertically if
needed.
Note that this implementation assumes the project does not use ES6 syntax.
With ES6 syntax this would look cleaner using a ...spread operator on the
properties of style and focus instead of setting them to falsly/empty values.
The onFocus was removed when scrolling because in a scrolling situation this
caused any selection beyond the visible area (i.e., when having to scroll down)
to break down and select the first option again and again