### PR TITLE
Fix tests broken by Zepto removal

### DIFF
--- a/test/ui/test/button-bold.jsx
+++ b/test/ui/test/button-bold.jsx
@@ -79,7 +79,7 @@ describe('ButtonBold', function() {
 		var buttonDOMNode = ReactDOM.findDOMNode(buttonBold);
 
 		assert.strictEqual(
-			$(buttonDOMNode).hasClass('ae-button-pressed'),
+			buttonDOMNode.classList.contains('ae-button-pressed'),
 			true
 		);
 	});

--- a/test/ui/test/button-code.jsx
+++ b/test/ui/test/button-code.jsx
@@ -50,7 +50,7 @@ describe('ButtonCode', function() {
 		var buttonDOMNode = ReactDOM.findDOMNode(buttonCode);
 
 		assert.strictEqual(
-			$(buttonDOMNode).hasClass('ae-button-pressed'),
+			buttonDOMNode.classList.contains('ae-button-pressed'),
 			true
 		);
 	});

--- a/test/ui/test/button-h1.jsx
+++ b/test/ui/test/button-h1.jsx
@@ -50,7 +50,7 @@ describe('ButtonH1', function() {
 		var buttonDOMNode = ReactDOM.findDOMNode(buttonH1);
 
 		assert.strictEqual(
-			$(buttonDOMNode).hasClass('ae-button-pressed'),
+			buttonDOMNode.classList.contains('ae-button-pressed'),
 			true
 		);
 	});

--- a/test/ui/test/button-h2.jsx
+++ b/test/ui/test/button-h2.jsx
@@ -50,7 +50,7 @@ describe('ButtonH2', function() {
 		var buttonDOMNode = ReactDOM.findDOMNode(buttonH2);
 
 		assert.strictEqual(
-			$(buttonDOMNode).hasClass('ae-button-pressed'),
+			buttonDOMNode.classList.contains('ae-button-pressed'),
 			true
 		);
 	});

--- a/test/ui/test/button-image-align-center.jsx
+++ b/test/ui/test/button-image-align-center.jsx
@@ -91,7 +91,7 @@ describe('ButtonImageAlignCenter', function() {
 		var buttonDOMNode = ReactDOM.findDOMNode(buttonImageAlignCenter);
 
 		assert.strictEqual(
-			$(buttonDOMNode).hasClass('ae-button-pressed'),
+			buttonDOMNode.classList.contains('ae-button-pressed'),
 			true
 		);
 	});

--- a/test/ui/test/button-image-align-left.jsx
+++ b/test/ui/test/button-image-align-left.jsx
@@ -87,7 +87,7 @@ describe('ButtonImageAlignLeft', function() {
 		var buttonDOMNode = ReactDOM.findDOMNode(buttonImageAlignLeft);
 
 		assert.strictEqual(
-			$(buttonDOMNode).hasClass('ae-button-pressed'),
+			buttonDOMNode.classList.contains('ae-button-pressed'),
 			true
 		);
 	});

--- a/test/ui/test/button-image-align-right.jsx
+++ b/test/ui/test/button-image-align-right.jsx
@@ -87,7 +87,7 @@ describe('ButtonImageAlignRight', function() {
 		var buttonDOMNode = ReactDOM.findDOMNode(buttonImageAlignRight);
 
 		assert.strictEqual(
-			$(buttonDOMNode).hasClass('ae-button-pressed'),
+			buttonDOMNode.classList.contains('ae-button-pressed'),
 			true
 		);
 	});

--- a/test/ui/test/button-italic.jsx
+++ b/test/ui/test/button-italic.jsx
@@ -79,7 +79,7 @@ describe('ButtonItalic', function() {
 		var buttonDOMNode = ReactDOM.findDOMNode(buttonItalic);
 
 		assert.strictEqual(
-			$(buttonDOMNode).hasClass('ae-button-pressed'),
+			buttonDOMNode.classList.contains('ae-button-pressed'),
 			true
 		);
 	});

--- a/test/ui/test/button-ol.jsx
+++ b/test/ui/test/button-ol.jsx
@@ -50,7 +50,7 @@ describe('ButtonOrderedList', function() {
 		var buttonDOMNode = ReactDOM.findDOMNode(buttonOrderedlist);
 
 		assert.strictEqual(
-			$(buttonDOMNode).hasClass('ae-button-pressed'),
+			buttonDOMNode.classList.contains('ae-button-pressed'),
 			true
 		);
 	});

--- a/test/ui/test/button-paragraph-align-left.jsx
+++ b/test/ui/test/button-paragraph-align-left.jsx
@@ -73,6 +73,6 @@ describe('ButtonParagraphAlignLeft', function() {
 
 		var buttonDOMNode = ReactDOM.findDOMNode(buttonParagraphAlignLeft);
 
-		assert.isTrue($(buttonDOMNode).hasClass('ae-button-pressed'));
+		assert.isTrue(buttonDOMNode.classList.contains('ae-button-pressed'));
 	});
 });

