### PR TITLE
Deal with 12 remaining "no-used-vars" lints related to function args

### DIFF
--- a/src/components/main.jsx
+++ b/src/components/main.jsx
@@ -47,7 +47,7 @@ class UI extends React.Component {
 		};
 
 		this._keyDownListener = CKEDITOR.tools.debounce(
-			event => {
+			_event => {
 				this._setUIHidden(document.activeElement);
 			},
 			this.props.eventsDelay,
@@ -225,7 +225,7 @@ class UI extends React.Component {
 	 * @method _onActionPerformed
 	 * @param {SynteticEvent} event The provided event
 	 */
-	_onActionPerformed(event) {
+	_onActionPerformed(_event) {
 		const editor = this.props.editor.get('nativeEditor');
 
 		editor.focus();

--- a/src/components/toolbars/toolbar-add.jsx
+++ b/src/components/toolbars/toolbar-add.jsx
@@ -51,7 +51,7 @@ class ToolbarAdd extends React.Component {
 	 * @param {Object} prevProps The previous state of the component's properties.
 	 * @param {Object} prevState Component's previous state.
 	 */
-	componentDidUpdate(prevProps, prevState) {
+	componentDidUpdate(_prevProps, _prevState) {
 		this._updatePosition();
 
 		// In case of exclusive rendering, focus the first descendant (button)

--- a/src/components/toolbars/toolbar-styles.jsx
+++ b/src/components/toolbars/toolbar-styles.jsx
@@ -48,7 +48,7 @@ class ToolbarStyles extends React.Component {
 	 * @param {Object} prevProps The previous state of the component's properties.
 	 * @param {Object} prevState Component's previous state.
 	 */
-	componentDidUpdate(prevProps, prevState) {
+	componentDidUpdate(_prevProps, _prevState) {
 		this._updatePosition();
 	}
 

--- a/src/core/table.js
+++ b/src/core/table.js
@@ -381,7 +381,7 @@
 
 		headingCommands.forEach(function(heading) {
 			event.editor.addCommand('tableHeading' + heading, {
-				exec: function(editor) {
+				exec: function(_editor) {
 					tableUtils.setHeading(null, heading);
 				},
 			});

--- a/src/plugins/dragresize.js
+++ b/src/plugins/dragresize.js
@@ -41,7 +41,7 @@
 				Math.round(box.height / 2) - 3 + top
 			);
 		},
-		tl: function(handle, left, top, box) {
+		tl: function(handle, left, top, _box) {
 			positionElement(handle, left - 3, top - 3);
 		},
 		tm: function(handle, left, top, box) {
@@ -92,7 +92,7 @@
 				return;
 			}
 
-			editor.once('contentDom', function(evt) {
+			editor.once('contentDom', function(_evt) {
 				init(editor);
 			});
 		},
@@ -228,7 +228,6 @@
 
 			IMAGE_HANDLES[this.cfg.imageScaleResize].forEach(function(
 				handleName,
-				index
 			) {
 				handles[handleName] = instance.handles[
 					handleName

--- a/src/plugins/dragresize_ie11.js
+++ b/src/plugins/dragresize_ie11.js
@@ -101,7 +101,7 @@
 
 			// Add a listener to handle selection change events and properly detect editor
 			// interactions on the widgets without messing with widget native selection
-			editor.on('selectionChange', function(event) {
+			editor.on('selectionChange', function(_event) {
 				let selection = editor.getSelection();
 
 				if (selection) {

--- a/src/plugins/embedurl.js
+++ b/src/plugins/embedurl.js
@@ -462,7 +462,7 @@ if (!CKEDITOR.plugins.get('embedurl')) {
 				false
 			);
 
-			editor.on('selectionChange', event => {
+			editor.on('selectionChange', _event => {
 				const selection = editor.getSelection();
 
 				if (selection) {


### PR DESCRIPTION
Fixes:

```
src/components/main.jsx
   50:4   error  'event' is defined but never used. Allowed unused args must match /^_/  no-unused-vars
  228:21  error  'event' is defined but never used. Allowed unused args must match /^_/  no-unused-vars

src/components/toolbars/toolbar-add.jsx
   54:21  error  'prevProps' is defined but never used. Allowed unused args must match /^_/  no-unused-vars
   54:32  error  'prevState' is defined but never used. Allowed unused args must match /^_/  no-unused-vars

src/components/toolbars/toolbar-styles.jsx
   51:21  error  'prevProps' is defined but never used. Allowed unused args must match /^_/  no-unused-vars
   51:32  error  'prevState' is defined but never used. Allowed unused args must match /^_/  no-unused-vars

src/core/table.js
  384:20  error  'editor' is defined but never used. Allowed unused args must match /^_/  no-unused-vars

src/plugins/dragresize_ie11.js
   104:42  error  'event' is defined but never used. Allowed unused args must match /^_/  no-unused-vars

src/plugins/dragresize.js
   44:35  error  'box' is defined but never used. Allowed unused args must match /^_/    no-unused-vars
   95:39  error  'evt' is defined but never used. Allowed unused args must match /^_/    no-unused-vars
  231:5   error  'index' is defined but never used. Allowed unused args must match /^_/  no-unused-vars

src/plugins/embedurl.js
  465:33  error  'event' is defined but never used. Allowed unused args must match /^_/  no-unused-vars
```

For all of these, I indicated that the parameters are intentionally unused by prefixing theme with an underscore. The one exception was the `forEach()` call in dragresize.js, which I just removed, because it is customary to omit the index parameter in that case.

Note that there is a smell here that I am not dealing with: those `componentDidUpdate()` calls where we are ignoring both the props and the state are probably a sign that we are doing things in too much of an imperative way. But refactoring is not the goal here (lint fixing is) so I am moving on for now.

Test plan: `npm run dev && npm run test && npm run start` and check the
demo.

Related: https://github.com/liferay/alloy-editor/issues/990