### PR TITLE
Clear browser selection on editor destroy (#532)

### DIFF
--- a/src/plugins/dragresize.js
+++ b/src/plugins/dragresize.js
@@ -59,6 +59,7 @@
 
         function selectionChange() {
             var selection = editor.getSelection();
+
             if (!selection) return;
             // If an element is selected and that element is an IMG
             if (selection.getType() !== CKEDITOR.SELECTION_NONE && selection.getStartElement().is('img')) {
@@ -98,6 +99,14 @@
         editor.on('beforeModeUnload', function self() {
             editor.removeListener('beforeModeUnload', self);
             resizer.hide();
+        });
+
+        editor.on('destroy', function() {
+            var resizeElement = document.getElementById('ckimgrsz');
+
+            if (resizeElement) {
+                resizeElement.remove();
+            }
         });
 
         // Update the selection when the browser window is resized
@@ -146,7 +155,9 @@
         isHandle: function(el) {
             var handles = this.handles;
             for (var n in handles) {
-                if (handles[n] === el) return true;
+                if (handles[n] === el) {
+                    return true;
+                }
             }
             return false;
         },

--- a/src/ui/react/src/adapter/alloy-editor.js
+++ b/src/ui/react/src/adapter/alloy-editor.js
@@ -100,24 +100,13 @@
          * @method _clearSelections
          */
         _clearSelections: function() {
-            var selection = null;
+            var nativeEditor = this.get('nativeEditor');
+            var isMSSelection = typeof window.getSelection != 'function';
 
-            if(window.getSelection) {
-                selection = window.getSelection();
-
-            }
-            else if(document.selection) {
-                selection = document.selection;
-
-            }
-            if(selection) {
-                if(selection.empty){
-                    selection.empty();
-                }
-
-                if(selection.removeAllRanges) {
-                    selection.removeAllRanges();
-                }
+            if (isMSSelection) {
+                nativeEditor.document.$.selection.empty();
+            } else {
+               nativeEditor.document.getWindow().$.getSelection().removeAllRanges();
             }
         },
 

--- a/src/ui/react/src/adapter/alloy-editor.js
+++ b/src/ui/react/src/adapter/alloy-editor.js
@@ -86,7 +86,38 @@
                     }
                 }
 
+                this._clearSelections();
+
                 nativeEditor.destroy();
+            }
+        },
+
+
+        /**
+         * Clear selections from window object
+         *
+         * @protected
+         * @method _clearSelections
+         */
+        _clearSelections: function() {
+            var selection = null;
+
+            if(window.getSelection) {
+                selection = window.getSelection();
+
+            }
+            else if(document.selection) {
+                selection = document.selection;
+
+            }
+            if(selection) {
+                if(selection.empty){
+                    selection.empty();
+                }
+
+                if(selection.removeAllRanges) {
+                    selection.removeAllRanges();
+                }
             }
         },
 


### PR DESCRIPTION
Hey @ipeychev, this is a possible fix for #532.

Directly invoking CKEditor's `editor.getSelection().removeAllRanges()` won't generally work since the method usually does nothing when the editor is not focused (and focusing it prior to destroying it causes some issues), so we tried to do it manually.

What do you think?