### PR TITLE
Fixes #1061 Allow only the required style for IE and Chrome

### DIFF
--- a/src/plugins/dragresize_ie11.js
+++ b/src/plugins/dragresize_ie11.js
@@ -528,11 +528,11 @@
                     var el = shift.element;
 
                     // Alignment changed.
-                    if ( shift.changed.align ) {
+                    if ( shift.changed.align || el.$.style.marginLeft === 'auto' && el.$.style.marginRight === 'auto') {
                         // No caption in the new state.
                         if ( !shift.newData.hasCaption ) {
                             // Changed to "center" (non-captioned).
-                            if ( newValue == 'center' ) {
+                            if ( newValue == 'center' || el.$.style.marginLeft === 'auto' && el.$.style.marginRight === 'auto') {
                                 shift.deflate();
                                 shift.element = wrapInCentering( editor, el );
                             }

--- a/src/plugins/imagealignment.js
+++ b/src/plugins/imagealignment.js
@@ -80,6 +80,7 @@
                         }
                     });
                     centeredImage = true;
+                    imageContainer.style.textAlign = '';
                 }
             }
 
@@ -142,11 +143,6 @@
                     });
                 }
             });
-
-            var imageContainer = image.$.parentNode;
-
-            imageContainer.style.textAlign = IMAGE_ALIGNMENT.CENTER;
-
         }
     };
 


### PR DESCRIPTION
#1061
https://issues.liferay.com/browse/LPS-90092

Removing the unnecessary alignment to both Chrome and IE will fix this issue. Removing the addition of center alignment to the parent in chrome, will allow the editor to function correctly in chrome. Also adding a check to add the center alignment to IE when it sees that the element contains marginLeft and marginRight auto. 
Let me know if there are any questions or comments about this.
Thank you.