### PR TITLE
Fix last lint in src/core/tools.js (prefer-rest-params)

### DIFF
--- a/src/core/tools.js
+++ b/src/core/tools.js
@@ -85,11 +85,11 @@
 	 */
 	CKEDITOR.tools.merge =
 		CKEDITOR.tools.merge ||
-		function() {
+		function(...args) {
 			let result = {};
 
-			for (let i = 0; i < arguments.length; ++i) {
-				let obj = arguments[i];
+			for (let i = 0; i < args.length; ++i) {
+				let obj = args[i];
 
 				for (let key in obj) {
 					if (Object.prototype.hasOwnProperty.call(obj, key)) {


### PR DESCRIPTION
```
src/core/tools.js
  92:15  error  Use the rest parameters instead of 'arguments'  prefer-rest-params
```

Test plan: `npm run dev && npm run test && npm run start`

Related: https://github.com/liferay/alloy-editor/issues/990