### PR TITLE
Fixes #983 - Make sure code is correctly formatted before publishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "dev": "gulp --gulpfile scripts/build/gulp/gulpfile.js",
     "format": "prettier --write -- '*.js' '{api,scripts,src,test}/**/*.js'",
     "prettier": "prettier --write -- '*.js' '{api,scripts,src,test}/**/*.js'",
+    "prepublishOnly": "npm run checkFormat && npm run test",
     "start": "webpack-dev-server --config webpack.dev.js",
     "test": "karma start karma.js",
     "testSaucelabs": "karma start karma-saucelabs.js"

--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -33,7 +33,7 @@ const config = {
 						reduce_vars: false,
 						switches: false,
 						toplevel: false,
-						typeofs: false,
+						typeofs: false
 					},
 					output: {
 						comments: false


### PR DESCRIPTION
Add a "prepublishOnly" task that errors out if we try to publish code that isn't formatted with Prettier. Also runs the tests for obvious reasons.

Once we have linting back up and running we can fail even faster with respect to formatting and warn or error at lint-time.

This commit includes a fix for one incorrectly formatted file. There are also a couple of others that need re-formatting:

- scripts/build/gulp/tasks/build.js
- scripts/build/gulp/tasks/css.js

but I am leaving those so as to avoid an unnecessary conflict with #982.