### PR TITLE
Fix 3 lints by removing UNSUPPORTED_*_API variables

### DIFF
--- a/src/components/uibridge/button.jsx
+++ b/src/components/uibridge/button.jsx
@@ -8,14 +8,6 @@ import React from 'react';
 		return;
 	}
 
-	// Some methods like `getState` and `setState` clash with React's own state methods. For them,
-	// unsupported means that we don't account for the different meaning in the passed or returned
-	// arguments.
-	let UNSUPPORTED_BUTTON_API = {
-		// getState: function() {},
-		// setState: function(state) {},
-	};
-
 	let BUTTON_DEFS = {};
 
 	/**

--- a/src/components/uibridge/menu-button.jsx
+++ b/src/components/uibridge/menu-button.jsx
@@ -9,14 +9,6 @@ import React from 'react';
 		return;
 	}
 
-	// Some methods like `getState` and `setState` clash with React's own state methods. For them,
-	// unsupported means that we don't account for the different meaning in the passed or returned
-	// arguments.
-	let UNSUPPORTED_MENUBUTTON_API = {
-		// getState: function() {},
-		// setState: function(state) {},
-	};
-
 	let MENUBUTTON_DEFS = {};
 
 	/**

--- a/src/components/uibridge/richcombo.jsx
+++ b/src/components/uibridge/richcombo.jsx
@@ -10,12 +10,6 @@ import React from 'react';
 		return;
 	}
 
-	// Some methods like `setState` clash with React's own state methods. For them, unsupported means
-	// that we don't account for the different meaning in the passed or returned arguments.
-	let UNSUPPORTED_RICHCOMBO_API = {
-		// setState: noop,
-	};
-
 	let RICH_COMBO_DEFS = {};
 
 	/**


### PR DESCRIPTION
When I last touched these files I kept these variables in there as a kind of documentation, but I don't think they provide much value to be honest. Removing them to pacify these lints:

```
src/components/uibridge/button.jsx
  14:6  error  'UNSUPPORTED_BUTTON_API' is assigned a value but never used  no-unused-vars

src/components/uibridge/menu-button.jsx
  15:6  error  'UNSUPPORTED_MENUBUTTON_API' is assigned a value but never used  no-unused-vars

src/components/uibridge/richcombo.jsx
  15:6  error  'UNSUPPORTED_RICHCOMBO_API' is assigned a value but never used  no-unused-vars
```

With this change, those three files are lint-clean.

Related: https://github.com/liferay/alloy-editor/issues/990