### PR TITLE
Remove require-dir dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9164,12 +9164,6 @@
         "uuid": "^3.3.2"
       }
     },
-    "require-dir": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/require-dir/-/require-dir-1.2.0.tgz",
-      "integrity": "sha512-LY85DTSu+heYgDqq/mK+7zFHWkttVNRXC9NKcKGyuGLdlsfbjEPrIEYdCVrx6hqnJb+xSu3Lzaoo8VnmOhhjNA==",
-      "dev": true
-    },
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "karma-webpack": "^3.0.0",
     "mocha": "5.2.0",
     "prettier": "1.15.3",
-    "require-dir": "^1.0.0",
     "run-sequence": "^2.2.1",
     "sinon": "1.15.4",
     "terser-webpack-plugin": "^1.2.1",

--- a/scripts/build/gulp/gulpfile.js
+++ b/scripts/build/gulp/gulpfile.js
@@ -1,7 +1,8 @@
 const gulp = require('gulp');
-const path = require('path');
-const requireDir = require('require-dir');
 
-requireDir(path.join(__dirname, 'tasks'));
+require('./tasks/build');
+require('./tasks/css');
+require('./tasks/icons');
+require('./tasks/languages');
 
 gulp.task('default', ['build']);


### PR DESCRIPTION
This dependency doesn't do much for us: removing it shows that we can get by without it (note how we used four lines invoking the package before this commit, and when we remove the package we can get an equivalent outcome with four lines, leaving the total count unchanged).

In any case, the real motivation here is that when we move to Gulp v4 (see #980), the pattern is to refer to tasks using function references rather than strings, which means we'd have to manually import the "build" tasks additionally anyway. Reducing our dependency footprint is just a bonus.

Test plan: `npm run build` and see that everything still works.