### PR TITLE
Adjust toolbar placement on right side to prevent overflow

### DIFF
--- a/src/ui/react/src/components/base/widget-position.js
+++ b/src/ui/react/src/components/base/widget-position.js
@@ -148,8 +148,8 @@
             }
 
 
-            if (left > document.body.offsetWidth - halfWidth) {
-                left = document.body.offsetWidth - halfWidth;
+            if (left > document.body.offsetWidth - offsetWidth) {
+                left = document.body.offsetWidth - offsetWidth;
             }
 
             if (top < 0) {


### PR DESCRIPTION
## Issue
The toolbar may overflow on the right side of the screen if the user has a smaller screen or resizes the browser. This will prevent users from seeing toolbar options.

## Reproduce
Example of issue can be found here: https://github.com/liferay/alloy-editor/issues/866#issuecomment-404677783


## Solution
By checking if the placement of the `left` is going to be greater than the document's body offset subtracted by the toolbar width, we can prevent any overflow.


