### PR TITLE
Eliminate React warnings when editing image alt attribute

### DIFF
--- a/src/components/buttons/button-accessibility-image-alt.jsx
+++ b/src/components/buttons/button-accessibility-image-alt.jsx
@@ -35,9 +35,11 @@ class ButtonAccessibilityImageAlt extends React.Component {
 			.getSelection()
 			.getSelectedElement();
 
+		const imageAlt = (element && element.getAttribute('alt')) || '';
+
 		this.state = {
 			element,
-			imageAlt: element ? element.getAttribute('alt') : '',
+			imageAlt,
 		};
 	}
 


### PR DESCRIPTION
We had this console spew:

```
react-dom.development.js:506 Warning: `value` prop on `input` should
not be null. Consider using an empty string to clear the component or
`undefined` for uncontrolled components.
```

With this change, we no longer pass a null-ish value as and the console is clean.

Test plan: `npm run dev && npm run test && npm run start`; then in demo, click on image, click on alt button, see console is clean and setting an alt still works.

Closes: https://github.com/liferay/alloy-editor/issues/1030
Internal: https://issues.liferay.com/browse/IFI-435