### PR TITLE
Don't let webpack use "eval" devtool in tests

### DIFF
--- a/karma.common.js
+++ b/karma.common.js
@@ -123,6 +123,12 @@ module.exports = {
 
 	webpack: {
 		mode: 'development',
+
+		// Beware! Don't set devtool to 'eval' or similar because it will
+		// cause modules to be executed as many times as they are required
+		// instead of once only, breaking everything.
+		devtool: false,
+
 		module: {
 			rules: [
 				{


### PR DESCRIPTION
This one had me scratching my head for a while. While working on:

https://github.com/liferay/alloy-editor/issues/1123

I noticed that we weren't setting up the React context when rendering in tests, but when we did set it up, the context consumers still weren't getting the context.

Adding some logging, I could see that the context module was getting evaluated over and over again (123 times!), and I was able to confirm that we were getting a different (ie. `!==`) context object every time. Analysis in the debugger revealed that webpack was requiring modules by evaling their string representations, which meant that usual module once-only semantics were not enforced.

This breaks a bunch of stuff in the test suite, but luckily there is an easy fix: turn off "devtool" in the config and you don't get the "eval" treatment any more.

https://webpack.js.org/configuration/devtool/

Test plan: add logging and see that modules are only being evaluated once, fixing a bunch of failures in my local development branch.