### PR TITLE
Fixes error in Safari on paste

### DIFF
--- a/src/plugins/addimages.js
+++ b/src/plugins/addimages.js
@@ -129,7 +129,7 @@
              * @param {CKEDITOR.dom.event} event A `paste` event, as received natively from CKEditor
              */
             _onPaste: function(event) {
-                if (event.data.$.clipboardData) {
+                if (event.data.$.clipboardData && event.data.$.clipboardData.items) {
                     var pastedData = event.data.$.clipboardData.items[0];
 
                     if (pastedData.type.indexOf('image') === 0) {

--- a/src/plugins/pasteimages.js
+++ b/src/plugins/pasteimages.js
@@ -50,7 +50,7 @@
              * @param {CKEDITOR.dom.event} event A `paste` event, as received natively from CKEditor
              */
             _onPaste: function(event) {
-                if (event.data.$.clipboardData) {
+                if (event.data.$.clipboardData && event.data.$.clipboardData.items) {
                     var pastedData = event.data.$.clipboardData.items[0];
                     var editor = event.listenerData.editor;
 


### PR DESCRIPTION
When pasting an image into the editor in Safari the following error is previously thrown:

> TypeError: undefined is not an object (evaluating 'e.data.$.clipboardData.items')