### PR TITLE
Use a more recent Node in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_script:
 language: node_js
 
 node_js:
-- '8'
+- 'node'
 
 script:
   - npm run build && npm run testSaucelabs


### PR DESCRIPTION
We were pegged at 8, but let's see if we have any more stability by
using the latest stable release at all times:

https://docs.travis-ci.com/user/languages/javascript-with-nodejs/#specifying-nodejs-versions