### PR TITLE
Fix #1109 auto-embedding of pasted video (etc) URLs

### DIFF
--- a/src/plugins/embed.js
+++ b/src/plugins/embed.js
@@ -1,3 +1,5 @@
+import {HIGH_PRIORITY} from './priorities';
+
 /* istanbul ignore if */
 if (!CKEDITOR.plugins.get('ae_embed')) {
 	let REGEX_HTTP = /^https?/;
@@ -134,17 +136,26 @@ if (!CKEDITOR.plugins.get('ae_embed')) {
 
 			// Add a listener to handle paste events and turn links into embed objects
 			editor.once('contentDom', function() {
-				editor.on('paste', function(event) {
-					let link = event.data.dataValue;
+				editor.on(
+					'paste',
+					function(event) {
+						let link = event.data.dataValue;
 
-					if (REGEX_HTTP.test(link)) {
-						event.stop();
+						if (REGEX_HTTP.test(link)) {
+							event.stop();
 
-						editor.execCommand('embedUrl', {
-							url: event.data.dataValue,
-						});
-					}
-				});
+							editor.execCommand('embedUrl', {
+								url: event.data.dataValue,
+							});
+						}
+					},
+					null,
+					null,
+					// Make sure we run before autolink's paste handler,
+					// otherwise the link will be turned into an anchor and our
+					// REGEX_HTTP test will fail.
+					HIGH_PRIORITY
+				);
 			});
 
 			// Add a listener to handle selection change events and properly detect editor

--- a/src/plugins/priorities.js
+++ b/src/plugins/priorities.js
@@ -1,0 +1,7 @@
+/**
+ * Priorities that can be used to control the order in which event handlers run.
+ *
+ * @see https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_event.html#method-on
+ */
+export const DEFAULT_PRIORITY = 10;
+export const HIGH_PRIORITY = 5;


### PR DESCRIPTION
The "embed" plugin checks to see whether pasted text matches a regex for strings starting with "http://" (or "https://"), but the "autolink" plug-in also listens to paste events and ends up transforming any links into anchor tags before the "embed" plug-in sees them. This means that the regex doesn't match and the embed will never work.

In this commit we add a priority mechanism in order to allow the "embed" plug-in to run first.

The gotcha: when we paste a link, the "selectionChange" handler runs in the "embed" plug-in and ends up firing an "editorInteraction" event with the new selection, and that means we see the link toolbar pop-up. Previously on pasting a link, no toolbar would appear. Still need to find a solution for that.

Test plan: `npm run dev && npm run test && npm run start`; in demo, paste normal links, video links, video links with extra query params etc:

- https://nodesecurity.io/advisories/755 (a normal link)
- https://www.youtube.com/watch?v=s5VpRV9yfuc (a video)
- https://youtu.be/s5VpRV9yfuc?t=178 (same video, but with a starting
  timestamp)

Closes: https://github.com/liferay/alloy-editor/issues/1109