### PR TITLE
Fix bad variable name in button-link-browse.jsx (no-undef)

### DIFF
--- a/src/components/buttons/button-link-browse.jsx
+++ b/src/components/buttons/button-link-browse.jsx
@@ -72,7 +72,7 @@ class ButtonLinkBrowse extends React.Component {
 	 * @method _requestExclusive
 	 */
 	_requestExclusive() {
-		this.props.requestExclusive(LinkBrowse.key);
+		this.props.requestExclusive(ButtonLinkBrowse.key);
 	}
 }
 


### PR DESCRIPTION
```
src/components/buttons/button-link-browse.jsx
  75:31  error  'LinkBrowse' is not defined  no-undef
```

This one looks to be another legit bug. Yay for the linter!

Test plan: `npm run dev && npm run test && npm run start`, see demo.

Related: https://github.com/liferay/alloy-editor/issues/990