### PR TITLE
Fixes #1052 - Use fake timers and clean up debounce tests

### DIFF
--- a/src/core/debounce.js
+++ b/src/core/debounce.js
@@ -1,42 +1,38 @@
-(function() {
-	'use strict';
+/**
+ * Debounce util function. If a function execution is expensive, it might be debounced. This means
+ * that it will be executed after some amount of time after its last call. For example, if we attach a
+ * a function on scroll event, it might be called hundreds times per second. In this case it may be
+ * debounced with, let's say 100ms. The real execution of this function will happen 100ms after last
+ * scroll event.
+ *
+ * @memberof CKEDITOR.tools
+ * @method debounce
+ * @param {Array} args An array of arguments which the callback will receive.
+ * @param {Function} callback The callback which has to be called after given timeout.
+ * @param {Number} timeout Timeout in milliseconds after which the callback will be called.
+ * @param {Object} context The context in which the callback will be called. This argument is optional.
+ * @static
+ */
+CKEDITOR.tools.debounce =
+	CKEDITOR.tools.debounce ||
+	function(callback, timeout, context, args = []) {
+		let debounceHandle;
 
-	/**
-	 * Debounce util function. If a function execution is expensive, it might be debounced. This means
-	 * that it will be executed after some amount of time after its last call. For example, if we attach a
-	 * a function on scroll event, it might be called hundreds times per second. In this case it may be
-	 * debounced with, let's say 100ms. The real execution of this function will happen 100ms after last
-	 * scroll event.
-	 *
-	 * @memberof CKEDITOR.tools
-	 * @method debounce
-	 * @param {Array} args An array of arguments which the callback will receive.
-	 * @param {Function} callback The callback which has to be called after given timeout.
-	 * @param {Number} timeout Timeout in milliseconds after which the callback will be called.
-	 * @param {Object} context The context in which the callback will be called. This argument is optional.
-	 * @static
-	 */
-	CKEDITOR.tools.debounce =
-		CKEDITOR.tools.debounce ||
-		function(callback, timeout, context, args = []) {
-			let debounceHandle;
+		let callFn = function(...callArgs) {
+			/* eslint-disable babel/no-invalid-this */
+			let callContext = context || this;
+			/* eslint-enable babel/no-invalid-this */
 
-			let callFn = function(...callArgs) {
-				/* eslint-disable babel/no-invalid-this */
-				let callContext = context || this;
-				/* eslint-enable babel/no-invalid-this */
+			clearTimeout(debounceHandle);
 
-				clearTimeout(debounceHandle);
-
-				debounceHandle = setTimeout(function() {
-					callback.apply(callContext, [...callArgs, ...args]);
-				}, timeout);
-			};
-
-			callFn.detach = function() {
-				clearTimeout(debounceHandle);
-			};
-
-			return callFn;
+			debounceHandle = setTimeout(function() {
+				callback.apply(callContext, [...callArgs, ...args]);
+			}, timeout);
 		};
-})();
+
+		callFn.detach = function() {
+			clearTimeout(debounceHandle);
+		};
+
+		return callFn;
+	};

--- a/src/core/debounce.js
+++ b/src/core/debounce.js
@@ -13,26 +13,28 @@
  * @param {Object} context The context in which the callback will be called. This argument is optional.
  * @static
  */
-CKEDITOR.tools.debounce =
-	CKEDITOR.tools.debounce ||
-	function(callback, timeout, context, args = []) {
-		let debounceHandle;
+function debounce(callback, timeout, context, args = []) {
+	let debounceHandle;
 
-		let callFn = function(...callArgs) {
-			/* eslint-disable babel/no-invalid-this */
-			let callContext = context || this;
-			/* eslint-enable babel/no-invalid-this */
+	let callFn = function(...callArgs) {
+		/* eslint-disable babel/no-invalid-this */
+		let callContext = context || this;
+		/* eslint-enable babel/no-invalid-this */
 
-			clearTimeout(debounceHandle);
+		clearTimeout(debounceHandle);
 
-			debounceHandle = setTimeout(function() {
-				callback.apply(callContext, [...callArgs, ...args]);
-			}, timeout);
-		};
-
-		callFn.detach = function() {
-			clearTimeout(debounceHandle);
-		};
-
-		return callFn;
+		debounceHandle = setTimeout(function() {
+			callback.apply(callContext, [...callArgs, ...args]);
+		}, timeout);
 	};
+
+	callFn.detach = function() {
+		clearTimeout(debounceHandle);
+	};
+
+	return callFn;
+}
+
+CKEDITOR.tools.debounce = CKEDITOR.tools.debounce || debounce;
+
+export default debounce;

--- a/test/core/test/debounce.js
+++ b/test/core/test/debounce.js
@@ -11,7 +11,7 @@ describe('Debounce', () => {
 		clock.restore();
 	});
 
-	it('should debounce function execution', () => {
+	it('debounces function execution', () => {
 		const listener = sinon.stub();
 		const fn = CKEDITOR.tools.debounce(listener, 0);
 
@@ -23,7 +23,7 @@ describe('Debounce', () => {
 		assert.ok(listener.calledOnce);
 	});
 
-	it('should call debounced function with additional alguments', () => {
+	it('calls debounced function with additional alguments', () => {
 		const listener = sinon.stub();
 		const fn = CKEDITOR.tools.debounce(listener, 0);
 
@@ -33,7 +33,7 @@ describe('Debounce', () => {
 		assert.ok(listener.calledWith('param1'));
 	});
 
-	it('should debounce function execution with context and params', () => {
+	it('debounces function execution with context and params', () => {
 		const ctx = {};
 		const listener = sinon.stub();
 		const args = ['param1', 'param2'];
@@ -49,7 +49,7 @@ describe('Debounce', () => {
 		assert.ok(listener.calledWith('param1', 'param2'));
 	});
 
-	it('should detach a debounced function execution', () => {
+	it('detaches a debounced function execution', () => {
 		const listener = sinon.stub();
 		const fn = CKEDITOR.tools.debounce(listener, 100);
 
@@ -61,7 +61,7 @@ describe('Debounce', () => {
 		assert.notOk(listener.calledOnce);
 	});
 
-	it('should debounce function execution for the specified delay', () => {
+	it('debounces function execution for the specified delay', () => {
 		const listener = sinon.stub();
 		const fn = CKEDITOR.tools.debounce(listener, 20);
 

--- a/test/core/test/debounce.js
+++ b/test/core/test/debounce.js
@@ -1,7 +1,7 @@
 const assert = chai.assert;
 
-describe('Debounce', function() {
-	it('should debounce function execution', function(done) {
+describe('Debounce', () => {
+	it('should debounce function execution', done => {
 		const listener = sinon.stub();
 		const fn = CKEDITOR.tools.debounce(listener, 0);
 
@@ -9,26 +9,26 @@ describe('Debounce', function() {
 		fn();
 		fn();
 
-		setTimeout(function() {
+		setTimeout(() => {
 			assert.ok(listener.calledOnce);
 
 			done();
 		}, 0);
 	});
 
-	it('should call debounced function with additional alguments', function(done) {
+	it('should call debounced function with additional alguments', done => {
 		const listener = sinon.stub();
 		const fn = CKEDITOR.tools.debounce(listener, 0);
 
 		fn('param1');
 
-		setTimeout(function() {
+		setTimeout(() => {
 			assert.ok(listener.calledWith('param1'));
 			done();
 		}, 0);
 	});
 
-	it('should debounce function execution with context and params', function(done) {
+	it('should debounce function execution with context and params', done => {
 		const ctx = {};
 		const listener = sinon.stub();
 		const args = ['param1', 'param2'];
@@ -38,7 +38,7 @@ describe('Debounce', function() {
 		fn();
 		fn();
 
-		setTimeout(function() {
+		setTimeout(() => {
 			assert.ok(listener.calledOnce);
 			assert.ok(listener.calledOn(ctx));
 			assert.ok(listener.calledWith('param1', 'param2'));
@@ -47,7 +47,7 @@ describe('Debounce', function() {
 		}, 0);
 	});
 
-	it('should detach a debounced function execution', function(done) {
+	it('should detach a debounced function execution', done => {
 		const listener = sinon.stub();
 		const fn = CKEDITOR.tools.debounce(listener, 100);
 
@@ -55,28 +55,28 @@ describe('Debounce', function() {
 
 		fn.detach();
 
-		setTimeout(function() {
+		setTimeout(() => {
 			assert.notOk(listener.calledOnce);
 
 			done();
 		}, 0);
 	});
 
-	xit('should debounce function execution for the specified delay', function(done) {
+	xit('should debounce function execution for the specified delay', done => {
 		const listener = sinon.stub();
 		const fn = CKEDITOR.tools.debounce(listener, 20);
 
 		fn();
 
-		setTimeout(function() {
+		setTimeout(() => {
 			fn();
 		}, 10);
 
-		setTimeout(function() {
+		setTimeout(() => {
 			fn();
 		}, 10);
 
-		setTimeout(function() {
+		setTimeout(() => {
 			assert.ok(listener.calledOnce);
 
 			done();

--- a/test/core/test/debounce.js
+++ b/test/core/test/debounce.js
@@ -62,7 +62,7 @@ describe('Debounce', () => {
 		}, 0);
 	});
 
-	xit('should debounce function execution for the specified delay', done => {
+	it('should debounce function execution for the specified delay', done => {
 		const listener = sinon.stub();
 		const fn = CKEDITOR.tools.debounce(listener, 20);
 

--- a/test/core/test/debounce.js
+++ b/test/core/test/debounce.js
@@ -1,5 +1,7 @@
 const assert = chai.assert;
 
+import debounce from '../../../src/core/debounce';
+
 describe('Debounce', () => {
 	let clock;
 
@@ -13,7 +15,7 @@ describe('Debounce', () => {
 
 	it('debounces function execution', () => {
 		const listener = sinon.stub();
-		const fn = CKEDITOR.tools.debounce(listener, 0);
+		const fn = debounce(listener, 0);
 
 		fn();
 		fn();
@@ -25,7 +27,7 @@ describe('Debounce', () => {
 
 	it('calls debounced function with additional alguments', () => {
 		const listener = sinon.stub();
-		const fn = CKEDITOR.tools.debounce(listener, 0);
+		const fn = debounce(listener, 0);
 
 		fn('param1');
 
@@ -37,7 +39,7 @@ describe('Debounce', () => {
 		const ctx = {};
 		const listener = sinon.stub();
 		const args = ['param1', 'param2'];
-		const fn = CKEDITOR.tools.debounce(listener, 0, ctx, args);
+		const fn = debounce(listener, 0, ctx, args);
 
 		fn();
 		fn();
@@ -51,7 +53,7 @@ describe('Debounce', () => {
 
 	it('detaches a debounced function execution', () => {
 		const listener = sinon.stub();
-		const fn = CKEDITOR.tools.debounce(listener, 100);
+		const fn = debounce(listener, 100);
 
 		fn();
 
@@ -63,7 +65,7 @@ describe('Debounce', () => {
 
 	it('debounces function execution for the specified delay', () => {
 		const listener = sinon.stub();
-		const fn = CKEDITOR.tools.debounce(listener, 20);
+		const fn = debounce(listener, 20);
 
 		fn();
 		clock.tick(10);

--- a/test/core/test/debounce.js
+++ b/test/core/test/debounce.js
@@ -68,13 +68,8 @@ describe('Debounce', () => {
 
 		fn();
 
-		setTimeout(() => {
-			fn();
-		}, 10);
-
-		setTimeout(() => {
-			fn();
-		}, 10);
+		setTimeout(fn, 10);
+		setTimeout(fn, 10);
 
 		setTimeout(() => {
 			assert.ok(listener.calledOnce);

--- a/test/core/test/debounce.js
+++ b/test/core/test/debounce.js
@@ -1,7 +1,17 @@
 const assert = chai.assert;
 
 describe('Debounce', () => {
-	it('should debounce function execution', done => {
+	let clock;
+
+	beforeEach(() => {
+		clock = sinon.useFakeTimers();
+	});
+
+	afterEach(() => {
+		clock.restore();
+	});
+
+	it('should debounce function execution', () => {
 		const listener = sinon.stub();
 		const fn = CKEDITOR.tools.debounce(listener, 0);
 
@@ -9,26 +19,21 @@ describe('Debounce', () => {
 		fn();
 		fn();
 
-		setTimeout(() => {
-			assert.ok(listener.calledOnce);
-
-			done();
-		}, 0);
+		clock.tick(10);
+		assert.ok(listener.calledOnce);
 	});
 
-	it('should call debounced function with additional alguments', done => {
+	it('should call debounced function with additional alguments', () => {
 		const listener = sinon.stub();
 		const fn = CKEDITOR.tools.debounce(listener, 0);
 
 		fn('param1');
 
-		setTimeout(() => {
-			assert.ok(listener.calledWith('param1'));
-			done();
-		}, 0);
+		clock.tick(10);
+		assert.ok(listener.calledWith('param1'));
 	});
 
-	it('should debounce function execution with context and params', done => {
+	it('should debounce function execution with context and params', () => {
 		const ctx = {};
 		const listener = sinon.stub();
 		const args = ['param1', 'param2'];
@@ -38,16 +43,13 @@ describe('Debounce', () => {
 		fn();
 		fn();
 
-		setTimeout(() => {
-			assert.ok(listener.calledOnce);
-			assert.ok(listener.calledOn(ctx));
-			assert.ok(listener.calledWith('param1', 'param2'));
-
-			done();
-		}, 0);
+		clock.tick(10);
+		assert.ok(listener.calledOnce);
+		assert.ok(listener.calledOn(ctx));
+		assert.ok(listener.calledWith('param1', 'param2'));
 	});
 
-	it('should detach a debounced function execution', done => {
+	it('should detach a debounced function execution', () => {
 		const listener = sinon.stub();
 		const fn = CKEDITOR.tools.debounce(listener, 100);
 
@@ -55,26 +57,21 @@ describe('Debounce', () => {
 
 		fn.detach();
 
-		setTimeout(() => {
-			assert.notOk(listener.calledOnce);
-
-			done();
-		}, 0);
+		clock.tick(10);
+		assert.notOk(listener.calledOnce);
 	});
 
-	it('should debounce function execution for the specified delay', done => {
+	it('should debounce function execution for the specified delay', () => {
 		const listener = sinon.stub();
 		const fn = CKEDITOR.tools.debounce(listener, 20);
 
 		fn();
+		clock.tick(10);
+		fn();
+		clock.tick(10);
+		fn();
+		clock.tick(40);
 
-		setTimeout(fn, 10);
-		setTimeout(fn, 10);
-
-		setTimeout(() => {
-			assert.ok(listener.calledOnce);
-
-			done();
-		}, 40);
+		assert.ok(listener.calledOnce);
 	});
 });

--- a/test/core/test/debounce.js
+++ b/test/core/test/debounce.js
@@ -1,89 +1,85 @@
-(function() {
-	'use strict';
+var assert = chai.assert;
 
-	var assert = chai.assert;
+describe('Debounce', function() {
+	it('should debounce function execution', function(done) {
+		var listener = sinon.stub();
+		var fn = CKEDITOR.tools.debounce(listener, 0);
 
-	describe('Debounce', function() {
-		it('should debounce function execution', function(done) {
-			var listener = sinon.stub();
-			var fn = CKEDITOR.tools.debounce(listener, 0);
+		fn();
+		fn();
+		fn();
 
-			fn();
-			fn();
-			fn();
+		setTimeout(function() {
+			assert.ok(listener.calledOnce);
 
-			setTimeout(function() {
-				assert.ok(listener.calledOnce);
-
-				done();
-			}, 0);
-		});
-
-		it('should call debounced function with additional alguments', function(done) {
-			var listener = sinon.stub();
-			var fn = CKEDITOR.tools.debounce(listener, 0);
-
-			fn('param1');
-
-			setTimeout(function() {
-				assert.ok(listener.calledWith('param1'));
-				done();
-			}, 0);
-		});
-
-		it('should debounce function execution with context and params', function(done) {
-			var ctx = {};
-			var listener = sinon.stub();
-			var args = ['param1', 'param2'];
-			var fn = CKEDITOR.tools.debounce(listener, 0, ctx, args);
-
-			fn();
-			fn();
-			fn();
-
-			setTimeout(function() {
-				assert.ok(listener.calledOnce);
-				assert.ok(listener.calledOn(ctx));
-				assert.ok(listener.calledWith('param1', 'param2'));
-
-				done();
-			}, 0);
-		});
-
-		it('should detach a debounced function execution', function(done) {
-			var listener = sinon.stub();
-			var fn = CKEDITOR.tools.debounce(listener, 100);
-
-			fn();
-
-			fn.detach();
-
-			setTimeout(function() {
-				assert.notOk(listener.calledOnce);
-
-				done();
-			}, 0);
-		});
-
-		xit('should debounce function execution for the specified delay', function(done) {
-			var listener = sinon.stub();
-			var fn = CKEDITOR.tools.debounce(listener, 20);
-
-			fn();
-
-			setTimeout(function() {
-				fn();
-			}, 10);
-
-			setTimeout(function() {
-				fn();
-			}, 10);
-
-			setTimeout(function() {
-				assert.ok(listener.calledOnce);
-
-				done();
-			}, 40);
-		});
+			done();
+		}, 0);
 	});
-})();
+
+	it('should call debounced function with additional alguments', function(done) {
+		var listener = sinon.stub();
+		var fn = CKEDITOR.tools.debounce(listener, 0);
+
+		fn('param1');
+
+		setTimeout(function() {
+			assert.ok(listener.calledWith('param1'));
+			done();
+		}, 0);
+	});
+
+	it('should debounce function execution with context and params', function(done) {
+		var ctx = {};
+		var listener = sinon.stub();
+		var args = ['param1', 'param2'];
+		var fn = CKEDITOR.tools.debounce(listener, 0, ctx, args);
+
+		fn();
+		fn();
+		fn();
+
+		setTimeout(function() {
+			assert.ok(listener.calledOnce);
+			assert.ok(listener.calledOn(ctx));
+			assert.ok(listener.calledWith('param1', 'param2'));
+
+			done();
+		}, 0);
+	});
+
+	it('should detach a debounced function execution', function(done) {
+		var listener = sinon.stub();
+		var fn = CKEDITOR.tools.debounce(listener, 100);
+
+		fn();
+
+		fn.detach();
+
+		setTimeout(function() {
+			assert.notOk(listener.calledOnce);
+
+			done();
+		}, 0);
+	});
+
+	xit('should debounce function execution for the specified delay', function(done) {
+		var listener = sinon.stub();
+		var fn = CKEDITOR.tools.debounce(listener, 20);
+
+		fn();
+
+		setTimeout(function() {
+			fn();
+		}, 10);
+
+		setTimeout(function() {
+			fn();
+		}, 10);
+
+		setTimeout(function() {
+			assert.ok(listener.calledOnce);
+
+			done();
+		}, 40);
+	});
+});

--- a/test/core/test/debounce.js
+++ b/test/core/test/debounce.js
@@ -69,9 +69,10 @@ describe('Debounce', () => {
 		clock.tick(10);
 		fn();
 		clock.tick(10);
+		assert.notOk(listener.calledOnce);
+
 		fn();
 		clock.tick(40);
-
 		assert.ok(listener.calledOnce);
 	});
 });

--- a/test/core/test/debounce.js
+++ b/test/core/test/debounce.js
@@ -1,9 +1,9 @@
-var assert = chai.assert;
+const assert = chai.assert;
 
 describe('Debounce', function() {
 	it('should debounce function execution', function(done) {
-		var listener = sinon.stub();
-		var fn = CKEDITOR.tools.debounce(listener, 0);
+		const listener = sinon.stub();
+		const fn = CKEDITOR.tools.debounce(listener, 0);
 
 		fn();
 		fn();
@@ -17,8 +17,8 @@ describe('Debounce', function() {
 	});
 
 	it('should call debounced function with additional alguments', function(done) {
-		var listener = sinon.stub();
-		var fn = CKEDITOR.tools.debounce(listener, 0);
+		const listener = sinon.stub();
+		const fn = CKEDITOR.tools.debounce(listener, 0);
 
 		fn('param1');
 
@@ -29,10 +29,10 @@ describe('Debounce', function() {
 	});
 
 	it('should debounce function execution with context and params', function(done) {
-		var ctx = {};
-		var listener = sinon.stub();
-		var args = ['param1', 'param2'];
-		var fn = CKEDITOR.tools.debounce(listener, 0, ctx, args);
+		const ctx = {};
+		const listener = sinon.stub();
+		const args = ['param1', 'param2'];
+		const fn = CKEDITOR.tools.debounce(listener, 0, ctx, args);
 
 		fn();
 		fn();
@@ -48,8 +48,8 @@ describe('Debounce', function() {
 	});
 
 	it('should detach a debounced function execution', function(done) {
-		var listener = sinon.stub();
-		var fn = CKEDITOR.tools.debounce(listener, 100);
+		const listener = sinon.stub();
+		const fn = CKEDITOR.tools.debounce(listener, 100);
 
 		fn();
 
@@ -63,8 +63,8 @@ describe('Debounce', function() {
 	});
 
 	xit('should debounce function execution for the specified delay', function(done) {
-		var listener = sinon.stub();
-		var fn = CKEDITOR.tools.debounce(listener, 20);
+		const listener = sinon.stub();
+		const fn = CKEDITOR.tools.debounce(listener, 20);
 
 		fn();
 


### PR DESCRIPTION
Principally, this PR address #1052 by making our debounce tests use fake timers. This should make the tests more robust and avoid spurious failures. Along the way I addressed a number of other issues:

- Got rid of unnecessary IIFE and "use strict"
- Updated `var` to `const`, `function` to arrow function etc
- Address problem where we were not exporting the debounce function and therefore weren't explicity testing it (see 296522e).