### PR TITLE
Restore lint suppression in src/adapter/main.js

### DIFF
--- a/src/adapter/main.js
+++ b/src/adapter/main.js
@@ -198,9 +198,9 @@ const loadLanguageResources = function(callback) {
 					AlloyEditor.fire('languageResourcesLoaded');
 				}
 			},
-			/* eslint-disable no-invalid-this */
+			/* eslint-disable babel/no-invalid-this */
 			this // Always `AlloyEditor`.
-			/* eslint-enable no-invalid-this */
+			/* eslint-enable babel/no-invalid-this */
 		);
 	}
 };


### PR DESCRIPTION
Fixes:

```
  202:4  error  Unexpected 'this'  babel/no-invalid-this
```

Not sure which recent change caused the rule name to change here, but I
didn't notice the breakage in the flood of lints that we currently
still have (157 errors on current `HEAD`).

Related: https://github.com/liferay/alloy-editor/issues/990