### PR TITLE
Change dragresize implementation on IE to modify heigh and width insi…

### DIFF
--- a/src/plugins/dragresize_ie.js
+++ b/src/plugins/dragresize_ie.js
@@ -878,10 +878,9 @@
                 // Don't update attributes if less than 10.
                 // This is to prevent images to visually disappear.
                 if (newWidth >= 15 && (newHeight >= 15 || newHeight === 'auto')) {
-                    image.setAttributes({
-                        width: newWidth,
-                        height: newHeight
-                    });
+                    image.$.style.width = newWidth;
+                    image.$.style.height = newHeight;
+                    
                     updateData = true;
                 } else {
                     updateData = false;
@@ -902,10 +901,8 @@
                 resizer.removeClass('cke_image_resizing');
 
                 if (updateData) {
-                    widget.setData({
-                        height: newHeight,
-                        width: newWidth
-                    });
+                    widget.element.$.style.width = newWidth;
+                    widget.element.$.style.height = newHeight;
 
                     // Save another undo snapshot: after resizing.
                     editor.fire('saveSnapshot');

--- a/src/plugins/dragresize_ie11.js
+++ b/src/plugins/dragresize_ie11.js
@@ -1296,7 +1296,9 @@
                 // Don't update attributes if less than 10.
                 // This is to prevent images to visually disappear.
                 if ( newWidth >= 15 && newHeight >= 15 ) {
-                    image.setAttributes( { width: newWidth, height: newHeight } );
+                    image.$.style.width = newWidth;
+                    image.$.style.height = newHeight;
+
                     updateData = true;
                 } else {
                     updateData = false;
@@ -1316,7 +1318,8 @@
                 resizer.removeClass( 'cke_image_resizing' );
 
                 if ( updateData ) {
-                    widget.setData( { width: newWidth, height: newHeight } );
+                    widget.element.$.style.width = newWidth;
+                    widget.element.$.style.height = newHeight;
 
                     // Save another undo snapshot: after resizing.
                     editor.fire( 'saveSnapshot' );


### PR DESCRIPTION
…de the style attribute so as to be consistent with the standard AlloyEditor resizing behavior.

Please employ to following template as the base structure of Pull Requests for **AlloyEditor** (liferay/alloy-editor) project. Pull Requests not incorporating the sections below will be regarded as unsatisfying and rejected. 

## Prelude
Default dragresize implementation doesn't work in IE11, so the CKEditor behavior was copied over without changes.

## Issue
The issue is a mismatch in how dragresize modifies height/width for an image between IE and other browsers. In most browsers, we modify height and width inside the image's style attribute. However, IE's implementation of dragresize copies directly from how CKEditor handles this which is to use individual height and width attributes for the image. The problem here is if both are present because the image was edited in different browsers then the edits from non-IE browsers will always take precedence.

## Solution
I removed our use of the height/width attributes for dragresize_ie and replaced them with style modifications to line up with the behavior on other browsers.

## Test
This fix has been tested on Internet Explorer 11, the main environment were we use dragresize_ie.
