### PR TITLE
Sets editor property before potentially start the render phase

### DIFF
--- a/src/ui/react/src/adapter/alloy-editor.js
+++ b/src/ui/react/src/adapter/alloy-editor.js
@@ -60,9 +60,9 @@
 
             }.bind(this));
 
-            AlloyEditor.loadLanguageResources(this._renderUI.bind(this));
-
             this._editor = editor;
+
+            AlloyEditor.loadLanguageResources(this._renderUI.bind(this));
         },
 
         /**

--- a/src/ui/react/src/adapter/main.js
+++ b/src/ui/react/src/adapter/main.js
@@ -96,7 +96,9 @@
                 if (AlloyEditor.Strings) {
                     setTimeout(callback, 0);
                 } else {
-                    AlloyEditor.once('languageResourcesLoaded', callback);
+                    AlloyEditor.once('languageResourcesLoaded', function() {
+                        setTimeout(callback, 0);
+                    });
                 }
             }
 


### PR DESCRIPTION
This is a potential fix for #724. The code path is not yet tested because we didn't find a proper way to test the `LoadLanguageResources` path, if I remember correctly.