### PR TITLE
Make it possible to run with non-minified CKEDITOR build

### DIFF
--- a/karma.common.js
+++ b/karma.common.js
@@ -17,16 +17,20 @@ if (!DEBUG) {
 	preprocessors['dist/alloy-editor/src/**/*.js'] = ['coverage'];
 }
 
+const CKEDITOR_DIR = DEBUG ? 'lib/ckeditor-debug' : 'dist/alloy-editor';
+
 const filesToLoad = [
 	/* AlloyEditor skins */
 	'dist/alloy-editor/assets/alloy-editor-ocean.css',
 
-	/* CKEditor JS files */
-	'dist/alloy-editor/ckeditor.js',
-	'dist/alloy-editor/styles.js',
-	'dist/alloy-editor/config.js',
-	'dist/alloy-editor/skins/moono/*.css',
-	'dist/alloy-editor/lang/*.js',
+	/* CKEditor files */
+	`${CKEDITOR_DIR}/ckeditor.js`,
+	`${CKEDITOR_DIR}/styles.js`,
+	`${CKEDITOR_DIR}/config.js`,
+	`${CKEDITOR_DIR}/lang/*.js`,
+	`${CKEDITOR_DIR}/skins/moono/*.css`,
+
+
 	'test/ui/test/plugins/test_*/plugin.js',
 
 	/* bender requires CKEDITOR, should be after ckeditor.js */

--- a/karma.common.js
+++ b/karma.common.js
@@ -30,7 +30,6 @@ const filesToLoad = [
 	`${CKEDITOR_DIR}/lang/*.js`,
 	`${CKEDITOR_DIR}/skins/moono/*.css`,
 
-
 	'test/ui/test/plugins/test_*/plugin.js',
 
 	/* bender requires CKEDITOR, should be after ckeditor.js */


### PR DESCRIPTION
While working on #1148 some of the tests would end up throwing exceptions deep inside the minified CKEDITOR source. You can get the debugger to "pretty print", but it's still super hard to find your way around because all the variable names are minified.

Test plan: `npm run test` (all pass), `npm run test:debug` (see all pass except for two pre-existing failures, and see via the browser dev tools that the CKEDITOR source is unminified).

Builds on: https://github.com/liferay/alloy-editor/pull/1155

Closes: https://github.com/liferay/alloy-editor/issues/1150