### PR TITLE
Parallelize webpack builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,10 +56,10 @@
     "dist/**/*"
   ],
   "scripts": {
-    "build:assets": "gulp --gulpfile scripts/build/gulp/gulpfile.js",
-    "build": "npm run build:assets -- --release && webpack --config webpack.prod.js && webpack --config webpack.dev.js",
+    "build:assets": "gulp --gulpfile scripts/build/gulp/gulpfile.js build:assets",
+    "build": "gulp --gulpfile scripts/build/gulp/gulpfile.js --release",
     "checkFormat": "prettier --list-different -- '*.js' '{api,scripts,src,test}/**/*.js'",
-    "dev": "npm run build:assets && webpack --config webpack.dev.js",
+    "dev": "gulp --gulpfile scripts/build/gulp/gulpfile.js",
     "format": "prettier --write -- '*.js' '{api,scripts,src,test}/**/*.js'",
     "prettier": "prettier --write -- '*.js' '{api,scripts,src,test}/**/*.js'",
     "start": "webpack-dev-server --config webpack.dev.js",

--- a/scripts/build/gulp/tasks/build.js
+++ b/scripts/build/gulp/tasks/build.js
@@ -6,19 +6,59 @@ const gulp = require('gulp');
 const path = require('path');
 const runSequence = require('run-sequence');
 const template = require('gulp-template');
+const webpack = require('webpack');
 const Constants = require('../constants');
 
-gulp.task('build', function(callback) {
-	const tasks = ['build-demo', 'post-cleanup'];
+runSequence.options.ignoreUndefinedTasks = true;
 
-	if (argv.release) {
-		tasks.push('minimize-css');
-	}
+function ifRelease(task) {
+	return !!argv.release && task;
+}
 
+function createBundle(configName, callback) {
+	const config = require(path.join(process.env.PWD, configName));
+	webpack(config, (error, {stats}) => {
+		if (error) {
+			callback(error);
+			return;
+		}
+		const errors = stats.reduce((acc, {compilation: {errors}}) => {
+			if (errors) {
+				acc.push(...errors);
+			}
+			return acc;
+		}, []);
+		const [firstError, ...remainingErrors] = errors;
+		if (firstError) {
+			remainingErrors.forEach(console.log.bind(console));
+			callback(firstError);
+		}
+		console.log(stats.toString({colors: true}));
+		callback();
+	});
+}
+
+gulp.task('webpack.prod', callback => {
+	createBundle('webpack.prod', callback);
+});
+
+gulp.task('webpack.dev', callback => {
+	createBundle('webpack.dev', callback);
+});
+
+gulp.task('build:assets', function(callback) {
 	runSequence(
 		'clean-dist',
 		['build-css', 'copy-ckeditor', 'copy-languages', 'copy-svgs'],
-		tasks,
+		['build-demo', 'post-cleanup', ifRelease('minimize-css')],
+		callback
+	);
+});
+
+gulp.task('build', function(callback) {
+	runSequence(
+		'build:assets',
+		[ifRelease('webpack.prod'), 'webpack.dev'],
 		callback
 	);
 });

--- a/scripts/build/gulp/tasks/build.js
+++ b/scripts/build/gulp/tasks/build.js
@@ -1,12 +1,12 @@
-const gulp = require('gulp');
-
 const argv = require('yargs').argv;
-const Constants = require('../constants');
+
 const del = require('del');
 const fs = require('fs');
+const gulp = require('gulp');
 const path = require('path');
 const runSequence = require('run-sequence');
 const template = require('gulp-template');
+const Constants = require('../constants');
 
 gulp.task('build', function(callback) {
 	const tasks = ['build-demo', 'post-cleanup'];

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -1,29 +1,51 @@
 const path = require('path');
 
-const modules = {
-	rules: [
-		{
-			test: /\.(js|jsx)$/,
-			exclude: /(node_modules|lib)/,
-			loader: 'babel-loader'
-		}
-	]
+/**
+ * Turns a root-relative path into an absolute one.
+ *
+ * This ensures that webpack works identically when invoked from the
+ * top-level (eg. with `npm run webpack` or from a subdirectory (eg.
+ * from a file under `scripts/gulp`).
+ */
+function toAbsolute(rootRelativePath) {
+	return path.join(__dirname, rootRelativePath);
+}
+
+const base = {
+	/**
+	 * https://webpack.js.org/configuration/entry-context/
+	 */
+	context: toAbsolute('.'),
+
+	/**
+	 * https://webpack.js.org/configuration/module/
+	 */
+	module: {
+		rules: [
+			{
+				test: /\.(js|jsx)$/,
+				exclude: /(node_modules|lib)/,
+				loader: 'babel-loader'
+			}
+		]
+	}
 };
 
 module.exports = {
 	config: {
+		...base,
 		entry: './scripts/build/index.js',
 		output: {
-			path: path.resolve('dist/alloy-editor')
-		},
-		module: modules
+			path: toAbsolute('./dist/alloy-editor')
+		}
 	},
 	core: {
+		...base,
 		entry: './src/adapter/main.js',
 		output: {
 			library: 'AlloyEditor',
 			libraryTarget: 'window',
-			path: path.resolve('dist/alloy-editor')
+			path: toAbsolute('./dist/alloy-editor')
 		},
 		externals: {
 			react: {
@@ -40,24 +62,24 @@ module.exports = {
 				amd: 'react-dom',
 				umd: 'react-dom'
 			}
-		},
-		module: modules
+		}
 	},
 	noCkeditor: {
+		...base,
 		entry: './src/adapter/main.js',
 		output: {
 			library: 'AlloyEditor',
 			libraryTarget: 'window',
-			path: path.resolve('dist/alloy-editor')
-		},
-		module: modules
+			path: toAbsolute('./dist/alloy-editor')
+		}
 	},
 	noReact: {
+		...base,
 		entry: './scripts/build/index.js',
 		output: {
 			library: 'AlloyEditor',
 			libraryTarget: 'umd',
-			path: path.resolve('dist/alloy-editor')
+			path: toAbsolute('./dist/alloy-editor')
 		},
 		externals: {
 			react: {
@@ -74,7 +96,6 @@ module.exports = {
 				amd: 'react-dom',
 				umd: 'react-dom'
 			}
-		},
-		module: modules
+		}
 	}
 };

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -1,5 +1,4 @@
 const merge = require('webpack-merge');
-const webpack = require('webpack');
 
 const common = require('./webpack.common.js');
 


### PR DESCRIPTION
This is just an intermediate step towards making builds faster.

Before this PR, our build process looked like this:

1. Run "build:assets" using the `gulp` executable.
2. Do webpack.prod build using the `webpack` executable.
3. Do webpack.dev build using the `webpack` executable.

These serial processes took about 2s, 12s, and 38s respectively on my machine: a total of about 52s.

After this commit, we do this:

1. Use `gulp` to do everything the "build:assets" task did.
2. In parallel, run the two webpack builds from the same `gulp` invocation.

In the end, we wind shave only a few seconds from the original runtime (ie. going down to just under 50s) because we're always going to be limited by the length of the slowest job, and that job will actually run a little slower than usual when in parallel.

I have some follow-ups I'll be doing after this, such as seeing if switching to a different minifier is faster (we're spending most of the time in Uglify). Another will be asking why we commit the "dist" files at all, which seems unconventional.

Test plan:

- Confirm in-browser that dev environment still works after doing `npm  run dev` and `npm run start`.
- Compare `dist` output with current HEAD of "develop" branch is  identical.
- Compare `dist` output is same for:
  - Gulp (dev): node_modules/.bin/gulp --gulpfile ...`
  - Webpack(dev): node_modules/.bin/webpack --config webpack.dev.js`
  - Gulp (prod): node_modules/.bin/gulp --gulpfile ... --release`
  - Webpack(prod): node_modules/.bin/webpack --config webpack.prod.js`
32d3ea1