### PR TITLE
Fixes #924 Add four drag handles for image resizing

### DIFF
--- a/src/plugins/dragresize_ie11.js
+++ b/src/plugins/dragresize_ie11.js
@@ -75,12 +75,6 @@
                 'left:-5px;' +
                 'right:auto;' +
             '}' +
-            // Bottom-left corner style of the resizer.
-            '.cke_image_resizer.cke_image_resizer_left{' +
-                'right:auto;' +
-                'left:-25px;' +
-                'cursor:sw-resize;' +
-            '}' +
             '.cke_widget_wrapper:hover .cke_image_resizer,' +
             '.cke_image_resizer.cke_image_resizing{' +
                 'display:block' +
@@ -1348,11 +1342,6 @@
                 // Don't update data twice or more.
                 updateData = false;
             }
-        } );
-
-        // Change the position of the widget resizer when data changes.
-        widget.on( 'data', function() {
-            resizer[ widget.data.align == 'right' ? 'addClass' : 'removeClass' ]( 'cke_image_resizer_left' );
         } );
     }
 

--- a/src/plugins/dragresize_ie11.js
+++ b/src/plugins/dragresize_ie11.js
@@ -27,6 +27,8 @@
                 // wrapper is displayed property.
                 'line-height:0' +
             '}' +
+            '.cke_editable.cke_image_ne, .cke_editable.cke_image_ne *{cursor:ne-resize !important}' +
+            '.cke_editable.cke_image_nw, .cke_editable.cke_image_nw *{cursor:nw-resize !important}' +
             '.cke_editable.cke_image_sw, .cke_editable.cke_image_sw *{cursor:sw-resize !important}' +
             '.cke_editable.cke_image_se, .cke_editable.cke_image_se *{cursor:se-resize !important}' +
             '.cke_image_resizer{' +
@@ -34,8 +36,6 @@
                 'position:absolute;' +
                 'width:10px;' +
                 'height:10px;' +
-                'bottom:-5px;' +
-                'right:-5px;' +
                 'background:#000;' +
                 'outline:1px solid #fff;' +
                 // Prevent drag handler from being misplaced (#11207).
@@ -46,6 +46,34 @@
                 'position:relative;' +
                 'display:inline-block;' +
                 'line-height:0;' +
+            '}' +
+            // Top-right corner style of the resizer.
+            '.cke_image_resizer.cke_image_resizer_ne{' +
+                'cursor:ne-resize;' +
+                'left:auto;' +
+                'right:-5px;' +
+                'top:-5px;' +
+            '}' +
+            // Top-left corner style of the resizer.
+            '.cke_image_resizer.cke_image_resizer_nw{' +
+                'cursor:nw-resize;' +    
+                'left:-5px;' +
+                'right:auto;' +
+                'top:-5px;' +
+            '}' +
+            // Bottom-right corner style of the resizer.
+            '.cke_image_resizer.cke_image_resizer_se{' +
+                'bottom:-5px;' +
+                'cursor:se-resize;' +
+                'left:auto;' +
+                'right:-5px;' +
+            '}' +
+            // Bottom-left corner style of the resizer.
+            '.cke_image_resizer.cke_image_resizer_sw{' +
+                'bottom:-5px;' +
+                'cursor:sw-resize;' +
+                'left:-5px;' +
+                'right:auto;' +
             '}' +
             // Bottom-left corner style of the resizer.
             '.cke_image_resizer.cke_image_resizer_left{' +


### PR DESCRIPTION
## Prelude
Currently, IE11 only has one resize handle when resizing an image within AlloyEditor while other browsers (Chrome, Firefox) have four.  The task at hand is to implement resizing for IE11 such that it has a total of four drag handles and behaves in the same way as other browsers.
## Issue
https://github.com/liferay/alloy-editor/issues/924

## Solution

- Add styling for the four drag handles on the image resizer (one drag handle on each corner).  
- Add four drag handles as child elements of the image resizer, each with its proper CSS style
     - `factorX` and `factorY` can be either +1 or -1, and they take into account which drag handle is being used.
     - Height and width adjustment with `adjustToX()` and `adjustToY()` methods use `factorX` and `factorY` to determine whether to enlarge or shrink an image.
- No longer need to consider left, center, or right alignment since resizing behaves the same way

## Test
This fix has been tested on Internet Explorer 11, the main environment where we use dragresize_ie11.js.

## Notes

- Re-sending this as a fixed PR from https://github.com/liferay/alloy-editor/pull/925
- With this change, the drag handles for images on IE11 are off-set in Liferay portal.  Refinements to their positioning will be made separately in the Liferay repositories since this behaviour is specific to the Liferay portal