### PR TITLE
Fixes #1000 - Speed up builds

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2384,6 +2384,12 @@
         "readable-stream": "^2.3.5"
       }
     },
+    "co": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+      "dev": true
+    },
     "coa": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/coa/-/coa-1.0.4.tgz",
@@ -3236,6 +3242,12 @@
         "object.defaults": "^1.1.0"
       }
     },
+    "easy-stack": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/easy-stack/-/easy-stack-1.0.0.tgz",
+      "integrity": "sha1-EskbMIWjfwuqM26UhurEv5Tj54g=",
+      "dev": true
+    },
     "ecc-jsbn": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
@@ -3812,6 +3824,12 @@
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
+      "dev": true
+    },
+    "event-pubsub": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/event-pubsub/-/event-pubsub-4.3.0.tgz",
+      "integrity": "sha512-z7IyloorXvKbFx9Bpie2+vMJKKx1fH1EN5yiTfp8CiLOTptSYy1g8H4yDpGlEdshL1PBiFtBHepF2cNsqeEeFQ==",
       "dev": true
     },
     "event-stream": {
@@ -6630,6 +6648,21 @@
       "integrity": "sha512-wlEBIZ5LP8usDylWbDNhKPEFVFdI5hCHpnVoT/Ysvoi/PRhJENm/Rlh9TvjYB38HFfKZN7OzEbRjmjvLkFw11g==",
       "dev": true
     },
+    "js-message": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/js-message/-/js-message-1.0.5.tgz",
+      "integrity": "sha1-IwDSSxrwjondCVvBpMnJz8uJLRU=",
+      "dev": true
+    },
+    "js-queue": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/js-queue/-/js-queue-2.0.0.tgz",
+      "integrity": "sha1-NiITz4YPRo8BJfxslqvBdCUx+Ug=",
+      "dev": true,
+      "requires": {
+        "easy-stack": "^1.0.0"
+      }
+    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -6675,6 +6708,15 @@
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true
     },
+    "json-stable-stringify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+      "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+      "dev": true,
+      "requires": {
+        "jsonify": "~0.0.0"
+      }
+    },
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
@@ -6697,6 +6739,12 @@
       "version": "0.5.1",
       "resolved": "http://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
       "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
+      "dev": true
+    },
+    "jsonify": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
       "dev": true
     },
     "jsprim": {
@@ -7176,6 +7224,18 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
       "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
+      "dev": true
+    },
+    "lodash.endswith": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/lodash.endswith/-/lodash.endswith-4.2.1.tgz",
+      "integrity": "sha1-/tWawXOO0+I27dcGTsRWRIs3vAk=",
+      "dev": true
+    },
+    "lodash.flatten": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
+      "integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8=",
       "dev": true
     },
     "lodash.memoize": {
@@ -7783,6 +7843,17 @@
         }
       }
     },
+    "node-ipc": {
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/node-ipc/-/node-ipc-9.1.1.tgz",
+      "integrity": "sha512-FAyICv0sIRJxVp3GW5fzgaf9jwwRQxAKDJlmNFUL5hOy+W4X/I5AypyHoq0DXXbo9o/gt79gj++4cMr4jVWE/w==",
+      "dev": true,
+      "requires": {
+        "event-pubsub": "4.3.0",
+        "js-message": "1.0.5",
+        "js-queue": "2.0.0"
+      }
+    },
     "node-libs-browser": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.2.0.tgz",
@@ -8304,6 +8375,59 @@
         "cyclist": "~0.2.2",
         "inherits": "^2.0.3",
         "readable-stream": "^2.1.5"
+      }
+    },
+    "parallel-webpack": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/parallel-webpack/-/parallel-webpack-2.3.0.tgz",
+      "integrity": "sha512-RCIDF+YOqyAJeM8NumtOQ8JYjUXexDRIN4slFNfvUp1RxLB1zLeLZMAwlP6s7l9LhuR5xJ2pv8ckIsdESzSqog==",
+      "dev": true,
+      "requires": {
+        "ajv": "^4.9.2",
+        "bluebird": "^3.0.6",
+        "chalk": "^1.1.1",
+        "interpret": "^1.0.1",
+        "lodash.assign": "^4.0.8",
+        "lodash.endswith": "^4.0.1",
+        "lodash.flatten": "^4.2.0",
+        "minimist": "^1.2.0",
+        "node-ipc": "^9.1.0",
+        "pluralize": "^1.2.1",
+        "supports-color": "^3.1.2",
+        "worker-farm": "^1.3.1"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "4.11.8",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
+          "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
+          "dev": true,
+          "requires": {
+            "co": "^4.6.0",
+            "json-stable-stringify": "^1.0.1"
+          }
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        },
+        "pluralize": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-1.2.1.tgz",
+          "integrity": "sha1-0aIUg/0iu0HlihL6NCGCMUCJfEU=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "3.2.3",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+          "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+          "dev": true,
+          "requires": {
+            "has-flag": "^1.0.0"
+          }
+        }
       }
     },
     "parent-module": {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "karma-verbose-reporter": "0.0.6",
     "karma-webpack": "^3.0.0",
     "mocha": "5.2.0",
+    "parallel-webpack": "2.3.0",
     "prettier": "1.15.3",
     "sinon": "1.15.4",
     "terser-webpack-plugin": "^1.2.1",

--- a/scripts/build/gulp/tasks/build.js
+++ b/scripts/build/gulp/tasks/build.js
@@ -3,8 +3,8 @@ const argv = require('yargs').argv;
 const del = require('del');
 const fs = require('fs');
 const gulp = require('gulp');
+const run = require('parallel-webpack').run;
 const path = require('path');
-const webpack = require('webpack');
 const Constants = require('../constants');
 
 require('./css');
@@ -23,51 +23,57 @@ function ifRelease(task) {
 	}
 }
 
