### PR TITLE
Fix bad identifier in button-embed-video-edit.jsx (no-undef)

### DIFF
--- a/src/components/buttons/button-embed-video-edit.jsx
+++ b/src/components/buttons/button-embed-video-edit.jsx
@@ -96,7 +96,7 @@ class ButtonEmbedVideoEdit extends React.Component {
 		return {
 			element,
 			initialEmbed: {
-				videoUrl,
+				videoURL,
 			},
 			videoURL,
 		};


### PR DESCRIPTION
```
src/components/buttons/button-embed-video-edit.jsx
   99:5   error  'videoUrl' is not defined                              no-undef
```

Also looks like a legit bug.

Test plan: `npm run dev && npm run test && npm run start` and hit demo.

Related: https://github.com/liferay/alloy-editor/issues/990