### PR TITLE
Fix 1 lint in button-link-autocomplete-list.jsx (no-unused-vars)

### DIFF
--- a/src/components/buttons/button-link-autocomplete-list.jsx
+++ b/src/components/buttons/button-link-autocomplete-list.jsx
@@ -172,8 +172,6 @@ class ButtonLinkAutocompleteList extends React.Component {
 	 * @protected
 	 */
 	_updateItems() {
-		const instance = this;
-
 		if (!this.props.term) {
 			return;
 		}


### PR DESCRIPTION
```
src/components/buttons/button-link-autocomplete-list.jsx
  175:9  error  'instance' is assigned a value but never used  no-unused-vars
```

The `instance` variable was originally added in bdbd6b03d, but it is not needed after 2dc8faf99.

Related: https://github.com/liferay/alloy-editor/issues/990