### PR TITLE
Remove unused gulp-empty dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5244,51 +5244,6 @@
         "vinyl-sourcemaps-apply": "^0.2.1"
       }
     },
-    "gulp-empty": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/gulp-empty/-/gulp-empty-0.1.2.tgz",
-      "integrity": "sha1-Q2HgRlKefjZFs9WeBH6yO9dRcus=",
-      "dev": true,
-      "requires": {
-        "through2": "^0.6.5"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-          "dev": true
-        },
-        "readable-stream": {
-          "version": "1.0.34",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-          "dev": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
-            "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
-          }
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-          "dev": true
-        },
-        "through2": {
-          "version": "0.6.5",
-          "resolved": "http://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-          "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
-          "dev": true,
-          "requires": {
-            "readable-stream": ">=1.0.33-1 <1.1.0-0",
-            "xtend": ">=4.0.0 <4.1.0-0"
-          }
-        }
-      }
-    },
     "gulp-iconfont": {
       "version": "10.0.2",
       "resolved": "https://registry.npmjs.org/gulp-iconfont/-/gulp-iconfont-10.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "gulp-concat": "^2.6.1",
     "gulp-consolidate": "^0.2.0",
     "gulp-cssnano": "^2.1.3",
-    "gulp-empty": "^0.1.2",
     "gulp-iconfont": "^10.0.2",
     "gulp-rename": "^1.2.2",
     "gulp-sass": "^4.0.1",

--- a/scripts/build/gulp/tasks/fonts.js
+++ b/scripts/build/gulp/tasks/fonts.js
@@ -8,7 +8,6 @@ const es = require('event-stream');
 const fs = require('fs');
 const gulp = require('gulp');
 const iconfont = require('gulp-iconfont');
-const noop = require('gulp-empty');
 const path = require('path');
 const rename = require('gulp-rename');
 const runSequence = require('run-sequence');


### PR DESCRIPTION
Originally submitted as part of #958. Splitting it off to see if Travis accepts a smaller change.