### PR TITLE
Fix no-undef lint in src/plugins/dragresize_ie11.js

### DIFF
--- a/src/plugins/dragresize_ie11.js
+++ b/src/plugins/dragresize_ie11.js
@@ -1415,9 +1415,6 @@
 				moveDiffX = nativeEvt.screenX - startX;
 				moveDiffY = startY - nativeEvt.screenY;
 
-				// This is the aspect ratio of the move difference.
-				moveRatio = Math.abs(moveDiffX / moveDiffY);
-
 				// Resize with NE, SE drag handles
 				if (factorX == 1) {
 					if (moveDiffX <= 0) {


### PR DESCRIPTION
```
src/plugins/dragresize_ie.js
  1410:5   error  'moveRatio' is not defined           no-undef
```

This is another "no-undef" "bug" but not like the ones in #1025 and #1026. Here we have something that is missing a `let` keyword, but it turns out variable is unused anyway, so I just removed it.

Last use was removed in d6145d2c4ad866fbe, I believe.

In any case, no real harm here at runtime, because I believe it just ended up assigning to `window.moveRatio`.

Test plan: `npm run dev && npm run test && npm run start`

Related: https://github.com/liferay/alloy-editor/issues/990