### PR TITLE
Turn "babel/no-invalid-this" into a warning in plug-in files

### DIFF
--- a/src/core/plugins.js
+++ b/src/core/plugins.js
@@ -23,6 +23,7 @@
 						return function(editor) {
 							editor.__processingPlugin__ = payload;
 
+							// eslint-disable-next-line babel/no-invalid-this
 							originalPluginMethod.call(this, editor);
 
 							editor.__processingPlugin__ = null;
@@ -74,6 +75,7 @@
 			// Wrap original load function so we can transform the plugin input parameter
 			// before passing it down to the original callback
 			return function(names, callback, scope) {
+				// eslint-disable-next-line babel/no-invalid-this
 				pluginsLoad.call(this, names, function(plugins) {
 					if (callback) {
 						Object.keys(plugins).forEach(function(pluginName) {

--- a/src/plugins/.eslintrc.js
+++ b/src/plugins/.eslintrc.js
@@ -1,0 +1,5 @@
+module.exports = {
+	rules: {
+		'babel/no-invalid-this': 'warn',
+	},
+};


### PR DESCRIPTION
This drops us from:

    ✖ 112 problems (112 errors, 0 warnings)

to:

    ✖ 80 problems (80 errors, 0 warnings)

on the current `HEAD`.

We're doing this because the plug-in system relies on this pattern pervasively (functions being invoked with a `this` value set from the outside). But we'd like to consider moving away from this pattern in the future, so we turn the errors into warning rather than suppressing them entirely.

I'm doing this with a cascading configuration file at "src/plugins/.eslintrc.js" that takes effect for the whole directory, plus a couple of disabling comments in one plug-in related place outside it. There are still a small number of "babel/no-invalid-this" violations outside the files that are affected by this commit, but they need to be looked at separately to determine what the appropriate fix is (although I fear it will probably be the same).

Related: https://github.com/liferay/alloy-editor/issues/990