### PR TITLE
Add test:debug script for investigating test issues

### DIFF
--- a/karma.common.js
+++ b/karma.common.js
@@ -7,12 +7,15 @@ const alloyEditorDir = 'dist/alloy-editor/';
 
 const preprocessors = {
 	'test/**/*.html': ['html2js'],
-	'+(test|src)/**/*.js*': ['webpack'],
+	'src/**/*.js*': ['webpack'],
+	'test/**/*.js*': ['webpack'],
 	'scripts/test/loader-alloy-editor.js': ['webpack'],
 };
 
-if (!(argv.debug || argv.d)) {
-	preprocessors[path.join(alloyEditorDir, 'test/**/*.js')] = ['coverage'];
+const DEBUG = argv.debug || argv.d;
+
+if (!DEBUG) {
+	preprocessors[path.join(alloyEditorDir, 'src/**/*.js')] = ['coverage'];
 }
 
 const filesToLoad = [
@@ -155,10 +158,10 @@ module.exports = {
 
 	// level of logging
 	// possible values: config.LOG_DISABLE || config.LOG_ERROR || config.LOG_WARN || config.LOG_INFO || config.LOG_DEBUG
-	logLevel: 'info',
+	logLevel: DEBUG ? 'debug' : 'info',
 
 	// enable / disable watching file and executing tests whenever any file changes
 	autoWatch: false,
 
-	singleRun: true,
+	singleRun: !DEBUG,
 };

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "prepublishOnly": "npm run checkFormat && npm run test",
     "start": "webpack-dev-server --config webpack.dev.js",
     "test": "karma start karma.js",
+    "test:debug": "karma start karma.js --debug",
     "testSaucelabs": "karma start karma-saucelabs.js"
   },
   "repository": {


### PR DESCRIPTION
A few changes in here:

- Split out one of the preprocessor patterns into two lines so that readers don't have to look up the significance of "+"; if you're curious, it is explained [here](https://github.com/isaacs/minimatch).
- Create `DEBUG` constant (set when running with the `-d` or `--debug` flags) for readability and use it in a few places.
- When `DEBUG` is set, increase log level from "info" to "debug".
- When `DEBUG` is set, set "singleRun" to `true`, which means you can interact with the tests in the browser console.
- Add a "test:debug" script to run with `--debug`; this is a shortcut for doing `npm run test -- --debug`.
- Produce coverage information for "src", not "test"; seems like this was back-to-front.

Doing this in service of:

https://github.com/liferay/alloy-editor/issues/1123