### PR TITLE
Fix 9 remaining "guard-for-in" lints

### DIFF
--- a/src/plugins/dragresize.js
+++ b/src/plugins/dragresize.js
@@ -236,7 +236,9 @@
 			});
 
 			for (let n in handles) {
-				container.appendChild(handles[n]);
+				if (handles.hasOwnProperty(n)) {
+					container.appendChild(handles[n]);
+				}
 			}
 		},
 		createHandle: function(name) {
@@ -325,20 +327,31 @@
 			let handles = this.handles;
 
 			for (let handle in handles) {
-				POSITION_ELEMENT_FN[handle](handles[handle], left, top, box);
+				if (handles.hasOwnProperty(handle)) {
+					POSITION_ELEMENT_FN[handle](
+						handles[handle],
+						left,
+						top,
+						box
+					);
+				}
 			}
 		},
 		showHandles: function() {
 			let handles = this.handles;
 			this.updateHandles(this.box);
 			for (let n in handles) {
-				handles[n].style.display = 'block';
+				if (handles.hasOwnProperty(n)) {
+					handles[n].style.display = 'block';
+				}
 			}
 		},
 		hideHandles: function() {
 			let handles = this.handles;
 			for (let n in handles) {
-				handles[n].style.display = 'none';
+				if (handles.hasOwnProperty(n)) {
+					handles[n].style.display = 'none';
+				}
 			}
 		},
 		showPreview: function() {

--- a/src/plugins/dragresize_ie.js
+++ b/src/plugins/dragresize_ie.js
@@ -89,7 +89,7 @@
 		requires: 'widget',
 	});
 
-	// Wiget states (forms) depending on alignment and configuration.
+	// Widget states (forms) depending on alignment and configuration.
 	//
 	// Non-captioned widget (inline styles)
 	// 		┌──────┬───────────────────────────────┬─────────────────────────────┐

--- a/src/plugins/dragresize_ie.js
+++ b/src/plugins/dragresize_ie.js
@@ -328,7 +328,9 @@
 					this.data.hasCaption
 				) {
 					for (let c in this.data.classes) {
-						this.parts.image.removeClass(c);
+						if (this.data.classes.hasOwnProperty(c)) {
+							this.parts.image.removeClass(c);
+						}
 					}
 				}
 
@@ -552,10 +554,12 @@
 			// If there's an image, then cool, we got a widget.
 			// Now just remove dimension attributes expressed with %.
 			for (let d in dimensions) {
-				let dimension = image.attributes[d];
+				if (dimensions.hasOwnProperty(d)) {
+					let dimension = image.attributes[d];
 
-				if (dimension && dimension.match(regexPercent)) {
-					delete image.attributes[d];
+					if (dimension && dimension.match(regexPercent)) {
+						delete image.attributes[d];
+					}
 				}
 			}
 

--- a/src/plugins/dragresize_ie11.js
+++ b/src/plugins/dragresize_ie11.js
@@ -140,7 +140,11 @@
 
 			let integrate = alignCommandIntegrator(editor);
 
-			for (let value in align) integrate(value);
+			for (let value in align) {
+				if (align.hasOwnProperty(value)) {
+					integrate(value);
+				}
+			}
 		},
 	});
 
@@ -381,8 +385,11 @@
 					!this.oldData.hasCaption &&
 					this.data.hasCaption
 				) {
-					for (let c in this.data.classes)
-						this.parts.image.removeClass(c);
+					for (let c in this.data.classes) {
+						if (this.data.classes.hasOwnProperty(c)) {
+							this.parts.image.removeClass(c);
+						}
+					}
 				}
 
 				// Set dimensions of the image according to gathered data.
@@ -1036,7 +1043,9 @@
 			// If there's an image, then cool, we got a widget.
 			// Now just remove dimension attributes expressed with %.
 			for (let d in dimensions) {
-				let dimension = image.attributes[d];
+				if (dimensions.hasOwnProperty(d)) {
+					let dimension = image.attributes[d];
+				}
 
 				if (dimension && dimension.match(regexPercent))
 					delete image.attributes[d];

--- a/src/plugins/dragresize_ie11.js
+++ b/src/plugins/dragresize_ie11.js
@@ -148,7 +148,7 @@
 		},
 	});
 
-	// Wiget states (forms) depending on alignment and configuration.
+	// Widget states (forms) depending on alignment and configuration.
 	//
 	// Non-captioned widget (inline styles)
 	// 		┌──────┬───────────────────────────────┬─────────────────────────────┐


### PR DESCRIPTION
```
src/plugins/dragresize_ie.js
  330:6   error  The body of a for-in should be wrapped in an if statement to filter unwanted properties from the prototype  guard-for-in
  554:4   error  The body of a for-in should be wrapped in an if statement to filter unwanted properties from the prototype  guard-for-in

src/plugins/dragresize_ie11.js
    143:4   error  The body of a for-in should be wrapped in an if statement to filter unwanted properties from the prototype  guard-for-in
    384:6   error  The body of a for-in should be wrapped in an if statement to filter unwanted properties from the prototype  guard-for-in
  1038:4   error  The body of a for-in should be wrapped in an if statement to filter unwanted properties from the prototype  guard-for-in

src/plugins/dragresize.js
  238:4   error  The body of a for-in should be wrapped in an if statement to filter unwanted properties from the prototype  guard-for-in
  327:4   error  The body of a for-in should be wrapped in an if statement to filter unwanted properties from the prototype  guard-for-in
  334:4   error  The body of a for-in should be wrapped in an if statement to filter unwanted properties from the prototype  guard-for-in
  340:4   error  The body of a for-in should be wrapped in an if statement to filter unwanted properties from the prototype  guard-for-in
```

One other one is fixed in: https://github.com/liferay/alloy-editor/pull/1018

This is pretty damn paranoid - some of these are operating on object literals, so the only way the guard could prevent garbage from getting through would be if somebody had defined enumerable properties on `Object.prototype` - but it is better to be safe than sorry I guess. And seeing as at least a couple of these are in modules built for IE, I'm being super conservative and just applying the change suggested by the linter.

Related: https://github.com/liferay/alloy-editor/issues/990


