### PR TITLE
Resize visible

### DIFF
--- a/src/ui/react/src/components/main.jsx
+++ b/src/ui/react/src/components/main.jsx
@@ -349,6 +349,7 @@
 
             if (domNode) {
                 var editable = this.props.editor.get('nativeEditor').editable();
+                var parentNode = target.parentNode;
                 var targetNode = new CKEDITOR.dom.node(target);
 
                 if (!editable) {
@@ -357,7 +358,11 @@
                     });
                 } else {
                     var res = (editable.$ === target) || editable.contains(targetNode) ||
-                        (new CKEDITOR.dom.element(domNode)).contains(targetNode) || (target.parentNode.id === "ckimgrsz");
+                        (new CKEDITOR.dom.element(domNode)).contains(targetNode);
+
+                    if (parentNode) {
+                        res = res || parentNode.id === "ckimgrsz";
+                    }
 
                     if (!res) {
                         this.setState({

--- a/src/ui/react/src/components/main.jsx
+++ b/src/ui/react/src/components/main.jsx
@@ -357,7 +357,7 @@
                     });
                 } else {
                     var res = (editable.$ === target) || editable.contains(targetNode) ||
-                        (new CKEDITOR.dom.element(domNode)).contains(targetNode);
+                        (new CKEDITOR.dom.element(domNode)).contains(targetNode) || (target.parentNode.id === "ckimgrsz");
 
                     if (!res) {
                         this.setState({


### PR DESCRIPTION
## Issue
https://github.com/liferay/alloy-editor/issues/852

In [_setUIHidden](https://github.com/liferay/alloy-editor/blob/d34fe1b67b9a70e417aac72842ead20222131903/src/ui/react/src/components/main.jsx#L347) we check whether the user's interaction target is within the editor / editable area.  

The issue is that dragresize dynamically generates the drag handles outside of the editable div and making `editable.contains(targetNode)` false and thus we're treating resizing as though we're outside the UI.

## Solution
We modify the [_setUIHidden check](https://github.com/liferay/alloy-editor/blob/d34fe1b67b9a70e417aac72842ead20222131903/src/ui/react/src/components/main.jsx#L359) to also test whether we're resizing an image.  We do this by checking whether the target is within the div with id "ckimgrsz".

## Test
Chrome and FireFox.