### PR TITLE
Fix 1 lint in button-paragraph-align.jsx (no-unused-vars)

### DIFF
--- a/src/components/buttons/button-paragraph-align.jsx
+++ b/src/components/buttons/button-paragraph-align.jsx
@@ -19,8 +19,6 @@ class ButtonParagraphAlign extends React.Component {
 	 * @return {Object} The content which should be rendered.
 	 */
 	render() {
-		const activeAlignment = AlloyEditor.Strings.alignLeft;
-
 		let buttonCommandsList;
 		let buttonCommandsListId;
 


### PR DESCRIPTION
Fixes:

```
src/components/buttons/button-paragraph-align.jsx
  22:9  error  'activeAlignment' is assigned a value but never used  no-unused-vars
```

Added in 1ab02307b380, I believe, and never used.

Related: https://github.com/liferay/alloy-editor/issues/990