### PR TITLE
Remove BREAKING_CHANGES.md

### DIFF
--- a/BREAKING_CHANGES.md
+++ b/BREAKING_CHANGES.md
@@ -1,8 +1,0 @@
-0.4.0
-All AlloyEditor plugins are renamed and they are now prefixed with "ae_". Example: previously "addimages",
-now "ae_addimages". The goal of this change is to isolate as much as possible AlloyEditor's plugins
-from these of CKEDitor and prevent possibilities for clashing.
-
-0.3.0
-Issue #219 removes the event 'imageDrop' when user D&D image inside the editor. Instead, an event 'imageAdd'
-will be fired.


### PR DESCRIPTION
BREAKING_CHANGES.md is basically unmaintained (last updated in 2015), so remove it. I would have preferred to merge its contents into CHANGELOG.md, but in testing with `github_changelog_generator` I found that it overwrites any manual changes made to the document.