### PR TITLE
Fix lint in button-separator.jsx (no-unused-vars)

### DIFF
--- a/src/components/buttons/button-separator.jsx
+++ b/src/components/buttons/button-separator.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 /**
  * The ButtonSeparator function renders a simple separator.
  */
-function ButtonSeparator(props) {
+function ButtonSeparator(_props) {
 	return <span className="ae-separator" />;
 }
 


### PR DESCRIPTION
```
src/components/buttons/button-separator.jsx
  6:26  error  'props' is defined but never used. Allowed unused args must match /^_/  no-unused-vars
```

Related: https://github.com/liferay/alloy-editor/issues/990