### PR TITLE
Fix #898 | Added center align css interaction between IE11 and other …

### DIFF
--- a/src/plugins/dragresize_ie11.js
+++ b/src/plugins/dragresize_ie11.js
@@ -863,6 +863,10 @@
 
                 wrapper.removeStyle( 'text-align' );
             }
+
+            var image = wrapper.$.querySelector('img');
+
+            image.removeAttribute('style');
         }
     }
 

--- a/src/plugins/imagealignment.js
+++ b/src/plugins/imagealignment.js
@@ -66,6 +66,23 @@
                 return styleCheck;
             });
 
+            if (!imageAlignment) {
+                var imageContainer = image.$.parentNode;
+
+                if (imageContainer.style.textAlign == IMAGE_ALIGNMENT.CENTER) {
+                    CENTERED_IMAGE_STYLE.forEach(function (style) {
+                        image.setStyle(style.name, style.value);
+
+                        if (style.vendorPrefixes) {
+                            style.vendorPrefixes.forEach(function (vendorPrefix) {
+                                image.setStyle(vendorPrefix + style.name, style.value);
+                            });
+                        }
+                    });
+                    centeredImage = true;
+                }
+            }
+
             imageAlignment = centeredImage ? IMAGE_ALIGNMENT.CENTER : null;
         }
 
@@ -95,6 +112,12 @@
                     });
                 }
             });
+
+            var imageContainer = image.$.parentNode;
+
+            if (imageContainer.style.textAlign == IMAGE_ALIGNMENT.CENTER) {
+                imageContainer.style.textAlign = '';
+            }
         }
     };
 
@@ -119,6 +142,11 @@
                     });
                 }
             });
+
+            var imageContainer = image.$.parentNode;
+
+            imageContainer.style.textAlign = IMAGE_ALIGNMENT.CENTER;
+
         }
     };
 


### PR DESCRIPTION
…browsers

## Issue
https://github.com/liferay/alloy-editor/issues/898
The issue is the difference in center alignment for IE11 and other browsers will clash and produce unexpected behaviors such as unable to unalign. The left and right align work correctly since this is only adding `float: left` and `float: right` to the content. 

Center align is problematic since in IE11, it adds `text-align: center` style to the parentNode of the image, image container. While in other browsers the styles `margin-right: auto`, `margin-left: auto` and `display:block` is added to the image.

## Solution
A solution is to adjust these styles so that they will be correct no matter which browser is being used. 
When aligning in other browsers, the first check `getImageAlignment `will look for a text-align Style in the image container. If it is found, then that means it has been previously edited and expect to be center aligned. Then it will add the center alignment in the image. The `removeImageAlignment `will check and remove the text-align style from the image container. `setImageAlignment `will add the style to the image container so that if the content is being worked on in IE11, it will be properly aligned.

In IE11, the style is removed from the image since they are not needed on the image but on the image container. 

I tested on Firefox, Chrome, and IE11.

Let me know if there are any questions or comments about this.
Thank you.