-function createBundle(configName, callback) {
-	const config = require(path.join(process.env.PWD, configName));
-	webpack(config, (error, stats) => {
-		if (error || stats.hasErrors()) {
-			if (error) {
-				// Configuration errors etc.
-				// See: https://webpack.js.org/api/node/#webpack-
-				callback(error);
-			} else {
-				// Compilation errors.
-				const errors = stats.stats.reduce(
-					(acc, {compilation: {errors}}) => {
-						if (errors) {
-							acc.push(...errors);
-						}
-						return acc;
-					},
-					[]
-				);
-				const [firstError, ...remainingErrors] = errors;
-				if (firstError) {
-					remainingErrors.forEach(console.log.bind(console));
-					callback(firstError);
-				}
-				console.log(stats.toString({colors: true}));
+let haveShownHint = false;
+
+function createBundle(configName) {
+	const config = path.join(process.env.PWD, `${configName}.js`);
+	const showStats = !!process.env.STATS;
+	if (!showStats && !haveShownHint) {
+		console.log(
+			'\nNot showing webpack stats; run with `env STATS=1` to show\n'
+		);
+		haveShownHint = true;
+	}
+
+	return run(config, {
+		watch: false,
+		maxRetries: 1,
+		stats: showStats,
+		maxConcurrentWorkers: 4,
+	})
+		.then(results => {
+			if (results) {
+				results.forEach(result => {
+					let parsed;
+					try {
+						// Expect an object with "errors", "warnings" etc keys. Not
+						// currently using it for anything but leaving this here as
+						// documentation.
+						JSON.parse(result);
+					} catch (e) {
+						console.warn('Unable to parse worker result!');
+					}
+				});
 			}
-			return;
-		}
-		if (process.env.STATS) {
-			console.log(`\n${stats.toString({colors: true})}\n`);
-		} else {
-			console.log(
-				'\nNot showing webpack stats; run with `env STATS=1` to show\n'
-			);
-		}
-		callback();
-	});
+		})
+		.catch(error => {
+			if (error.message) {
+				// parallel-webpack seems to throw errors that are not Error
+				// instances, and they get logged by gulp as "Error: [object
+				// Object]", so wrap them here to make them useful.
+				throw new Error(error.message);
+			} else {
+				throw error;
+			}
+		});
 }
 
-gulp.task('build:webpack.prod', callback => {
-	createBundle('webpack.prod', callback);
+gulp.task('build:webpack.prod', () => {
+	return createBundle('webpack.prod');
 });
 
-gulp.task('build:webpack.dev', callback => {
-	createBundle('webpack.dev', callback);
+gulp.task('build:webpack.dev', () => {
+	return createBundle('webpack.dev');
 });
 
 gulp.task('build:clean', function() {

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -24,7 +24,7 @@ const base = {
 		rules: [
 			{
 				test: /\.(js|jsx)$/,
-				exclude: /(node_modules|lib)/,
+				include: toAbsolute('./src'),
 				loader: 'babel-loader',
 			},
 		],


### PR DESCRIPTION
# Step 1. Avoid accessing stats (doesn't help much)

According to https://webpack.js.org/guides/build-performance/ accessing fields on the stats object can be expensive. So, I changed things here to only access it if `stats.hasErrors()` is true, or if you pass in an environment variable:

```sh
env STATS=1 npm run build
```

By default, stats won't be shown. Instead, you'll see this in the build output:

```
[15:30:44] Starting 'build:webpack.dev'...

Not showing webpack stats; run with `env STATS=1` to show

[15:31:07] Finished 'build:webpack.dev' after 23 s

Not showing webpack stats; run with `env STATS=1` to show

[15:31:11] Finished 'build:webpack.prod' after 27 s
```

In testing this, I found a bug in the original code which explains why the stats output is not in color. I was calling `stats.stats.toString({colors: true})` but I needed to call `stats.toString({colors: true})`. It still "worked", but not in color.

The bottom-line? Sadly this doesn't trim anything much noticeable off the build time, but at least it fixes a bug and makes the output cleaner, so going with it.

# Step 2. Use a whitelist instead of a blacklist (doesn't help much)

# Step 3. Use parallel-webpack (helps a lot)

So we were already doing some amount of parallelization here (Gulp tasks in parallel, minification in parallel), but because a lot of this is I/O-bound we still have idle CPU resources sitting around which could be compiling our bundles for us.

parallel-webpack uses child worker processes, and we can actually saturate the CPU with it, at least on my laptop, dropping build times in half (from about 29s to 14s).

Here's evidence that we actually make use of the CPU now; previously we only used about 10%:

![cpu](https://user-images.githubusercontent.com/7074/51846859-b982f500-231a-11e9-8690-297fbf68552e.png)

Build output looks like this:

```
[16:22:21] Starting 'build:webpack.prod'...
[16:22:21] Starting 'build:webpack.dev'...

Not showing webpack stats; run with `env STATS=1` to show

[WEBPACK] Building 4 targets
[WEBPACK] Building 4 targets
[WEBPACK] Started building alloy-editor-no-ckeditor.js
[WEBPACK] Started building alloy-editor-core.js
[WEBPACK] Started building alloy-editor-all.js
[WEBPACK] Started building alloy-editor-no-react.js
[WEBPACK] Started building alloy-editor-all-min.js
[WEBPACK] Started building alloy-editor-no-ckeditor-min.js
[WEBPACK] Started building alloy-editor-core-min.js
[WEBPACK] Started building alloy-editor-no-react-min.js
[WEBPACK] Finished building alloy-editor-core.js within 9.037 seconds
[WEBPACK] Finished building alloy-editor-no-ckeditor.js within 9.588 seconds
[WEBPACK] Finished building alloy-editor-no-react.js within 9.632 seconds
[WEBPACK] Finished building alloy-editor-core-min.js within 9.475 seconds
[WEBPACK] Finished building alloy-editor-all.js within 9.984 seconds
[WEBPACK] Finished build after 10.836 seconds
[16:22:32] Finished 'build:webpack.dev' after 11 s
[WEBPACK] Finished building alloy-editor-no-ckeditor-min.js within 9.974 seconds
[WEBPACK] Finished building alloy-editor-no-react-min.js within 10.786 seconds
[WEBPACK] Finished building alloy-editor-all-min.js within 11.275 seconds
[WEBPACK] Finished build after 12.389 seconds
[16:22:34] Finished 'build:webpack.prod' after 13 s
[16:22:34] Finished 'build' after 13 s
[16:22:34] Finished 'default' after 13 s
```

As you can see, I kept the `env STATS=1` pattern from Step 1.

# Testing

- `npm run test` still passes
- `npm run start` and test in browser
- compare "dist" results

## "dist" before

```
   882296 28 Jan 16:49 dist/alloy-editor/alloy-editor-all-min.js
  5517088 28 Jan 16:49 dist/alloy-editor/alloy-editor-all.js
   278868 28 Jan 16:49 dist/alloy-editor/alloy-editor-core-min.js
  2069445 28 Jan 16:49 dist/alloy-editor/alloy-editor-core.js
   390120 28 Jan 16:49 dist/alloy-editor/alloy-editor-no-ckeditor-min.js
  4213528 28 Jan 16:49 dist/alloy-editor/alloy-editor-no-ckeditor.js
   771364 28 Jan 16:49 dist/alloy-editor/alloy-editor-no-react-min.js
  3376525 28 Jan 16:49 dist/alloy-editor/alloy-editor-no-react.js
```

## "dist" after

```
   882102 28 Jan 16:48 dist/alloy-editor/alloy-editor-all-min.js
  5517345 28 Jan 16:48 dist/alloy-editor/alloy-editor-all.js
   278868 28 Jan 16:48 dist/alloy-editor/alloy-editor-core-min.js
  2069445 28 Jan 16:48 dist/alloy-editor/alloy-editor-core.js
   390120 28 Jan 16:48 dist/alloy-editor/alloy-editor-no-ckeditor-min.js
  4213528 28 Jan 16:48 dist/alloy-editor/alloy-editor-no-ckeditor.js
   771170 28 Jan 16:48 dist/alloy-editor/alloy-editor-no-react-min.js
  3376786 28 Jan 16:48 dist/alloy-editor/alloy-editor-no-react.js
```

Closes: #1000 
