### PR TITLE
Fix 2 lints in core/debounce.js

### DIFF
--- a/src/core/debounce.js
+++ b/src/core/debounce.js
@@ -18,28 +18,18 @@
 	 */
 	CKEDITOR.tools.debounce =
 		CKEDITOR.tools.debounce ||
-		function(callback, timeout, context, args) {
+		function(callback, timeout, context, args = []) {
 			let debounceHandle;
 
-			let callFn = function() {
+			let callFn = function(...callArgs) {
+				/* eslint-disable babel/no-invalid-this */
 				let callContext = context || this;
+				/* eslint-enable babel/no-invalid-this */
 
 				clearTimeout(debounceHandle);
 
-				let result = [];
-
-				for (
-					let len = arguments.length, startIndex = 0;
-					startIndex < len;
-					++startIndex
-				) {
-					result.push(arguments[startIndex]);
-				}
-
-				let callArgs = result.concat(args || []);
-
 				debounceHandle = setTimeout(function() {
-					callback.apply(callContext, callArgs);
+					callback.apply(callContext, [...callArgs, ...args]);
 				}, timeout);
 			};
 


### PR DESCRIPTION
```
src/core/debounce.js
  25:34  error  Unexpected 'this'                               babel/no-invalid-this
  36:18  error  Use the rest parameters instead of 'arguments'  prefer-rest-params
```

The use of `this` in this function is expected (required, even), so suppress that lint.

The use of `arguments`, however, isn't required, so I replaced it.

This function isn't like other debounce functions I've seen: it allows you to pass a set of default arguments at creation-time, and in the absence of arguments being passed at call-time you get the defaults. That sounds reasonable enough (although a more conventional way to do this would be to use `bind()`).

The weirder thing, though, is what happens if you supply defaults at creation-time *and* also pass arguments at call-time: in this case, the wrapped function ends up getting called with the defaults *appended* to the call-time args. I can't imagine a scenario in which this behavior would be non-surprising or useful, and the test suite doesn't even exercise this behavior, so perhaps this is accidental design (it *does* verify that default args get used in the absence of calltime args).

In any case, I am leaving the behavior intact and just making the changes to satisfy the linter. If we want, we can separately remove the weird concatenating behavior.

Usual test plan: `npm run dev && npm run text && npm run start` and play with demo.

Related: https://github.com/liferay/alloy-editor/issues/990