### PR TITLE
Don't ship font-related CSS any more

### DIFF
--- a/scripts/build/gulp/tasks/css.js
+++ b/scripts/build/gulp/tasks/css.js
@@ -38,23 +38,12 @@ function getJoinTasks() {
 
 	return skins.map(function(skin) {
 		const skinFileName = 'alloy-editor-' + skin + '.css';
-		const skinFontFileName = 'alloyeditor-font-' + skin + '.css';
 
 		const fn = function() {
 			return gulp
-				.src(
-					[
-						path.join(
-							Constants.rootDir,
-							'src/assets/sass/skin',
-							skin,
-							'.font-cache',
-							skinFontFileName
-						),
-						path.join(cssDir, 'skin', skin, 'main.css'),
-					],
-					{allowEmpty: true}
-				)
+				.src([path.join(cssDir, 'skin', skin, 'main.css')], {
+					allowEmpty: true,
+				})
 				.pipe(concat(skinFileName))
 				.pipe(
 					gulp.dest(path.join(Constants.editorDistFolder, 'assets'))


### PR DESCRIPTION
We moved to SVG icons from font-based ones in d1b061729f9ca4f9476059c, but we have continued to include the font-related CSS in our build, which leads to console spam like this when you do certain things:

```
GET http://localhost:9000/alloy-editor/assets/fonts/alloyeditor-ocean.woff net::ERR_ABORTED 404 (Not Found)
GET http://localhost:9000/alloy-editor/assets/fonts/alloyeditor-ocean.ttf net::ERR_ABORTED 404 (Not Found)
```

(For example, if you hit "+" in the LHS margin and then hit the "+" icon in the pop-up toolbar.)

We should be able to omit this safely. There are still some straggling references to `ae-icon-*` classes in the codebase (apart from the `ae-icon-svg-*` ones, which are legit), but removing these will be the subject of another pull.

Tested plan: `npm run build && npm run test && npm run start`

Fixes: #1068