### PR TITLE
Fix lint in core/selection-region.js (no-unused-vars)

### DIFF
--- a/src/core/selection-region.js
+++ b/src/core/selection-region.js
@@ -285,14 +285,12 @@
 			let bottom = 0;
 			let clientRects;
 			let left = Infinity;
-			let rangeCount;
 			let right = -Infinity;
 			let top = Infinity;
 
 			if (nativeSelection.createRange) {
 				clientRects = nativeSelection.createRange().getClientRects();
 			} else {
-				rangeCount = nativeSelection.rangeCount;
 				clientRects =
 					nativeSelection.rangeCount > 0
 						? nativeSelection.getRangeAt(0).getClientRects()


### PR DESCRIPTION
```
src/core/selection-region.js
  288:8  error  'rangeCount' is assigned a value but never used  no-unused-vars
```

The earliest trace of this that I can find is in e0ec699dceaa683b4 ("So far", authored in 2014), and it seems it was never used then or any time since.

Test plan: `npm run dev && npm run test && npm run start` and check demo.

Related: https://github.com/liferay/alloy-editor/issues/990