### PR TITLE
Fixes https://github.com/liferay/alloy-editor/issues/900 Add closing …

### DIFF
--- a/src/plugins/dragresize_ie11.js
+++ b/src/plugins/dragresize_ie11.js
@@ -1000,7 +1000,7 @@
 
                 // Update element styles.
                 if ( !alignClasses && !CKEDITOR.tools.isEmpty( styles ) )
-                    attrs.style = CKEDITOR.tools.writeCssText( styles );
+                    attrs.style = CKEDITOR.tools.writeCssText( styles ) + ';';
             }
 
             return el;


### PR DESCRIPTION
IE11 uses [writeCssText](https://github.com/ckeditor/ckeditor-dev/blob/2dbe13b237acfd06dbd069ef4d69e384730c050c/core/tools.js#L1083-L1094) which uses join meaning there is no ending semi-colon.  This leads to style / CSS selector differences between browsers.

Let me know if there's any questions.