### PR TITLE
Remove stray ">" from button-embed-edit.jsx, fixing 1 lint

### DIFF
--- a/src/components/buttons/button-embed-edit.jsx
+++ b/src/components/buttons/button-embed-edit.jsx
@@ -144,7 +144,6 @@ class ButtonEmbedEdit extends React.Component {
 						title={AlloyEditor.Strings.clear}>
 						<ButtonIcon editor={editor} symbol="times-clear" />
 					</button>
-					>
 				</div>
 				<button
 					aria-label={AlloyEditor.Strings.confirm}


### PR DESCRIPTION
Linter was complaining:

```
src/components/buttons/button-embed-edit.jsx
  147:6  error  HTML entities must be escaped  react/no-unescaped-entities
```

Looks like a bug introduced in 88ec95553. I love it when the linter finds (non-stylistic) issues!

Related: https://github.com/liferay/alloy-editor/issues/990