### PR TITLE
Fixes #1081 - Make dev environment hot-reloading work

### DIFF
--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -14,6 +14,7 @@ const All = merge(common.config, config, {
 	devServer: {
 		contentBase: './dist',
 		port: 9000,
+		publicPath: '/alloy-editor',
 	},
 });
 


### PR DESCRIPTION
We need the "publicPath" setting to make this work. With this change, `npm run start` prints this:

```
ℹ ｢wds｣: Project is running at http://localhost:9000/
ℹ ｢wds｣: webpack output is served from /alloy-editor
ℹ ｢wds｣: Content not from webpack is served from ./dist
```

Note the "served from /alloy-editor" bit. (Prior to this commit is instead said "served from /".) This allows the "alloy-editor/alloy-editor-all.js" script that our demo index.html references to be hot-reloaded.

Test plan: `npm run dev && npm run start`; hit demo and see it working, then add a `console.log`, see webpack recompile, and see the browser reload the module without any intervention (output appears in console).

Closes: https://github.com/liferay/alloy-editor/issues/1081