### PR TITLE
Fixes #1061 Allow only required style for IE and other browsers

### DIFF
--- a/src/plugins/dragresize_ie11.js
+++ b/src/plugins/dragresize_ie11.js
@@ -583,11 +583,11 @@
 					let el = shift.element;
 
 					// Alignment changed.
-					if (shift.changed.align) {
+					if (shift.changed.align || el.$.style.marginLeft === 'auto' && el.$.style.marginRight === 'auto') {
 						// No caption in the new state.
 						if (!shift.newData.hasCaption) {
 							// Changed to "center" (non-captioned).
-							if (newValue == 'center') {
+							if (newValue == 'center' || el.$.style.marginLeft === 'auto' && el.$.style.marginRight === 'auto') {
 								shift.deflate();
 								shift.element = wrapInCentering(editor, el);
 							}

--- a/src/plugins/imagealignment.js
+++ b/src/plugins/imagealignment.js
@@ -94,6 +94,7 @@ if (!CKEDITOR.plugins.get('ae_imagealignment')) {
 						}
 					});
 					centeredImage = true;
+					imageContainer.style.textAlign = '';
 				}
 			}
 
@@ -162,10 +163,6 @@ if (!CKEDITOR.plugins.get('ae_imagealignment')) {
 					});
 				}
 			});
-
-			let imageContainer = image.$.parentNode;
-
-			imageContainer.style.textAlign = IMAGE_ALIGNMENT.CENTER;
 		}
 	};
 


### PR DESCRIPTION
Resent from https://github.com/liferay/alloy-editor/pull/1098

> #1061
> https://issues.liferay.com/browse/LPS-90092
> 
> Removing the unnecessary alignment to both Chrome and IE will fix this issue. Removing the addition of center alignment to the parent in chrome, will allow the editor to function correctly in chrome. Also adding a check to add the center alignment to IE when it sees that the element contains marginLeft and marginRight auto.
> Let me know if there are any questions or comments about this.
> Thank you.

Let me know if there is anything that needs to be changed or added.
Thank you.