### PR TITLE
Issue/768

### DIFF
--- a/src/plugins/placeholder.js
+++ b/src/plugins/placeholder.js
@@ -15,7 +15,11 @@
     var brFiller = CKEDITOR.env.needsBrFiller ? '<br>' : '';
 
     var enterModeEmptyValue = {
-        1: ['<p>' + brFiller + '</p>'],
+        1: [
+            '<p>' + brFiller + '</p>',
+            '<h1>' + brFiller + '</h1>',
+            '<h2>' + brFiller + '</h2>'
+        ],
         2: ['', ' ', brFiller],
         3: ['<div>' + brFiller + '</div>']
     };

--- a/test/plugins/test/placeholder.js
+++ b/test/plugins/test/placeholder.js
@@ -11,9 +11,7 @@
             '<h2>' + brFiller + '</h2>'
         ],
         2: ['', ' ', brFiller],
-        3: ['<div>' + brFiller + '</div>'],
-        4: ['<h1>' + brFiller + '</h1>'],
-        5: ['<h2>' + brFiller + '</h2>'],
+        3: ['<div>' + brFiller + '</div>']
     };
 
     var placeholderClass = 'ae-placeholder';

--- a/test/plugins/test/placeholder.js
+++ b/test/plugins/test/placeholder.js
@@ -5,9 +5,15 @@
     var brFiller = CKEDITOR.env.needsBrFiller ? '<br>' : '';
 
     var expectedEmptyValue = {
-        1: ['<p>' + brFiller + '</p>'],
+        1: [
+            '<p>' + brFiller + '</p>',
+            '<h1>' + brFiller + '</h1>',
+            '<h2>' + brFiller + '</h2>'
+        ],
         2: ['', ' ', brFiller],
-        3: ['<div>' + brFiller + '</div>']
+        3: ['<div>' + brFiller + '</div>'],
+        4: ['<h1>' + brFiller + '</h1>'],
+        5: ['<h2>' + brFiller + '</h2>'],
     };
 
     var placeholderClass = 'ae-placeholder';


### PR DESCRIPTION
## Prelude
Empty `<p>` elements are regarded empty content that causes the editor to show the placeholder message (`data-placeholder="Write some content here..."`). During certain scenarios the placeholder message fail to appear. 

## Issue
Check #768.

#### Steps to reproduce #768 
1. Add content and transforms it into `<h1>` or `<h2>` element. 
2. Empty the content of the header element. 
3. Placeholder message does NOT appear anymore since these tags are not deemed as elements that can potentially be empty. 

## Solution
- Extended the list of expected empty values in the `ae-placeholder` plugin. 

![ezgif com-video-to-gif 4](https://user-images.githubusercontent.com/6104164/32446294-b7857c5a-c308-11e7-9cc4-6edbe7e1d876.gif)
