### PR TITLE
Fix editor.on paste function and fix REGEX_URL

### DIFF
--- a/src/plugins/autolink.js
+++ b/src/plugins/autolink.js
@@ -25,8 +25,10 @@
 
     var REGEX_LAST_WORD = /[^\s]+/mg;
 
-    var REGEX_URL = /((([A - Za - z]{ 3, 9}: (?: \/\/)?)(?:[-;:&=\+\$,\w]+@)?[A-Za-z0-9.-]+|(https?\:\/\/|www.|[-;:&=\+\$,\w]+@)[A-Za-z0-9.-]+)((?:\/[\+~%\/.\w-_]*)?\??(?:[-\+=&;%@.\w_]*)#?(?:[\w]*))((.*):(\d*)\/?(.*))?)/i;
-
+    var REGEX_URL =  /(?:(?:https?|ftp):\/\/)?(?:\S+(?::\S*)?@)?(?:(?!10(?:\.\d{1,3}){3})(?!127(?:\.\d{1,3}){3})(?!169\.254(?:\.\d{1,3}){2})(?!192\.168(?:\.\d{1,3}){2})(?!172\.(?:1[6-9]|2\d|3[0-1])(?:\.\d{1,3}){2})(?:[1-9]\d?|1\d\d|2[01]\d|22[0-3])(?:\.(?:1?\d{1,2}|2[0-4]\d|25[0-5])){2}(?:\.(?:[1-9]\d?|1\d\d|2[0-4]\d|25[0-4]))|(?:(?:[a-z\u00a1-\uffff0-9]+-?)*[a-z\u00a1-\uffff0-9]+)(?:\.(?:[a-z\u00a1-\uffff0-9]+-?)*[a-z\u00a1}-\uffff0-9]+)*(?:\.(?:[a-z\u00a1-\uffff]{2,})))(?::\d{2,5})?(?:\/\S*)?/igm;
+	
+	var REGEX_EMAIL = /[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,4}/igm;
+		
     /**
      * CKEditor plugin which automatically generates links when user types text which looks like URL.
      *
@@ -56,23 +58,22 @@
 
                 editor.on('paste', function (event) {
                     if (event.data.method === 'paste') {
-                        var data = event.data.dataValue;
-
-                        if ( data.indexOf( '<' ) > -1 ) {
+						
+						if (event.data.dataValue.indexOf('<') > -1  || event.data.dataValue.indexOf('&lt;') > -1) {
                             return;
-                        }
-
-                        var match = data.match(REGEX_URL);
-
-                        if (match && match.length) {
-                            match = match[0];
-
-                            var remainder = data.replace(match, '');
-
-                            if (this._isValidURL(match)) {
-                                event.data.dataValue = '<a href=\"' + match + '\">' + match + '</a>' + remainder;
-                            }
-                        }
+						}
+					  
+						var instance = this;
+						
+						event.data.dataValue = event.data.dataValue.replace(REGEX_URL, function (url) {
+							if (instance._isValidURL(url)) {
+								if (instance._isValidEmail(url)) {
+									return '<a href=\"mailto:' + url + '\">' + url + '</a>';
+								} else {
+									return '<a href=\"' + url + '\">' + url + '</a>';
+								}
+							}
+						});
                     }
                 }.bind(this));
             },
@@ -142,6 +143,20 @@
 
                 return lastWord;
             },
+			
+			/**
+             * Checks if the given link is a valid Email.
+             *
+             * @instance
+             * @memberof CKEDITOR.plugins.ae_autolink
+             * @method isValidEmail
+             * @param {String} link The email we want to know if it is a valid Email
+             * @protected
+             * @return {Boolean} Returns true if the email is a valid Email, false otherwise
+             */
+            _isValidEmail: function(email) {
+                return RegExp(REGEX_EMAIL, 'i').test(email);
+            },
 
             /**
              * Checks if the given link is a valid URL.
@@ -154,7 +169,7 @@
              * @return {Boolean} Returns true if the link is a valid URL, false otherwise
              */
             _isValidURL: function(link) {
-                return REGEX_URL.test(link);
+                return RegExp(REGEX_URL, 'i').test(link);
             },
 
             /**


### PR DESCRIPTION
## Prelude
The issue was introduce by the following commit: 
"Adds a way to correct paste behavior of an URL"
https://github.com/liferay/alloy-editor/commit/32040b86150be5016a3e30ddaa78031a3c09b0c9

## Issue
Pasting text from the clipboard which contains url(s) the first url is automatically moving to the beginning of the paragraph replacing with an anchor link. The other urls stay untached. 

The issue is only reproducable when copying text from the clipboard
- which has url(s)
- and not contains new lines
- and the text is not copied from the editor itself.

When typeing text in the editor the url(s) are replacing with anchor links correctly.

## Solution
The original solution was wrong: only replaced the first url in the text and placed the anchor link to the beginning of the text.

I changed the REGEX_URL to find all the url occurrence in the text and i rewrited the paste function to replace all the urls in place with the anchor links. I also added the functionality to replace the valid emails with anchor links too.

https://issues.liferay.com/browse/LPS-85659