### PR TITLE
Fix last lint in src/plugins/dragresize.js (prefer-rest-params)

### DIFF
--- a/src/plugins/dragresize.js
+++ b/src/plugins/dragresize.js
@@ -537,8 +537,8 @@
 		if (fn.bind) {
 			return fn.bind(ctx);
 		}
-		return function() {
-			fn.apply(ctx, arguments);
+		return function(...args) {
+			fn.apply(ctx, args);
 		};
 	}
 


### PR DESCRIPTION
```
src/plugins/dragresize.js
  541:18  error  Use the rest parameters instead of 'arguments'  prefer-rest-params
```

Test plan: `npm run dev && npm run build && npm run start`, check demo.

Related: https://github.com/liferay/alloy-editor/issues/990