### PR TITLE
Fix lint in uibridge/menu.jsx (guard-for-in)

### DIFF
--- a/src/components/uibridge/menu.jsx
+++ b/src/components/uibridge/menu.jsx
@@ -77,7 +77,9 @@
 			 */
 			editor.addMenuItems = function(definitions) {
 				for (let itemName in definitions) {
-					this.addMenuItem(itemName, definitions[itemName]);
+					if (definitions.hasOwnProperty(itemName)) {
+						this.addMenuItem(itemName, definitions[itemName]);
+					}
 				}
 			};
 


### PR DESCRIPTION
Wrote some old-school code to fix this:

```
src/components/uibridge/menu.jsx
  79:5  error  The body of a for-in should be wrapped in an if statement to filter unwanted properties from the prototype  guard-for-in
```

FWIW, the "clever" way to do this with `Object.entries().forEach()` ends up being less readable because of the need to use a non-arrow function and pass in `this`.

Usual tests: `npm run dev && npm run test && npm run start` and look at demo.

Related: https://github.com/liferay/alloy-editor/issues/990