### PR TITLE
Fix 6 no-useless-escape lints

### DIFF
--- a/src/core/link.js
+++ b/src/core/link.js
@@ -2,8 +2,8 @@
 	'use strict';
 
 	let REGEX_BOOKMARK_SCHEME = /^#.*/i;
-	let REGEX_EMAIL_SCHEME = /^[a-z0-9\u0430-\u044F\._-]+@/i;
-	let REGEX_URI_SCHEME = /^(?:[a-z][a-z0-9+\-.]*)\:|^\//i;
+	let REGEX_EMAIL_SCHEME = /^[a-z0-9\u0430-\u044F._-]+@/i;
+	let REGEX_URI_SCHEME = /^(?:[a-z][a-z0-9+\-.]*):|^\//i;
 
 	/**
 	 * Link class utility. Provides methods for create, delete and update links.

--- a/src/plugins/autolink.js
+++ b/src/plugins/autolink.js
@@ -78,7 +78,7 @@
 								) > -1
 							) {
 								event.data.dataValue = event.data.dataValue.replace(
-									/<u><font color=\"#(.*?)\">|<\/font><\/u>/g,
+									/<u><font color="#(.*?)">|<\/font><\/u>/g,
 									''
 								);
 							}

--- a/src/plugins/dragresize_ie.js
+++ b/src/plugins/dragresize_ie.js
@@ -26,7 +26,7 @@
 		width: 'ew-resize',
 	};
 
-	let regexPercent = /^\s*(\d+\%)\s*$/i;
+	let regexPercent = /^\s*(\d+%)\s*$/i;
 
 	let template = '<img alt="" src="" />';
 

--- a/src/plugins/dragresize_ie11.js
+++ b/src/plugins/dragresize_ie11.js
@@ -19,7 +19,7 @@
 
 	let alignmentsObj = {left: 0, center: 1, right: 2};
 
-	let regexPercent = /^\s*(\d+\%)\s*$/i;
+	let regexPercent = /^\s*(\d+%)\s*$/i;
 
 	CKEDITOR.plugins.add('ae_dragresize_ie11', {
 		requires: 'widget',


### PR DESCRIPTION
```
src/core/link.js
  5:49  error  Unnecessary escape character: \.  no-useless-escape
  6:49  error  Unnecessary escape character: \:  no-useless-escape

src/plugins/autolink.js
  81:26  error  Unnecessary escape character: \"  no-useless-escape
  81:34  error  Unnecessary escape character: \"  no-useless-escape

src/plugins/dragresize_ie.js
   29:30  error  Unnecessary escape character: \%  no-useless-escape

src/plugins/dragresize_ie11.js
    22:30  error  Unnecessary escape character: \%  no-useless-escape
```

Related: https://github.com/liferay/alloy-editor/issues/990