### PR TITLE
Add support for running lints on changed files only

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "fix": "eslint --fix 'src/**/*.{js,jsx}'",
     "format": "prettier --write -- '*.js' '{api,scripts,src,test}/**/*.{js,jsx}'",
     "lint": "eslint 'src/**/*.{js,jsx}'",
+    "lint:changed": "git ls-files -mz -- 'src/**/*.js' 'src/**/*.jsx' | xargs -0 eslint",
     "lint:quiet": "eslint --quiet 'src/**/*.{js,jsx}'",
     "prettier": "prettier --write -- '*.js' '{api,scripts,src,test}/**/*.{js,jsx}'",
     "prepublishOnly": "npm run checkFormat && npm run test",


### PR DESCRIPTION
    npm run lint:changed

And if you want it to be errors only, not warnings:

    npm run lint:changed -- --quiet

And if you want it to run on added-but-not-yet-staged files, record the intent to add in the index first:

    git add -N src/the-new-file.js