### PR TITLE
Fix no-unused-vars lint in button-link-edit-browse.jsx

### DIFF
--- a/src/components/buttons/button-link-edit-browse.jsx
+++ b/src/components/buttons/button-link-edit-browse.jsx
@@ -64,8 +64,6 @@ class ButtonLinkEditBrowse extends React.Component {
 	 * @method _browseClick
 	 */
 	_browseClick = () => {
-		const instance = this;
-
 		const editor = this.props.editor.get('nativeEditor');
 
 		const url = editor.config.documentBrowseLinkUrl;


### PR DESCRIPTION
```
src/components/buttons/button-link-edit-browse.jsx
  67:9   error  'instance' is assigned a value but never used          no-unused-vars
```

There are other lint issues in this file, so this just fixes the safe one. At least a couple of the others relate to this method because of [the "TODO" noted down the bottom](https://github.com/liferay/alloy-editor/pull/1031/files#diff-4cb6cbd255309214de8f4fbfefa41957R73) (the method does nothing).

In any case, the move to arrow functions assigned to instance properties (in 73f21f1647c779a645f67e) makes the `instance` variable unnecessary, so we remove it and kill off one more lint.

Related: https://github.com/liferay/alloy-editor/issues/990