### PR TITLE
Fix 8 more lints, including last of the "no-unused-vars"

### DIFF
--- a/src/components/buttons/button-embed-video-edit.jsx
+++ b/src/components/buttons/button-embed-video-edit.jsx
@@ -117,8 +117,6 @@ class ButtonEmbedVideoEdit extends React.Component {
 			opacity: this.state.videoURL ? 1 : 0,
 		};
 
-		const icon = this.getIcon();
-
 		return (
 			<div className="ae-container-embed-video-edit">
 				<div className="ae-container-input xxl">

--- a/src/plugins/dragresize_ie11.js
+++ b/src/plugins/dragresize_ie11.js
@@ -92,7 +92,6 @@
 		init: function(editor) {
 			// Adapts configuration from original image plugin. Should be removed
 			// when we'll rename ae_dragresize_ie11 to image.
-			let config = editor.config;
 
 			let image = widgetDef(editor);
 
@@ -1045,10 +1044,9 @@
 			for (let d in dimensions) {
 				if (dimensions.hasOwnProperty(d)) {
 					let dimension = image.attributes[d];
+					if (dimension && dimension.match(regexPercent))
+						delete image.attributes[d];
 				}
-
-				if (dimension && dimension.match(regexPercent))
-					delete image.attributes[d];
 			}
 
 			return el;

--- a/src/plugins/tableresize.js
+++ b/src/plugins/tableresize.js
@@ -401,13 +401,13 @@
 			resizer.setStyle('left', pxUnit(resizerNewPosition));
 		});
 
-		let destroy = (this.destroy = function() {
+		this.destroy = function() {
 			detach();
 
 			document.getBody().setStyle('cursor', 'auto');
 
 			resizer.remove();
-		});
+		};
 
 		var isResizing = (this.isResizing = function() {
 			return resizing;

--- a/src/plugins/tabletools.js
+++ b/src/plugins/tabletools.js
@@ -800,8 +800,6 @@
 
 	CKEDITOR.plugins.add('ae_tabletools', {
 		init: function(editor) {
-			let lang = editor.lang.table;
-
 			function createDef(def) {
 				return CKEDITOR.tools.extend(def || {}, {
 					contextSensitive: 1,

--- a/test/plugins/test/autolink.js
+++ b/test/plugins/test/autolink.js
@@ -14,7 +14,6 @@
 	var KEY_SPACE = 32;
 
 	describe('AutoLink', function() {
-
 		before(function(done) {
 			Utils.createCKEditor.call(this, done, {
 				extraPlugins: 'ae_autolink',

--- a/test/ui/test/button-bridge.jsx
+++ b/test/ui/test/button-bridge.jsx
@@ -6,7 +6,6 @@
 	var Simulate = TestUtils.Simulate;
 
 	describe('ButtonBridge', function() {
-
 		before(function(done) {
 			Utils.createAlloyEditor.call(this, done, {
 				extraPlugins:


### PR DESCRIPTION
Fixes:

```
src/components/buttons/button-embed-video-edit.jsx
  120:9   error  'icon' is assigned a value but never used              no-unused-vars

src/plugins/dragresize_ie11.js
    95:8   error  'config' is assigned a value but never used                                                                 no-unused-vars
  1045:4   error  The body of a for-in should be wrapped in an if statement to filter unwanted properties from the prototype  guard-for-in
  1047:10  error  'dimension' is assigned a value but never used                                                              no-unused-vars
  1050:9   error  'dimension' is not defined                                                                                  no-undef
  1050:22  error  'dimension' is not defined                                                                                  no-undef

src/plugins/tableresize.js
  404:7   error  'destroy' is assigned a value but never used  no-unused-vars

src/plugins/tabletools.js
  803:8  error  'lang' is assigned a value but never used  no-unused-vars
```

The "dragresize_ie11.js" ones are a bit embarrassing, because I actually caused 4 of those in (f9f3850163e6c1fa2) ie. #1019. This is why we need QA I guess, because somehow our test suite isn't enough to catch mistakes like this.

Test plan: `npm run dev && npm run test && npm run start` and check
demo.

Related: https://github.com/liferay/alloy-editor/issues/990