### PR TITLE
SF

### DIFF
--- a/src/plugins/autolist.js
+++ b/src/plugins/autolist.js
@@ -1,0 +1,184 @@
+(function() {
+	'use strict';
+
+	if (CKEDITOR.plugins.get('ae_autolist')) {
+		return;
+	}
+
+	var KEY_BACK = 8;
+
+	var KEY_SPACE = 32;
+
+	var bulletExpressions = [
+		{
+			regex: /^\*$/,
+			type: 'bulletedlist'
+		},
+		{
+			regex: /^1\.$/,
+			type: 'numberedlist'
+		}
+	];
+
+	/**
+     * CKEditor plugin which automatically generates ordered/unordered list when user types text which looks like list.
+     *
+     * @class CKEDITOR.plugins.ae_autolist
+     * @constructor
+     */
+	CKEDITOR.plugins.add(
+		'ae_autolist', {
+
+			/**
+			* Initialization of the plugin, part of CKeditor plugin lifecycle.
+			* The function registers the `keyup` event on the edition area.
+			*
+			* @method init
+			* @param {Object} editor The current editor instance
+			*/
+			init: function(editor) {
+				editor.once('contentDom', function() {
+					var editable = editor.editable();
+
+					editor.config.autolist = editor.config.autolist || bulletExpressions;
+
+					editable.attachListener(editable, 'keydown', this._onKeyDown, this, {
+						editor: editor
+					});
+
+				}.bind(this));
+			},
+
+			/**
+			* Check current line to find match with MATCHES object to create OL or UL
+			*
+			* @protected
+			* @method _checkLine
+			* @param {Integer} the position of the line
+			* @param {element} string that is checked if match exists
+			* @param {editor} Editor object
+			@ @param {Event} event Event object
+			*/
+			_checkLine: function(bullet, text, editor, event) {
+				var index = 0;
+
+				var configRegex = editor.config.autolist;
+
+				var regexLen = configRegex.length;
+
+				var found = false;
+
+				while (!found && regexLen > index) {
+
+					var regexItem = configRegex[index];
+
+					if (regexItem.regex.test(bullet)) {
+						found = {
+							editor: editor,
+							bullet: bullet,
+							text: text,
+							type: regexItem.type
+						};
+
+					}
+					index++;
+				}
+
+				return found;
+			},
+
+			/**
+			* Create list with different types: bulletedlist or numberedlist
+			*
+			* @protectec
+			* @method _createList
+			* @param {listCreation} object that contains bullet, text and type for creating the list
+			*/
+			_createList: function(listCreation) {
+				var editor = listCreation.editor;
+
+				var range = editor.getSelection().getRanges()[0];
+
+				range.endContainer.setText(listCreation.text);
+				editor.execCommand(listCreation.type);
+				this._subscribeToKeyDownEvent(editor, listCreation.bullet);
+			},
+
+			/**
+             * Listens to the `Space` key events to check if the last word
+             * introduced by the user should be replaced by a list (OL or UL)
+             *
+             * @protected
+             * @method _onKeyPress
+             * @param {Event} event Eventobject
+             */
+            _onKeyDown: function(event) {
+            	var nativeEvent = event.data.$;
+
+				this._currentKeyCode = nativeEvent.keyCode;
+				if (this._currentKeyCode === KEY_SPACE) {
+
+					var editor = event.listenerData.editor;
+
+					var range = editor.getSelection().getRanges()[0];
+
+					var textContainer = range.endContainer.getText();
+
+					var bullet = textContainer.substring(0, range.startOffset);
+
+					var text = textContainer.substring(range.startOffset, textContainer.length);
+
+					var listCreation = this._checkLine(bullet, text, editor, event);
+
+					if (listCreation) {
+						event.data.preventDefault();
+						this._createList(listCreation);
+					}
+				}
+            },
+
+            /**
+            * Listens to the 'Key Back', to check if after list is created, key back is clicked
+        	* to undo the list
+        	*
+        	* @protected
+        	* @method _onKeyDownCheckToDelete
+        	* @param {Event} event Eventobject
+            */
+            _onKeyDownCheckToDelete: function(event) {
+				var editor = event.listenerData.editor;
+
+                var nativeEvent = event.data.$;
+
+                var editable = editor.editable();
+
+                this._currentKeyCode = nativeEvent.keyCode;
+
+                editable.removeListener('keydown', this._onKeyDownCheckToDelete);
+
+                if (this._currentKeyCode === KEY_BACK) {
+					editor.execCommand('undo');
+					editor.insertHtml(event.listenerData.bullet + '&nbsp;');
+					event.data.preventDefault();
+				}
+            },
+
+            /**
+            * Add attachlistener after autolist is created.
+            *
+            * @protected
+            * @method _subscribeToKeyDownEvent
+            * @param {editor} Editor object
+            * @param {bullet} String to add at beginning of container when key back is clicked
+            */
+            _subscribeToKeyDownEvent: function(editor, bullet) {
+				var editable = editor.editable();
+
+				editable.attachListener(editable, 'keydown', this._onKeyDownCheckToDelete, this, {
+					editor: editor,
+					bullet: bullet
+				}, 1);
+			}
+        }
+	);
+}());

--- a/src/ui/react/src/adapter/alloy-editor.js
+++ b/src/ui/react/src/adapter/alloy-editor.js
@@ -271,7 +271,7 @@
              */
             extraPlugins: {
                 validator: AlloyEditor.Lang.isString,
-                value: 'ae_uicore,ae_selectionregion,ae_selectionkeystrokes,ae_dragresize,ae_imagealignment,ae_addimages,ae_placeholder,ae_tabletools,ae_tableresize,ae_autolink,ae_embed',
+                value: 'ae_uicore,ae_selectionregion,ae_selectionkeystrokes,ae_dragresize,ae_imagealignment,ae_addimages,ae_placeholder,ae_tabletools,ae_tableresize,ae_autolink,ae_embed,ae_autolist',
                 writeOnce: true
             },
 

