### PR TITLE
Fix #903 | If editor is present, drag and drop into non-editor…

### DIFF
--- a/src/plugins/addimages.js
+++ b/src/plugins/addimages.js
@@ -7,6 +7,13 @@
         return;
     }
 
+    window.addEventListener('dragover', function(event){
+        event.preventDefault();
+    },false);
+    window.addEventListener('drop', function(event){
+        event.preventDefault();
+    },false);
+
     /**
      * CKEditor plugin which allows Drag&Drop of images directly into the editable area. The image will be encoded
      * as Data URI. An event `beforeImageAdd` will be fired with the list of dropped images. If any of the listeners


### PR DESCRIPTION
## Issue

#903 
The current behavior in the portal is that drag&drop of media content (such as images and videos) onto the browser will open the content in the browser. This behavior becomes problematic when you initiate a a drag&drop of the content within something such as a Web Content. All work will be lost (if the work has not been saved) if a user does not the drop the content within the editable areas of the editor as the content will be loaded in the browser.
I cannot reproduce the issue with AlloyEditor's demo, but the issue is reproducible in the portal.

## Solution
The solution is very straight forward. If the media content is not currently being dropped into the editable area of the editor, we should prevent the default behavior of drag and drop.


I tested on Firefox and Chrome.

Let me know if there are any questions or comments about this.
Thank you.