### PR TITLE
Fix 1 lint in uibridge/uibridge.js (prefer-rest-params)

### DIFF
--- a/src/components/uibridge/uibridge.js
+++ b/src/components/uibridge/uibridge.js
@@ -25,7 +25,7 @@
 			let originalUIAddFn = editor.ui.add;
 
 			editor.ui.add = function(name, type, definition) {
-				originalUIAddFn.apply(this, arguments);
+				originalUIAddFn.call(this, name, type, definition);
 
 				let typeHandler = this._.handlers[type];
 


### PR DESCRIPTION
```
src/components/uibridge/uibridge.js
  28:33  error  Use the rest parameters instead of 'arguments'  prefer-rest-params
```

I don't know why the initial implementation did this, perhaps to be future-proof in case the upstream "add" function ever takes more than 3 parameters (most likely just to avoid spelling out the parameters explicitly). To remain future proof I could have changed it to:

```
editor.ui.add = function(name, type, definition, ...rest) {
  originalUIAddFn.call(this, name, type, definition, ...rest);
```
However, it seems like overkill because I think it's pretty unlikely that the signature will change from what is currently documented:

  https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_ui.html

Related: https://github.com/liferay/alloy-editor/issues/990