### PR TITLE
Support style string definition (Fixes #533)

### DIFF
--- a/src/ui/react/src/components/base/button-style.js
+++ b/src/ui/react/src/components/base/button-style.js
@@ -11,11 +11,15 @@
         // Allows validating props being passed to the component.
         propTypes: {
             /**
-             * The style the button should handle as described by http://docs.ckeditor.com/#!/api/CKEDITOR.style
+             * The style the button should handle. It can be a style object as described by http://docs.ckeditor.com/#!/api/CKEDITOR.style
+             * or a string pointing to an object inside the editor instance configuration
              *
-             * @property {Object} style
+             * @property {Object|String} style
              */
-            style: React.PropTypes.object
+            style: React.PropTypes.oneOfType([
+                React.PropTypes.object,
+                React.PropTypes.string
+            ])
         },
 
         /**
@@ -24,7 +28,25 @@
          * @method componentWillMount
          */
         componentWillMount: function() {
-            this._style = new CKEDITOR.style(this.props.style);
+            var Lang = AlloyEditor.Lang;
+            var style = this.props.style;
+
+            if (Lang.isString(style)) {
+                var parts = style.split('.');
+                var currentMember = this.props.editor.get('nativeEditor').config;
+                var property = parts.shift();
+
+                while (property && Lang.isObject(currentMember) && Lang.isObject(currentMember[property])) {
+                    currentMember = currentMember[property];
+                    property = parts.shift();
+                }
+
+                if (Lang.isObject(currentMember)) {
+                    style = currentMember;
+                }
+            }
+
+            this._style = new CKEDITOR.style(style);
         },
 
         /**

--- a/src/ui/react/src/components/base/button-style.js
+++ b/src/ui/react/src/components/base/button-style.js
@@ -11,8 +11,11 @@
         // Allows validating props being passed to the component.
         propTypes: {
             /**
-             * The style the button should handle. It can be a style object as described by http://docs.ckeditor.com/#!/api/CKEDITOR.style
-             * or a string pointing to an object inside the editor instance configuration
+             * The style the button should handle. Allowed values are:
+             * - Object as described by http://docs.ckeditor.com/#!/api/CKEDITOR.style.
+             * - String pointing to an object inside the editor instance configuration. For example, `style = 'coreStyles_bold'` will try to
+             * retrieve the style object from `editor.config.coreStyles_bold`. Nested properties such as `style = 'myplugin.myConfig.myStyle'`
+             * are also supported and will try to retrieve the style object from the editor configuration as well.
              *
              * @property {Object|String} style
              */

--- a/src/ui/react/src/components/buttons/button-bold.jsx
+++ b/src/ui/react/src/components/buttons/button-bold.jsx
@@ -64,9 +64,7 @@
                     fn: 'execCommand',
                     keys: CKEDITOR.CTRL + 66 /*B*/
                 },
-                style: {
-                    element: 'strong'
-                }
+                style: 'coreStyles_bold'
             };
         },
 

--- a/src/ui/react/src/components/buttons/button-italic.jsx
+++ b/src/ui/react/src/components/buttons/button-italic.jsx
@@ -64,9 +64,7 @@
                     fn: 'execCommand',
                     keys: CKEDITOR.CTRL + 73 /*I*/
                 },
-                style: {
-                    element: 'em'
-                }
+                style: 'coreStyles_italic'
             };
         },
 

--- a/src/ui/react/src/components/buttons/button-strike.jsx
+++ b/src/ui/react/src/components/buttons/button-strike.jsx
@@ -59,9 +59,7 @@
         getDefaultProps: function() {
             return {
                 command: 'strike',
-                style: {
-                    element: 's'
-                }
+                style: 'coreStyles_strike'
             };
         },
 

--- a/src/ui/react/src/components/buttons/button-subscript.jsx
+++ b/src/ui/react/src/components/buttons/button-subscript.jsx
@@ -59,9 +59,7 @@
         getDefaultProps: function() {
             return {
                 command: 'subscript',
-                style: {
-                    element: 'sub'
-                }
+                style: 'coreStyles_subscript'
             };
         },
 

--- a/src/ui/react/src/components/buttons/button-superscript.jsx
+++ b/src/ui/react/src/components/buttons/button-superscript.jsx
@@ -59,9 +59,7 @@
         getDefaultProps: function() {
             return {
                 command: 'superscript',
-                style: {
-                    element: 'sup'
-                }
+                style: 'coreStyles_superscript'
             };
         },
 

--- a/src/ui/react/src/components/buttons/button-underline.jsx
+++ b/src/ui/react/src/components/buttons/button-underline.jsx
@@ -64,9 +64,7 @@
                     fn: 'execCommand',
                     keys: CKEDITOR.CTRL + 85 /*U*/
                 },
-                style: {
-                    element: 'u'
-                }
+                style: 'coreStyles_underline'
             };
         },
 


### PR DESCRIPTION
Hey @ipeychev, this is the improvement we discussed for https://github.com/liferay/alloy-editor/issues/533.

Now, this will work out of the box:

```javascript
[...]
AlloyEditor.editable('editable', {
    coreStyles_bold: customBoldStyle,
    coreStyles_italic: customItalicStyle,
    coreStyles_underline: customUnderlineStyle,
    coreStyles_strike: customStrikeStyle,
    coreStyles_subscript: customSubscriptStyle,
    coreStyles_superscript: customSuperscriptStyle
});
```