--- a/test/plugins/test/autolist.js
+++ b/test/plugins/test/autolist.js
@@ -33,7 +33,7 @@
         it('should create a numbered list when pressing SPACE although the line has text', function() {
             testList.call(this, {
                 expected: '<ol><li>first line</li></ol>',
-                html: '<p>1.{ }first line</p>',
+                html: '<p>1.{}first line</p>',
                 keyCode: KEY_SPACE
             });
         });
@@ -41,7 +41,7 @@
         it('should create an empty bulleted list when pressing SPACE', function() {
             testList.call(this, {
                 expected: '<ul><li>&nbsp;</li></ul>',
-                html: '<p>*{ }</p>',
+                html: '<p>*{}</p>',
                 keyCode: KEY_SPACE
             });
         });
@@ -49,7 +49,7 @@
         it('should create a bulleted list when pressing SPACE although the line has text', function() {
             testList.call(this, {
                 expected: '<ul><li>first line</li></ul>',
-                html: '<p>*{ }first line</p>',
+                html: '<p>*{}first line</p>',
                 keyCode: KEY_SPACE
             });
         });
@@ -57,7 +57,7 @@
         it('Should not create numbered list when pressing SPACE in other position', function() {
         	testList.call(this, {
         		expected: '<p>1. no list</p>',
-        		html: '<p>1. { }no list</p>',
+        		html: '<p>1. {}no list</p>',
         		keyCode: KEY_SPACE
         	});
         });
@@ -65,7 +65,7 @@
         it('Should not create bulleted list when pressing SPACE in other position', function() {
         	testList.call(this, {
         		expected: '<p>* not create list</p>',
-        		html: '<p>* not create{ }list</p>',
+        		html: '<p>* not create{} list</p>',
         		keyCode: KEY_SPACE
         	});
         });

--- a/test/plugins/test/autolist.js
+++ b/test/plugins/test/autolist.js
@@ -1,0 +1,109 @@
+(function() {
+	'use strict';
+
+	var assert = chai.assert;
+
+	var KEY_A = 65;
+
+	var KEY_BACK = 8;
+
+	var KEY_SPACE = 32;
+
+	describe('Autolist', function() {
+		this.timeout(35000);
+
+		before(function(done) {
+            Utils.createCKEditor.call(this, done, {extraPlugins: 'undo,ae_autolist,undo', allowedContent: 'p ol ul li'});
+        });
+
+        after(Utils.destroyCKEditor);
+
+        beforeEach(Utils.beforeEach);
+
+        afterEach(Utils.afterEach);
+
+        it('should create an empty numbered list when pressing SPACE', function() {
+            testList.call(this, {
+                expected: '<ol><li>&nbsp;</li></ol>',
+                html: '<p>1.{}</p>',
+                keyCode: KEY_SPACE
+            });
+        });
+
+        it('should create a numbered list when pressing SPACE although the line has text', function() {
+            testList.call(this, {
+                expected: '<ol><li>first line</li></ol>',
+                html: '<p>1.{ }first line</p>',
+                keyCode: KEY_SPACE
+            });
+        });
+
+        it('should create an empty bulleted list when pressing SPACE', function() {
+            testList.call(this, {
+                expected: '<ul><li>&nbsp;</li></ul>',
+                html: '<p>*{ }</p>',
+                keyCode: KEY_SPACE
+            });
+        });
+
+        it('should create a bulleted list when pressing SPACE although the line has text', function() {
+            testList.call(this, {
+                expected: '<ul><li>first line</li></ul>',
+                html: '<p>*{ }first line</p>',
+                keyCode: KEY_SPACE
+            });
+        });
+
+        it('Should not create numbered list when pressing SPACE in other position', function() {
+        	testList.call(this, {
+        		expected: '<p>1. no list</p>',
+        		html: '<p>1. { }no list</p>',
+        		keyCode: KEY_SPACE
+        	});
+        });
+
+        it('Should not create bulleted list when pressing SPACE in other position', function() {
+        	testList.call(this, {
+        		expected: '<p>* not create list</p>',
+        		html: '<p>* not create{ }list</p>',
+        		keyCode: KEY_SPACE
+        	});
+        });
+
+        it('Should remove list and keep bullet when pressing BACK after creating list', function() {
+        	testList.call(this, {
+        		expected: '<ul><li>create list</li></ul>',
+        		html: '<p>*{}create list</p>',
+        		keyCode: KEY_SPACE
+        	});
+
+        	happen.keydown(this._editable, {
+        		keyCode: KEY_BACK
+        	});
+
+        	var data = getData.call(this);
+
+        	assert.equal(data, '<p>*&nbsp;create list</p>');
+
+        });
+
+        function testList(config) {
+        	bender.tools.selection.setWithHtml(this.nativeEditor, config.html);
+
+        	happen.keydown(this._editable, {
+        		keyCode: config.keyCode
+        	});
+
+        	var data = getData.call(this);
+        	assert.equal(data, config.expected);
+        }
+
+        function getData() {
+        	return bender.tools.getData(this.nativeEditor, {
+        		compatHtml: true,
+        		fixHtml: true
+        	});
+        }
+	});
+
+}());


### PR DESCRIPTION
Hey @ipeychev, this enables the automatic creation of lists when using a configurable set of expressions. By default, `1.` for numbered lists and `*` for bulleted lists.

![autolist](https://cloud.githubusercontent.com/assets/905006/14717449/dbca14e6-07f1-11e6-875b-51cb8b604261.gif)

Thanks!