### PR TITLE
Fix last lint in dragresize_ie.js (no-unused-vars)

### DIFF
--- a/src/plugins/dragresize_ie.js
+++ b/src/plugins/dragresize_ie.js
@@ -859,7 +859,6 @@
 
 			let moveDiffX;
 			let moveDiffY;
-			let moveRatio;
 
 			// Save the undo snapshot first: before resizing.
 			editor.fire('saveSnapshot');
@@ -921,9 +920,6 @@
 				// This is how far the mouse is from the point the button was pressed.
 				moveDiffX = nativeEvt.screenX - startX;
 				moveDiffY = startY - nativeEvt.screenY;
-
-				// This is the aspect ratio of the move difference.
-				moveRatio = Math.abs(moveDiffX / moveDiffY);
 
 				if (
 					imageScaleResize === 'width' ||


### PR DESCRIPTION
```
src/plugins/dragresize_ie.js
  862:8  error  'moveRatio' is assigned a value but never used  no-unused-vars
```

This is the exact same issue as fixed in "dragresize_ie11.js" in
39d4d18b1ff2e4d. With hundreds of lint errors in the report, I didn't
see this file had the same thing.

Fix is same: variable is unused, so removed it.

Test plan: `npm run dev && npm run test`

Related: https://github.com/liferay/alloy-editor/issues/990