--- a/test/ui/test/button-paragraph-align-rigth.jsx
+++ b/test/ui/test/button-paragraph-align-rigth.jsx
@@ -73,6 +73,6 @@ describe('ButtonParagraphAlignRight', function() {
 
 		var buttonDOMNode = ReactDOM.findDOMNode(buttonParagraphAlignRight);
 
-		assert.isTrue($(buttonDOMNode).hasClass('ae-button-pressed'));
+		assert.isTrue(buttonDOMNode.classList.contains('ae-button-pressed'));
 	});
 });

--- a/test/ui/test/button-paragraph-center.jsx
+++ b/test/ui/test/button-paragraph-center.jsx
@@ -73,6 +73,6 @@ describe('ButtonParagraphCenter', function() {
 
 		var buttonDOMNode = ReactDOM.findDOMNode(buttonParagraphCenter);
 
-		assert.isTrue($(buttonDOMNode).hasClass('ae-button-pressed'));
+		assert.isTrue(buttonDOMNode.classList.contains('ae-button-pressed'));
 	});
 });

--- a/test/ui/test/button-paragraph-justify.jsx
+++ b/test/ui/test/button-paragraph-justify.jsx
@@ -73,6 +73,6 @@ describe('ButtonParagraphJustify', function() {
 
 		var buttonDOMNode = ReactDOM.findDOMNode(buttonParagraphJustify);
 
-		assert.isTrue($(buttonDOMNode).hasClass('ae-button-pressed'));
+		assert.isTrue(buttonDOMNode.classList.contains('ae-button-pressed'));
 	});
 });

--- a/test/ui/test/button-quote.jsx
+++ b/test/ui/test/button-quote.jsx
@@ -50,7 +50,7 @@ describe('ButtonQuote', function() {
 		var buttonDOMNode = ReactDOM.findDOMNode(buttonQuote);
 
 		assert.strictEqual(
-			$(buttonDOMNode).hasClass('ae-button-pressed'),
+			buttonDOMNode.classList.contains('ae-button-pressed'),
 			true
 		);
 	});

--- a/test/ui/test/button-strike.jsx
+++ b/test/ui/test/button-strike.jsx
@@ -50,7 +50,7 @@ describe('ButtonStrike', function() {
 		var buttonDOMNode = ReactDOM.findDOMNode(buttonStrike);
 
 		assert.strictEqual(
-			$(buttonDOMNode).hasClass('ae-button-pressed'),
+			buttonDOMNode.classList.contains('ae-button-pressed'),
 			true
 		);
 	});

--- a/test/ui/test/button-subscript.jsx
+++ b/test/ui/test/button-subscript.jsx
@@ -50,7 +50,7 @@ describe('ButtonSubscript', function() {
 		var buttonDOMNode = ReactDOM.findDOMNode(buttonSubscript);
 
 		assert.strictEqual(
-			$(buttonDOMNode).hasClass('ae-button-pressed'),
+			buttonDOMNode.classList.contains('ae-button-pressed'),
 			true
 		);
 	});

--- a/test/ui/test/button-superscript.jsx
+++ b/test/ui/test/button-superscript.jsx
@@ -50,7 +50,7 @@ describe('ButtonSuperscript', function() {
 		var buttonDOMNode = ReactDOM.findDOMNode(buttonSuperscript);
 
 		assert.strictEqual(
-			$(buttonDOMNode).hasClass('ae-button-pressed'),
+			buttonDOMNode.classList.contains('ae-button-pressed'),
 			true
 		);
 	});

--- a/test/ui/test/button-twitter.jsx
+++ b/test/ui/test/button-twitter.jsx
@@ -63,7 +63,7 @@ describe('ButtonTwitter', function() {
 		var buttonDOMNode = ReactDOM.findDOMNode(buttonTwitter);
 
 		assert.strictEqual(
-			$(buttonDOMNode).hasClass('ae-button-pressed'),
+			buttonDOMNode.classList.contains('ae-button-pressed'),
 			true
 		);
 	});

--- a/test/ui/test/button-ul.jsx
+++ b/test/ui/test/button-ul.jsx
@@ -50,7 +50,7 @@ describe('ButtonUnorderedlist', function() {
 		var buttonDOMNode = ReactDOM.findDOMNode(buttonUnorderedlist);
 
 		assert.strictEqual(
-			$(buttonDOMNode).hasClass('ae-button-pressed'),
+			buttonDOMNode.classList.contains('ae-button-pressed'),
 			true
 		);
 	});

--- a/test/ui/test/button-underline.jsx
+++ b/test/ui/test/button-underline.jsx
@@ -79,7 +79,7 @@ describe('ButtonUnderline', function() {
 		var buttonDOMNode = ReactDOM.findDOMNode(buttonUnderline);
 
 		assert.strictEqual(
-			$(buttonDOMNode).hasClass('ae-button-pressed'),
+			buttonDOMNode.classList.contains('ae-button-pressed'),
 			true
 		);
 	});


### PR DESCRIPTION
I broke some tests by removing Zepto in:

https://github.com/liferay/alloy-editor/pull/1087

Didn't notice though because many of our tests are silently failing; related issue that I'm currently working on for that:

https://github.com/liferay/alloy-editor/issues/1123

We can replace these Zepto usages with classList because it is available on all of our supported platforms:

https://caniuse.com/#feat=classlist

Test plan: run tests in browser with Karma config `singleRun: false` so that I can see the failures no longer appear in the console.