### PR TITLE
Don't use process.env.PWD in build

### DIFF
--- a/scripts/build/gulp/tasks/build.js
+++ b/scripts/build/gulp/tasks/build.js
@@ -26,7 +26,7 @@ function ifRelease(task) {
 let haveShownHint = false;
 
 function createBundle(configName) {
-	const config = path.join(process.env.PWD, `${configName}.js`);
+	const config = path.join(__dirname, '../../../..',  `${configName}.js`);
 	const showStats = !!process.env.STATS;
 	if (!showStats && !haveShownHint) {
 		console.log(


### PR DESCRIPTION
Building on Windows is not officially supported, but we can easily remove one issue on that platform by removing our use of the `PWD` environment variable, which won't be set on Windows.

I can't remember why I did it this way, but I am guessing it was to avoid the ugliness of the "../../../..".

Test plan: add a `console.log` statement to sanity check the constructed path and do `npm run build`.