### PR TITLE
Adjust centerToolbar to prevent overflow

### DIFF
--- a/src/ui/react/src/selections/selection-position.js
+++ b/src/ui/react/src/selections/selection-position.js
@@ -24,13 +24,10 @@
 
         var widgetXY = toolbar.getWidgetXYPoint(rect.left + rect.width / 2 - scrollPosition.x, rect.top + scrollPosition.y, CKEDITOR.SELECTION_BOTTOM_TO_TOP);
 
-        toolbar.moveToPoint([
-            widgetXY[0],
-            widgetXY[1]
-        ], [
-            rect.left + rect.width / 2 - halfNodeWidth - scrollPosition.x,
-            rect.top - toolbarNode.offsetHeight + scrollPosition.y - gutter.top
-        ]);
+        new CKEDITOR.dom.element(toolbarNode).setStyles({
+        	left: widgetXY[0] + 'px',
+            top: widgetXY[1] + 'px'
+        });
     };
 
     /**


### PR DESCRIPTION
## Issue
The image toolbar will extend past the browser for certain image sizes and browser sizes. This can be seen here https://github.com/liferay/alloy-editor/issues/876

## Solution
By default, the image toolbar is set to be centered onto the image. We can adjust the `centerToolbar` to maintain the center position and adjust when it will overflow off the screen.

In Liferay, we will need to add `jsonObject.put("setPosition", "AlloyEditor.SelectionSetPosition.table");` to [`getToolbarsStylesSelectionsImageJSONObject`](https://github.com/liferay/liferay-portal/blob/master/modules/apps/frontend-editor/frontend-editor-alloyeditor-web/src/main/java/com/liferay/frontend/editor/alloyeditor/web/internal/editor/configuration/AlloyEditorConfigContributor.java#L222). This will allow the toolbar to follow the images when they are left, centered, and right aligned as well as keep from overflowing. 

https://issues.liferay.com/browse/LPS-84657