### PR TITLE
Fixes #998 Remove scrollTop from position for Safari

### DIFF
--- a/src/ui/react/src/components/base/widget-position.js
+++ b/src/ui/react/src/components/base/widget-position.js
@@ -280,11 +280,7 @@
                 var uiNodeMarginLeft = parseInt(uiNodeStyle.getPropertyValue('margin-left'), 10);
                 var uiNodeMarginRight = parseInt(uiNodeStyle.getPropertyValue('margin-right'), 10);
                 var totalWidth = uiNodeMarginLeft + uiNode.clientWidth + uiNodeMarginRight;
-
-                var scrollTop = uiNode ? uiNode.scrollTop : 0;
-
                 var xy = this.getWidgetXYPoint(interactionPoint.x, interactionPoint.y, interactionPoint.direction);
-                xy[1] += scrollTop;
 
                 if (xy[0] < 0) {
                     xy[0] = 0;

--- a/src/ui/react/src/components/base/widget-position.js
+++ b/src/ui/react/src/components/base/widget-position.js
@@ -281,7 +281,7 @@
                 var uiNodeMarginRight = parseInt(uiNodeStyle.getPropertyValue('margin-right'), 10);
                 var totalWidth = uiNodeMarginLeft + uiNode.clientWidth + uiNodeMarginRight;
 
-                var scrollTop = this.props.editor.get('uiNode') ? uiNode.scrollTop : 0;
+                var scrollTop = uiNode.tagName != 'BODY' ? uiNode.scrollTop : 0;
 
                 var xy = this.getWidgetXYPoint(interactionPoint.x, interactionPoint.y, interactionPoint.direction);
                 xy[1] += scrollTop;

--- a/src/ui/react/src/components/base/widget-position.js
+++ b/src/ui/react/src/components/base/widget-position.js
@@ -280,7 +280,11 @@
                 var uiNodeMarginLeft = parseInt(uiNodeStyle.getPropertyValue('margin-left'), 10);
                 var uiNodeMarginRight = parseInt(uiNodeStyle.getPropertyValue('margin-right'), 10);
                 var totalWidth = uiNodeMarginLeft + uiNode.clientWidth + uiNodeMarginRight;
+
+                var scrollTop = this.props.editor.get('uiNode') ? uiNode.scrollTop : 0;
+
                 var xy = this.getWidgetXYPoint(interactionPoint.x, interactionPoint.y, interactionPoint.direction);
+                xy[1] += scrollTop;
 
                 if (xy[0] < 0) {
                     xy[0] = 0;


### PR DESCRIPTION
## Issue
#998 
In Safari, the toolbar will display incorrectly if the window is scrolled.

## Solution
I removed the addition of scrollTop so that Safari will display the toolbar correctly. This is an issue in Safari since the document.body.scrollTop in Safari contains the correct value unlike other browsers where it is zero. 

## Test
Safari, Chrome, IE11, Firefox, Opera