### PR TITLE
Fix lint in oop/attribute.js (prefer-spread)

### DIFF
--- a/src/oop/attribute.js
+++ b/src/oop/attribute.js
@@ -109,7 +109,7 @@ Attribute.prototype = {
 			Lang.isString(stringOrFunction) &&
 			Lang.isFunction(this[stringOrFunction])
 		) {
-			result = this[stringOrFunction].apply(this, args);
+			result = this[stringOrFunction](...args);
 		} else if (Lang.isFunction(stringOrFunction)) {
 			result = stringOrFunction.apply(this, args);
 		}


### PR DESCRIPTION
```
src/oop/attribute.js
  112:13  error  Use the spread operator instead of '.apply()'  prefer-spread
```

Test plan: `npm run dev && npm run test && npm run start` then check out demo.

Related: https://github.com/liferay/alloy-editor/issues/990