### PR TITLE
Fix lint in src/oop/oop.js (no-throw-literal)

### DIFF
--- a/src/oop/oop.js
+++ b/src/oop/oop.js
@@ -15,7 +15,7 @@ import Lang from './lang';
  */
 const extend = function(receiver, supplier, protoProps, staticProps) {
 	if (!supplier || !receiver) {
-		throw 'extend failed, verify dependencies';
+		throw new Error('extend failed, verify dependencies');
 	}
 
 	let supplierProto = supplier.prototype;


### PR DESCRIPTION
This commit fixes the one lint in "oop/oop.js", which, BTW, is an awesome filename.

```
src/oop/oop.js
  18:3  error  Expected an object to be thrown  no-throw-literal
```

Test plan: `npm run dev && npm run test`

Related: https://github.com/liferay/alloy-editor/issues/990