### PR TITLE
Fixes #988 - Remove .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,4 +1,0 @@
-[*.js*]
-indent_style = space
-indent_size = 4
-trim_trailing_whitespace=true


### PR DESCRIPTION
This one is deemed obsolete thanks to Prettier.

Closes: https://github.com/liferay/alloy-editor/issues/988
