### PR TITLE
Add "npm run format:changed"

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "dev": "gulp --gulpfile scripts/build/gulp/gulpfile.js",
     "fix": "eslint --fix 'src/**/*.{js,jsx}'",
     "format": "prettier --write -- '*.js' '{api,scripts,src,test}/**/*.{js,jsx}'",
+    "format:changed": "git ls-files -mz *.js -- 'api/*.js' 'scripts/*.js' 'src/*.js' 'src/*.jsx' 'test/*.js' 'test/*.jsx' | xargs -0 prettier --write --",
     "lint": "eslint 'src/**/*.{js,jsx}'",
     "lint:changed": "git ls-files -mz -- 'src/**/*.js' 'src/**/*.jsx' | xargs -0 eslint",
     "lint:quiet": "eslint --quiet 'src/**/*.{js,jsx}'",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "format": "prettier --write -- '*.js' '{api,scripts,src,test}/**/*.{js,jsx}'",
     "format:changed": "git ls-files -mz *.js -- 'api/*.js' 'scripts/*.js' 'src/*.js' 'src/*.jsx' 'test/*.js' 'test/*.jsx' | xargs -0 prettier --write --",
     "lint": "eslint 'src/**/*.{js,jsx}'",
-    "lint:changed": "git ls-files -mz -- 'src/**/*.js' 'src/**/*.jsx' | xargs -0 eslint",
+    "lint:changed": "git ls-files -mz 'src/*.js' 'src/*.jsx' | xargs -0 eslint",
     "lint:quiet": "eslint --quiet 'src/**/*.{js,jsx}'",
     "prettier": "prettier --write -- '*.js' '{api,scripts,src,test}/**/*.{js,jsx}'",
     "prepublishOnly": "npm run checkFormat && npm run test",


### PR DESCRIPTION
Same idea as #1041, this one allows you to run Prettier only on files you've touched.

In testing this I learned some things about Git globs.

- `'src/*.js'` is actually the same as `'src/**/*.js'`; it matches at   any level.
- There is a "magic" globbing identifier that you can use to use actual "**" syntax (eg. `'(:glob)src/**/*.ls'`) but if you use it with multiple pathspecs, only the first one will be used.
- `'*.js'` will match anywhere in the hierarchy.

So, to make this work only for .js files in the root, I can't use  a pathspec of "*.js", because it will match files I don't want to match (like files in "lib/", for example). Instead, I am using shell parameter expansion to handle the top-level files, and pathspecs for the rest. No `(:glob)` magic because I need multiple pathspecs.

In the next commit I'll update the patterns in the "lint:changed" script as well to incorporate what I've learned here.