### PR TITLE
Exploratory refactor of HOCs (do not merge)

### DIFF
--- a/src/components/base/button-keystroke.js
+++ b/src/components/base/button-keystroke.js
@@ -16,10 +16,6 @@ export default WrappedComponent =>
 		 * @method componentWillMount
 		 */
 		componentWillMount() {
-			if (Lang.isFunction(super.componentWillMount)) {
-				super.componentWillMount();
-			}
-
 			let nativeEditor = this.props.editor.get('nativeEditor');
 			let keystroke = this.props.keystroke;
 
@@ -58,10 +54,6 @@ export default WrappedComponent =>
 		 * @method componentWillUnmount
 		 */
 		componentWillUnmount() {
-			if (Lang.isFunction(super.componentWillUnmount)) {
-				super.componentWillUnmount();
-			}
-
 			this.props.editor
 				.get('nativeEditor')
 				.setKeystroke(


### PR DESCRIPTION
As explained in #1037, there are some issues with the way we are using HOCs:

- We have multiple layers of wrapping and drill down through them using `ReactDOM.findDOMNode()`, which is deprecated.
- Forwarding refs through in order to avoid `findDOMNode()` is difficult because of the layers of indirection and the unorthodox wrapping model (which uses wrapping instead of composition).

As an exploratory refactoring, I am going to see if I can simplify some of this.

Starting with the first commit: "Remove super() calls from ButtonKeystroke HOC"

I am looking at teasing apart some of these HOCs. Starting with this one because it is only used in a few places. This one calls "super" but looking at the 6 callsites, none of them implement the overridden methods. So I am going to remove the `super()` calls to make it clear that there is no interaction with the superclass and these can probably be replaced with more conventional classes that don't require inheritance.

For reference, the 6 callsites are:

- src/components/buttons/button-embed.jsx
- src/components/buttons/button-link-browse.jsx
- src/components/buttons/button-link.jsx
- src/components/buttons/button-italic.jsx
- src/components/buttons/button-bold.jsx
- src/components/buttons/button-underline.jsx

And `ButtonKeystroke` is not exported anywhere as far as I can tell, so we can be confident that there are no unknown callers.

Related: https://github.com/liferay/alloy-editor/issues/1037