### PR TITLE
Fixes #992 - Left-side add icon not showing up on 2.x branch #992

### DIFF
--- a/src/components/toolbars/toolbar-add.jsx
+++ b/src/components/toolbars/toolbar-add.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
+import ButtonIcon from '../buttons/button-icon.jsx';
 import ToolbarButtons from '../base/toolbar-buttons.js';
 import WidgetArrowBox from '../base/widget-arrow-box.js';
 import WidgetDropdown from '../base/widget-dropdown.js';
@@ -114,7 +115,7 @@ class ToolbarAdd extends React.Component{
             if (this.props.selectionData && this.props.selectionData.region) {
                 buttons = (
                     <button aria-label={AlloyEditor.Strings.add} className="ae-button ae-button-add" onClick={this.props.requestExclusive.bind(this, ToolbarAdd.key)} title={AlloyEditor.Strings.add}>
-                        <span className="ae-icon-add"></span>
+                        <ButtonIcon editor={this.props.editor} symbol="plus" />
                     </button>
                 );
             }


### PR DESCRIPTION
Before the fix:

![advanced_editing_demo](https://user-images.githubusercontent.com/7074/51677993-90412c80-1fdb-11e9-8b6f-4463f8850083.png)

After the fix:

![advanced_editing_demo](https://user-images.githubusercontent.com/7074/51677981-88818800-1fdb-11e9-8f6b-b47d939834bc.png)
