### PR TITLE
Fixes #1079 - Eliminate misleading imports

### DIFF
--- a/src/components/uibridge/index.js
+++ b/src/components/uibridge/index.js
@@ -1,8 +1,6 @@
-import button from './button.jsx';
-import menuButton from './menu-button.jsx';
-import menu from './menu.jsx';
-import panelMenuButton from './panel-menu-button.jsx';
-import richcombo from './richcombo.jsx';
-import uibridge from './uibridge';
-
-export {button, menuButton, menu, panelMenuButton, richcombo, uibridge};
+import './button.jsx';
+import './menu-button.jsx';
+import './menu.jsx';
+import './panel-menu-button.jsx';
+import './richcombo.jsx';
+import './uibridge';

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -1,9 +1,9 @@
 import debounce from './debounce';
-import link from './link';
-import plugins from './plugins';
-import selectionRegion from './selection-region';
-import table from './table';
-import tools from './tools';
-import uicore from './uicore';
+import './link';
+import './plugins';
+import './selection-region';
+import './table';
+import './tools';
+import './uicore';
 
-export {debounce, link, plugins, selectionRegion, table, tools, uicore};
+export {debounce};

--- a/src/plugins/index.js
+++ b/src/plugins/index.js
@@ -1,31 +1,16 @@
-import addimages from './addimages';
-import autolink from './autolink';
-import autolist from './autolist';
-import dragresize from './dragresize';
-import dragresizeie from './dragresize_ie';
-import dragresizeie11 from './dragresize_ie11';
-import embed from './embed';
+import './addimages';
+import './autolink';
+import './autolist';
+import './dragresize';
+import './dragresize_ie';
+import './dragresize_ie11';
+import './embed';
 import embedurl from './embedurl';
-import imagealignment from './imagealignment';
-import pasteimages from './pasteimages';
-import placeholder from './placeholder';
-import selectionkeystrokes from './selectionkeystrokes';
-import tableresize from './tableresize';
-import tabletools from './tabletools';
+import './imagealignment';
+import './pasteimages';
+import './placeholder';
+import './selectionkeystrokes';
+import './tableresize';
+import './tabletools';
 
-export {
-	addimages,
-	autolink,
-	autolist,
-	dragresize,
-	dragresizeie,
-	dragresizeie11,
-	embed,
-	embedurl,
-	imagealignment,
-	pasteimages,
-	placeholder,
-	selectionkeystrokes,
-	tableresize,
-	tabletools,
-};
+export {embedurl};


### PR DESCRIPTION
We have modules that don't `export` anything, and in other places we `import` from those modules and re-`export` what we imported. In effect, we are importing these modules for their side-effects only, but the code gives the false impression that we are using the values that we import. This commit changes those imports to make it obvious that they are for side-effects only; ie:

```
import x from './x';
```

becomes:

```
import './x';
```

I made a script:

https://gist.github.com/wincent/189c39ef373c0a2060365baa1a6b8cab

to detect likely culprits:

```js

const fs = require('fs');
const path = require('path');

function walk(dir, filter = Boolean, sink) {
	fs.readdirSync(dir, {withFileTypes: true}).forEach(entry => {
		const file = path.join(dir, entry.name.toString());
		if (entry.isDirectory()) {
			walk(file, filter, sink);
		} else if (filter(file)) {
			sink.add(file);
		}
	});
	return sink;
}

function isJS(name) {
	return name.match(/\.jsx?/);
}

function isFirstParty(name) {
	return !name.match(/^(dist|lib|node_modules)\//);
}

const filter = name => isJS(name) && isFirstParty(name);
const files = walk('.', filter, new Set());

const cache = {};
const filesWithoutExports = new Set();
const filesWithImports = {};

function stripExtension(name) {
	return name.replace(/\.\w+$/, '');
}

for (let file of files) {
	const content = fs.readFileSync(file).toString();
	cache[file] = content;
	if (!content.match(/\bexports?\b/)) {
		filesWithoutExports.add(stripExtension(file));
	}

	if (content.match(/\bimport\b.+\bfrom\b.+\.\//)) {
		const imports = [];
		const regExp = /\bfrom\s+(['"])(.+?)\1/g;
		let match;
		while (match = regExp.exec(content)) {
			const extensionless = stripExtension(match[2]);
			const relative = path.relative('', path.join(path.dirname(file), extensionless));
			imports.push(relative);
		}
		filesWithImports[file] = imports;
	}
}

for (let [file, imports] of Object.entries(filesWithImports)) {
	const bad = imports.filter(target => {
		return filesWithoutExports.has(target);
	});
	if (bad.length) {
		console.log(`${file}:`);
		for (let target of bad) {
			console.log(`  ${target}`);
		}
	}
}
```

It identifies these problematic modules:

```
src/components/uibridge/index.js:
  src/components/uibridge/button
  src/components/uibridge/menu-button
  src/components/uibridge/menu
  src/components/uibridge/panel-menu-button
  src/components/uibridge/richcombo
  src/components/uibridge/uibridge
src/core/index.js:
  src/core/link
  src/core/plugins
  src/core/selection-region
  src/core/table
  src/core/tools
  src/core/uicore
src/plugins/index.js:
  src/plugins/addimages
  src/plugins/autolink
  src/plugins/autolist
  src/plugins/dragresize
  src/plugins/dragresize_ie
  src/plugins/dragresize_ie11
  src/plugins/embed
  src/plugins/imagealignment
  src/plugins/pasteimages
  src/plugins/placeholder
  src/plugins/selectionkeystrokes
  src/plugins/tableresize
  src/plugins/tabletools
```

Test plan: `npm run build && npm run test && npm run start` and check the demo.

Closes: #1079