### PR TITLE
Fix lints in plugins/Resizer.es.js

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -62,6 +62,7 @@ module.exports = {
 		'babel/no-invalid-this': 'error',
 		'no-invalid-this': 'off',
 		'no-for-of-loops/no-for-of-loops': 'error',
+		'no-unused-vars': ['error', {'argsIgnorePattern': '^_'}],
 		'react/prop-types': 'warn',
 		'valid-jsdoc': 'warn',
 	},

--- a/src/plugins/Resizer.es.js
+++ b/src/plugins/Resizer.es.js
@@ -16,7 +16,7 @@ const POSITION_ELEMENT_FN = {
 			Math.round(box.height / 2) - 3 + top
 		);
 	},
-	tl(handle, left, top, box) {
+	tl(handle, left, top, _box) {
 		positionElement(handle, left - 3, top - 3);
 	},
 	tr(handle, left, top, box) {
@@ -68,7 +68,7 @@ class Resizer {
 
 		this.handles = {};
 
-		IMAGE_HANDLES.forEach((handleName, index) => {
+		IMAGE_HANDLES.forEach((handleName) => {
 			this.handles[handleName] = this.createHandle(handleName);
 		});
 


### PR DESCRIPTION
```
  19:24  error  'box' is defined but never used    no-unused-vars
  71:38  error  'index' is defined but never used  no-unused-vars
```

I just removed the `index` param from the `forEach` call because it is totally standard to omit it.

For the `box` param, I added configuration to mark params starting with `_` as unused, because all the neighboring methods take a `box` and use it, and I wanted this one to basically say, "I know all my neighbors take a `box` and I could use it too but I don't need to".

Related: #990
