### PR TITLE
Image link dev

### DIFF
--- a/src/ui/react/src/selections/selection-test.js
+++ b/src/ui/react/src/selections/selection-test.js
@@ -30,11 +30,17 @@
     var linkSelectionTest = function(payload) {
         var nativeEditor = payload.editor.get('nativeEditor');
         var range = nativeEditor.getSelection().getRanges()[0];
+        var selectionData = payload.data.selectionData;
+
+        var selectionDataName;
 
         var element;
 
+        if (selectionData.element) selectionDataName = selectionData.element.getName();
+
         return !!(
             nativeEditor.isSelectionEmpty() &&
+            selectionDataName !== 'img' &&
             (element = (new CKEDITOR.Link(nativeEditor)).getFromSelection()) &&
             element.getText().length !== range.endOffset &&
             !element.isReadOnly() &&

--- a/src/ui/react/src/selections/selection-test.js
+++ b/src/ui/react/src/selections/selection-test.js
@@ -45,9 +45,18 @@
     var imageSelectionTest = function(payload) {
         var selectionData = payload.data.selectionData;
 
+        var selectionEmpty = false;
+
+        if (payload.editor) {
+            var nativeEditor = payload.editor._getNativeEditor();
+
+            selectionEmpty = nativeEditor.isSelectionEmpty();
+        }
+
         return !!(
             selectionData.element &&
             selectionData.element.getName() === 'img' &&
+            !selectionEmpty &&
             !selectionData.element.isReadOnly()
         );
     };


### PR DESCRIPTION
## Issue
https://github.com/liferay/alloy-editor/issues/848

## Solution
For most browsers "check if selection is empty" is sufficient to resolve this issue.

However the Chrome react unmount issue is different as CKEditor injects [7 zero-width space characters].  We test whether the selection is an image in linkSelectionTest to handle this.

## Test
Chrome, IE 11, and FireFox.

gif of issue and fix on Chrome
https://imgur.com/a/h08XgJt
