### PR TITLE
Fix lint in src/components/base/widget-exclusive.js

### DIFF
--- a/src/components/base/widget-exclusive.js
+++ b/src/components/base/widget-exclusive.js
@@ -38,7 +38,7 @@ export default WrappedComponent =>
 		 */
 		componentWillReceiveProps(nextProps) {
 			if (Lang.isFunction(super.componentWillReceiveProps)) {
-				super.componentWillReceiveProps();
+				super.componentWillReceiveProps(nextProps);
 			}
 
 			// Receiving properties means that the component is being re-rendered.


### PR DESCRIPTION
```
  39:29  error  'nextProps' is defined but never used. Allowed unused args must match /^_/  no-unused-vars
```

We were calling `super()` without propagating the args. Note that the way we are using subclassing in our HOCs is not a very orthodox approach; "The React Way" is to favor composition over inheritance.

Usual test plan: `npm run dev && npm run test && npm run start`; check demo.