### PR TITLE
Fixes #911 Use correct CSS to place drag resize handle at the corner

### DIFF
--- a/src/plugins/dragresize_ie11.js
+++ b/src/plugins/dragresize_ie11.js
@@ -50,7 +50,7 @@
             // Bottom-left corner style of the resizer.
             '.cke_image_resizer.cke_image_resizer_left{' +
                 'right:auto;' +
-                'left:-5px;' +
+                'left:-25px;' +
                 'cursor:sw-resize;' +
             '}' +
             '.cke_widget_wrapper:hover .cke_image_resizer,' +


### PR DESCRIPTION
**Issue**

#911
In IE11 when changing the image's alignment to the right the drag resize handle moves from it's expected lower righthand location to the lower lefthand side. However, the handle is misplaced slightly to the right of the lefthand corner.

**Solution**

The CSS property **left** for cke_image_resizer_left just has to be adjusted to be -25px isntead of -5px.

The issue only appears in IE11 and have tested also in Chrome, Firefox, and Edge. The issue is only reproducible on Liferay AlloyEditor.

Let me know if there are any questions or comments.
Thank you.