### PR TITLE
update version of require-dir to work with Node 0.10+

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "lodash": "4.17.4",
     "mkdirp": "0.5.1",
     "mocha": "3.2.0",
-    "require-dir": "0.3.0",
+    "require-dir": "0.3.2",
     "run-sequence": "1.1.2",
     "sinon": "1.15.4",
     "walk": "2.3.9",


### PR DESCRIPTION
### Intent
To update `require-dir` module so that it works well with Node 0.10.6 or above.

### Reference
`require.extensions` has been deprecated since node v0.10.6 and upgrading to node 8, which fully drops support for it, causes that error.

https://stackoverflow.com/questions/44298322/node-8-0-0-and-npm-4-2-0-error-express-load-require-extensions-hasownproperty-is