### PR TITLE
Fix embed tests

### DIFF
--- a/test/lib/utils.js
+++ b/test/lib/utils.js
@@ -197,8 +197,11 @@ if (!window.Utils) {
 				this.nativeEditor = null;
 			}
 
-			this._editable.parentNode.removeChild(this._editable);
-			this._editable = null;
+			if (this._editable) {
+				this._editable.parentNode.removeChild(this._editable);
+				this._editable = null;
+			}
+
 			Utils.removeContainer.call(this);
 			fixture.cleanup();
 
@@ -225,8 +228,10 @@ if (!window.Utils) {
 		},
 
 		removeContainer() {
-			this.container.parentNode.removeChild(this.container);
-			this.container = null;
+			if (this.container) {
+				this.container.parentNode.removeChild(this.container);
+				this.container = null;
+			}
 		},
 
 		_prepareFixtureForAssertion(htmlFixture) {

--- a/test/plugins/test/embed.js
+++ b/test/plugins/test/embed.js
@@ -1,30 +1,21 @@
 var assert = chai.assert;
 
+var sandbox = sinon.createSandbox();
+
 describe('Embed plugin', function() {
 	beforeEach(function(done) {
 		Utils.createCKEditor.call(this, done, {extraPlugins: 'ae_embed'});
 	});
 
 	afterEach(function(done) {
-		try {
-			if (CKEDITOR.tools.jsonp.restore) {
-				CKEDITOR.tools.jsonp.restore();
-			}
-
-			if (this.nativeEditor.insertHtml.restore) {
-				this.nativeEditor.insertHtml.restore();
-			}
-		} catch (error) {
-			console.error(error);
-		} finally {
-			Utils.destroyCKEditor.call(this, done);
-		}
+		sandbox.restore();
+		Utils.destroyCKEditor.call(this, done);
 	});
 
 	it('should not convert links inside content', function() {
 		var nativeEditor = this.nativeEditor;
 
-		var spy = sinon.spy(nativeEditor, 'execCommand');
+		var spy = sandbox.spy(nativeEditor, 'execCommand');
 
 		bender.tools.selection.setWithHtml(
 			nativeEditor,
@@ -44,7 +35,7 @@ describe('Embed plugin', function() {
 		var tweetReturnHtml =
 			'<blockquote class="twitter-tweet" align="center">Hello Earth! Can you hear me?</blockquote>';
 
-		sinon
+		sandbox
 			.stub(CKEDITOR.tools, 'jsonp')
 			.callsFake(function(fn, data, success, fail) {
 				success({html: tweetReturnHtml, provider_name: 'Twitter'});
@@ -70,7 +61,7 @@ describe('Embed plugin', function() {
 		var tweetReturnHtml =
 			'<blockquote class="twitter-tweet" align="center">Hello Earth! Can you hear me?</blockquote>';
 
-		sinon
+		sandbox
 			.stub(CKEDITOR.tools, 'jsonp')
 			.callsFake(function(fn, data, success, fail) {
 				success({html: tweetReturnHtml, provider_name: 'YouTube'});
@@ -96,7 +87,7 @@ describe('Embed plugin', function() {
 		var tweetReturnHtml =
 			'<blockquote class="twitter-tweet" align="center">Hello Earth! Can you hear me?</blockquote>';
 
-		sinon
+		sandbox
 			.stub(CKEDITOR.tools, 'jsonp')
 			.callsFake(function(fn, data, success, fail) {
 				success({
@@ -109,7 +100,7 @@ describe('Embed plugin', function() {
 
 		var isCalled = false;
 
-		sinon.stub(nativeEditor, 'insertHtml').callsFake(function() {
+		sandbox.stub(nativeEditor, 'insertHtml').callsFake(function() {
 			isCalled = true;
 			return;
 		});
@@ -126,7 +117,7 @@ describe('Embed plugin', function() {
 	it('should create a tag with url as href when url is pasted and there is a connection error', function() {
 		var url = 'https://foo.com';
 
-		sinon
+		sandbox
 			.stub(CKEDITOR.tools, 'jsonp')
 			.callsFake(function(fn, data, success, fail) {
 				fail({});
@@ -136,7 +127,7 @@ describe('Embed plugin', function() {
 
 		var isCalled = false;
 
-		sinon.stub(nativeEditor, 'insertHtml').callsFake(function() {
+		sandbox.stub(nativeEditor, 'insertHtml').callsFake(function() {
 			isCalled = true;
 			return;
 		});

--- a/test/plugins/test/embed.js
+++ b/test/plugins/test/embed.js
@@ -2,6 +2,14 @@ var assert = chai.assert;
 
 var sandbox = sinon.createSandbox();
 
+function applyFirefoxHack(nativeEditor) {
+	// Hack for Firefox.
+	// If a contenteditable has been in the DOM before this test runs,
+	// CKEDITOR will blow up on trying to insertHtml, unless we insert this
+	// magical content (whitespace and an empty selection) first.
+	bender.tools.selection.setWithHtml(nativeEditor, ' {}');
+}
+
 describe('Embed plugin', function() {
 	beforeEach(function(done) {
 		Utils.createCKEditor.call(this, done, {extraPlugins: 'ae_embed'});
@@ -43,7 +51,7 @@ describe('Embed plugin', function() {
 
 		var nativeEditor = this.nativeEditor;
 
-		bender.tools.selection.setWithHtml(nativeEditor, '{}');
+		applyFirefoxHack(nativeEditor);
 
 		nativeEditor.fire('paste', {
 			dataValue: url,
@@ -69,7 +77,7 @@ describe('Embed plugin', function() {
 
 		var nativeEditor = this.nativeEditor;
 
-		bender.tools.selection.setWithHtml(nativeEditor, '{}');
+		applyFirefoxHack(nativeEditor);
 
 		nativeEditor.fire('paste', {
 			dataValue: url,


### PR DESCRIPTION
Alas, I have to reintroduce the hack that I removed in c7f77084e7a5631e4814c92bf1. Notice though that I am not applying it in a blanket fashion everywhere -- that just makes other failures pop up elsewhere -- but instead am targeting it to the two places that need it. There are only two other failing tests in Firefox visible with `npm run test:debug` right now. If they require a similar fix I'll extract out the hack.

This is some really baffling behavior. To summarize:

- Tests only fail on Firefox, and only if a test has run before.
- In fact, it is not even necessary to run a test before to trigger the failure: just adding a "div" with a "contenteditable" attribute to the DOM is enough (removing it makes no difference).
- As I was single-stepping through the debugger, I saw CKEDITOR incorrectly attaching itself to the first contenteditable that it found, even if it did not have the "#editable" ID that we are passing in out call to `CKEDITOR.inline`, and even if we pass the actual DOM object instead of passing the ID name.
- When you set the selection using this hack, the problem magically goes away.

I'd still like to try this with a non-debug build of CKEDITOR -- see https://github.com/liferay/alloy-editor/issues/1150 -- so I can see what the actual error that is being thrown is, but for now it's just an inscrutable 'TypeError: "B is undefined"'.

Bonus: use Sinon sandboxes for better tear-down, and make tear-down in general more resilient.