### PR TITLE
Drag and Drop Doesn't Work Within the Editor Fixes #839

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Works on IE9+, Chrome, Firefox and Safari.
 ## Features
 
 * Smart toolbars appear right near the selected text and offer different functionality based on context
-* Easily add your own buttons (see the "marquee" example in [the demo](http://alloyeditor.com/demo/))
+* Easily add your own buttons (see the "marquee" example in [the docs](https://alloyeditor.com/docs/develop/create/create_buttons.html))
 * Paste images from clipboard, or Drag&Drop them from another application
 * Insert images from the device's camera!
 * Paste rich text from any web page and preserve its formatting

--- a/src/plugins/addimages.js
+++ b/src/plugins/addimages.js
@@ -125,17 +125,15 @@
 
                 var transferFiles = nativeEvent.dataTransfer.files;
 
-                if (transferFiles.length <= 0) {
-                    return;
+                if (transferFiles.length > 0) {
+                    new CKEDITOR.dom.event(nativeEvent).preventDefault();
+
+                    var editor = event.listenerData.editor;
+
+                    event.listenerData.editor.createSelectionFromPoint(nativeEvent.clientX, nativeEvent.clientY);
+
+                    this._handleFiles(transferFiles, editor);
                 }
-
-                new CKEDITOR.dom.event(nativeEvent).preventDefault();
-
-                var editor = event.listenerData.editor;
-
-                event.listenerData.editor.createSelectionFromPoint(nativeEvent.clientX, nativeEvent.clientY);
-
-                this._handleFiles(transferFiles, editor);
             },
 
             /**

--- a/src/plugins/addimages.js
+++ b/src/plugins/addimages.js
@@ -123,13 +123,19 @@
             _onDragDrop: function(event) {
                 var nativeEvent = event.data.$;
 
+                var transferFiles = nativeEvent.dataTransfer.files;
+
+                if (transferFiles.length <= 0) {
+                    return;
+                }
+
                 new CKEDITOR.dom.event(nativeEvent).preventDefault();
 
                 var editor = event.listenerData.editor;
 
                 event.listenerData.editor.createSelectionFromPoint(nativeEvent.clientX, nativeEvent.clientY);
 
-                this._handleFiles(nativeEvent.dataTransfer.files, editor);
+                this._handleFiles(transferFiles, editor);
             },
 
             /**


### PR DESCRIPTION
## Prelude
A customer noted to us that users are unable to drag and drop text or images internally in AlloyEditor. I verified that this is not only the case in the portal but on alloyeditor.com as well.

## Issue
You cannot internally drag and drop text or images within AlloyEditor.

*Steps to Reproduce :*

1. Content -> Blogs -> Add Blog Entry
2. Upload an image to the blog post content
3. Write text to the body content
4. Attempt to drag image in between some words

Expected Results: The image is moved to the location the cursor indicates.

Actual Results: The cursor properly traces where you will 'drop' the image but on mouse up nothing happens.  The image is not moved.

## Solution
I made it so the preventDefault is only fired by AlloyEditor's dragdrop function when we need to specifically override the behavior, otherwise the default CKEditor dragDrop should be use.

## Test
Tested on Chrome, Firefox, MS Edge, and IE11.
