### PR TITLE
Fixes #908 Remove unwanted tags after paste

### DIFF
--- a/src/plugins/autolink.js
+++ b/src/plugins/autolink.js
@@ -26,9 +26,9 @@
     var REGEX_LAST_WORD = /[^\s]+/gim;
 
     var REGEX_URL = /((([A - Za - z]{ 3, 9}: (?: \/\/)?)(?:[-;:&=\+\$,\w]+@)?[A-Za-z0-9.-]+|(https?\:\/\/|www.|[-;:&=.\+\$,\w]+@)[A-Za-z0-9.-]+)((?:\/[\+~%\/.\w-_]*)?\??(?:[-\+=&;%@.\w_]*)#?(?:[\w]*))((.*):(\d*)\/?(.*))?)/i;
-	
+
     var REGEX_EMAIL = /[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,4}/i;
-	
+
     /**
      * CKEditor plugin which automatically generates links when user types text which looks like URL.
      *
@@ -58,13 +58,16 @@
 
                 editor.on('paste', function (event) {
                     if (event.data.method === 'paste') {
-						
-                        if (event.data.dataValue.indexOf('<') > -1  || event.data.dataValue.indexOf('&lt;') > -1) {
+
+                        if (event.data.dataValue.indexOf('<') > -1 || event.data.dataValue.indexOf('&lt;') > -1) {
+                            if(event.data.dataValue.indexOf('<u><font color=\"') > -1) {
+                                event.data.dataValue = event.data.dataValue.replace(/<u><font color=\"#(.*?)\">|<\/font><\/u>/g,'');
+                            }
                             return;
                         }
 
                         var instance = this;
-						
+
                         event.data.dataValue = event.data.dataValue.replace(RegExp(REGEX_URL, 'gim'), function (url) {
                             if (instance._isValidURL(url)) {
                                 if (instance._isValidEmail(url)) {
@@ -143,7 +146,7 @@
 
                 return lastWord;
             },
-			
+
             /**
              * Checks if the given link is a valid Email.
              *


### PR DESCRIPTION
Resent PR https://github.com/liferay/alloy-editor/pull/909
Fixed typo that prevented the fix from working correctly.

> ## Issue
> https://github.com/liferay/alloy-editor/issues/908
> When copying and pasting a link in IE11, the pasted link will contain additional tags `<u><font>`.
> 
> ## Solution
> I created a check that will search for these unwanted tags. In this issue, the `<u><font color="` tag will be present and will be used to identify this issue. I did not include the color since this issue may occur with different colors. If they are found, they will be replaced with an empty space making sure to remove the start and end tags. It will search through the whole string so it will remove multiple tags.
> 
> The issue only appears in IE11 and have tested also in Chrome, Firefox, and Edge.
> 
> Let me know if there are any questions or comments.
> Thank you.

Please let me know if there are any questions or comments.
Thank you.