### PR TITLE
AUI-3148

### DIFF
--- a/src/plugins/addimages.js
+++ b/src/plugins/addimages.js
@@ -125,17 +125,15 @@
 
                 var transferFiles = nativeEvent.dataTransfer.files;
 
-                if (transferFiles.length <= 0) {
-                    return;
+                if (transferFiles.length > 0) {
+                    new CKEDITOR.dom.event(nativeEvent).preventDefault();
+
+                    var editor = event.listenerData.editor;
+
+                    event.listenerData.editor.createSelectionFromPoint(nativeEvent.clientX, nativeEvent.clientY);
+
+                    this._handleFiles(transferFiles, editor);
                 }
-
-                new CKEDITOR.dom.event(nativeEvent).preventDefault();
-
-                var editor = event.listenerData.editor;
-
-                event.listenerData.editor.createSelectionFromPoint(nativeEvent.clientX, nativeEvent.clientY);
-
-                this._handleFiles(transferFiles, editor);
             },
 
             /**

--- a/src/plugins/addimages.js
+++ b/src/plugins/addimages.js
@@ -123,13 +123,19 @@
             _onDragDrop: function(event) {
                 var nativeEvent = event.data.$;
 
+                var transferFiles = nativeEvent.dataTransfer.files;
+
+                if (transferFiles.length <= 0) {
+                    return;
+                }
+
                 new CKEDITOR.dom.event(nativeEvent).preventDefault();
 
                 var editor = event.listenerData.editor;
 
                 event.listenerData.editor.createSelectionFromPoint(nativeEvent.clientX, nativeEvent.clientY);
 
-                this._handleFiles(nativeEvent.dataTransfer.files, editor);
+                this._handleFiles(transferFiles, editor);
             },
 
             /**


### PR DESCRIPTION
Hey @liferay,

Attached is an update for http://issues.liferay.com/browse/AUI-3148.

> ## Prelude
> A customer noted to us that users are unable to drag and drop text or images internally in AlloyEditor. I verified that this is not only the case in the portal but on alloyeditor.com as well.
> 
> ## Issue
> https://issues.liferay.com/browse/AUI-3148
> 
> ## Solution
> I made it so the preventDefault is only fired by AlloyEditor's dragdrop function when we need to specifically override the behavior, otherwise the default CKEditor dragDrop should be use.
> 
> ## Test
> Tested on Chrome, Firefox, MS Edge, and IE11.

Please let me know if you have any questions. Thanks!