### PR TITLE
Context follow ups

### DIFF
--- a/src/components/buttons/button-accessibility-image-alt.jsx
+++ b/src/components/buttons/button-accessibility-image-alt.jsx
@@ -18,8 +18,6 @@ class ButtonAccessibilityImageAlt extends React.Component {
 
 	static key = 'AccessibilityImageAlt';
 
-	static propTypes = {};
-
 	constructor(props) {
 		super(props);
 

--- a/src/components/buttons/button-embed-video-edit.jsx
+++ b/src/components/buttons/button-embed-video-edit.jsx
@@ -18,8 +18,6 @@ class ButtonEmbedVideoEdit extends React.Component {
 
 	static key = 'embedVideoEdit';
 
-	static propTypes = {};
-
 	constructor(props) {
 		super(props);
 

--- a/src/components/buttons/button-item-selector-audio.jsx
+++ b/src/components/buttons/button-item-selector-audio.jsx
@@ -14,10 +14,6 @@ class ButtonItemSelectorAudio extends React.Component {
 
 	static key = 'audio';
 
-	static propTypes = {
-		editor: PropTypes.object.isRequired,
-	};
-
 	render() {
 		return (
 			<button
@@ -25,7 +21,7 @@ class ButtonItemSelectorAudio extends React.Component {
 				data-type="button-audio"
 				onClick={this._handleClick}
 				tabIndex={this.props.tabIndex}>
-				<ButtonIcon editor={this.props.editor} symbol="audio" />
+				<ButtonIcon symbol="audio" />
 			</button>
 		);
 	}

--- a/src/components/buttons/button-item-selector-image.jsx
+++ b/src/components/buttons/button-item-selector-image.jsx
@@ -14,10 +14,6 @@ class ButtonItemSelectorImage extends React.Component {
 
 	static key = 'image';
 
-	static propTypes = {
-		editor: PropTypes.object.isRequired,
-	};
-
 	render() {
 		return (
 			<button
@@ -25,7 +21,7 @@ class ButtonItemSelectorImage extends React.Component {
 				data-type="button-image"
 				onClick={this._handleClick}
 				tabIndex={this.props.tabIndex}>
-				<ButtonIcon editor={this.props.editor} symbol="picture" />
+				<ButtonIcon symbol="picture" />
 			</button>
 		);
 	}

--- a/src/components/buttons/button-item-selector-video.jsx
+++ b/src/components/buttons/button-item-selector-video.jsx
@@ -14,10 +14,6 @@ class ButtonItemSelectorVideo extends React.Component {
 
 	static key = 'video';
 
-	static propTypes = {
-		editor: PropTypes.object.isRequired,
-	};
-
 	render() {
 		return (
 			<button
@@ -25,7 +21,7 @@ class ButtonItemSelectorVideo extends React.Component {
 				data-type="button-video"
 				onClick={this._handleClick}
 				tabIndex={this.props.tabIndex}>
-				<ButtonIcon editor={this.props.editor} symbol="video" />
+				<ButtonIcon symbol="video" />
 			</button>
 		);
 	}

--- a/src/components/buttons/button-link-edit-browse.jsx
+++ b/src/components/buttons/button-link-edit-browse.jsx
@@ -14,8 +14,6 @@ import Lang from '../../oop/lang';
 class ButtonLinkEditBrowse extends React.Component {
 	static contextType = EditorContext;
 
-	static propTypes = {};
-
 	static key = 'linkEditBrowse';
 
 	/**


### PR DESCRIPTION
Follow-ups to comments posted on #1055:

- Remove empty `propTypes` declarations.
- Update the three new buttons merged while that PR was in-flight.