### PR TITLE
Fixes #915 - Checks if selection data exists in linkSelectionTest

### DIFF
--- a/src/ui/react/src/selections/selection-test.js
+++ b/src/ui/react/src/selections/selection-test.js
@@ -32,15 +32,12 @@
         var range = nativeEditor.getSelection().getRanges()[0];
         var selectionData = payload.data.selectionData;
 
-        var selectionDataName;
-
         var element;
-
-        if (selectionData.element) selectionDataName = selectionData.element.getName();
 
         return !!(
             nativeEditor.isSelectionEmpty() &&
-            selectionDataName !== 'img' &&
+            selectionData.element &&
+            selectionData.element.getName() !== 'img' &&
             (element = (new CKEDITOR.Link(nativeEditor)).getFromSelection()) &&
             element.getText().length !== range.endOffset &&
             !element.isReadOnly() &&


### PR DESCRIPTION
## Prelude
The issue described in #848 still exists for Chrome. I was not able to reproduce it in IE/Edge/Firefox.

The issue is that the linkSelectionTest does not check if the selectionData.element has any value (similar to what imageSelectionTest is checking).

## Issue
#915 

## Solution
The linkSelectionTest would return a false positive when there is no selection data. I added a condition to check for selection data (similar to what imageSelectionTest is doing). 

## Test
Chrome, IE 11, Edge, and FireFox

Before & after: 
https://imgur.com/a/wTe7Swz
