### PR TITLE
Fixes #1065 - Resolve console warnings about imageTPL prop

### DIFF
--- a/src/components/buttons/button-item-selector-image.jsx
+++ b/src/components/buttons/button-item-selector-image.jsx
@@ -16,7 +16,6 @@ class ButtonItemSelectorImage extends React.Component {
 
 	static propTypes = {
 		editor: PropTypes.object.isRequired,
-		imageTPL: PropTypes.string.isRequired,
 	};
 
 	render() {

--- a/src/components/buttons/button-item-selector-video.jsx
+++ b/src/components/buttons/button-item-selector-video.jsx
@@ -16,7 +16,6 @@ class ButtonItemSelectorVideo extends React.Component {
 
 	static propTypes = {
 		editor: PropTypes.object.isRequired,
-		imageTPL: PropTypes.string.isRequired,
 	};
 
 	render() {


### PR DESCRIPTION
Since 8a0aaf7, this is leading to this in the console on clicking the left-hand-side "+" button:

```
checkPropTypes.js:19 Warning: Failed prop type: The prop `imageTPL` is marked as required in `ButtonCommand`, but its value is `undefined`.
    in ButtonCommand (created by WidgetArrowBox)
    in WidgetArrowBox (created by WidgetExclusive)
    in div (created by WidgetExclusive)
    in WidgetExclusive;
```

The prop is not used in the component, so it doesn't seem to be required after all. I also looked in the Liferay Portal and see no other mentions of this property name, so I think it is safe to remove.

Test plan: `npm run dev && npm run test && npm run start` and hit the demo.

Closes: #1065