### PR TITLE
Fixes #1057 Keep styles in the image for IE

### DIFF
--- a/src/plugins/dragresize_ie.js
+++ b/src/plugins/dragresize_ie.js
@@ -901,8 +901,10 @@
                 resizer.removeClass('cke_image_resizing');
 
                 if (updateData) {
-                    widget.element.$.style.width = newWidth + 'px';
-                    widget.element.$.style.height = newHeight + 'px';
+                    widget.setData({
+                        height: newHeight,
+                        width: newWidth
+                    });
 
                     // Save another undo snapshot: after resizing.
                     editor.fire('saveSnapshot');

--- a/src/plugins/dragresize_ie11.js
+++ b/src/plugins/dragresize_ie11.js
@@ -56,7 +56,7 @@
             '}' +
             // Top-left corner style of the resizer.
             '.cke_image_resizer.cke_image_resizer_nw{' +
-                'cursor:nw-resize;' +    
+                'cursor:nw-resize;' +
                 'left:-5px;' +
                 'right:auto;' +
                 'top:-5px;' +
@@ -1335,8 +1335,10 @@
                 resizer.removeClass( 'cke_image_resizing' );
 
                 if ( updateData ) {
-                    widget.element.$.style.width = newWidth + 'px';
-                    widget.element.$.style.height = newHeight + 'px';
+                    widget.setData({
+                        height: newHeight,
+                        width: newWidth
+                    });
 
                     // Save another undo snapshot: after resizing.
                     editor.fire( 'saveSnapshot' );


### PR DESCRIPTION
## Issue
#1057 
In IE11, resizing an image and aligning will result in the image going back to its default size. 

## Solution
Update the size of the image and add the style to the image. This will keep the size of the image when aligning. 

Let me know if there are any questions or comments about this.
Thank you.

## Test
IE11
