### PR TITLE
Streamline and fool-proof-ize the clean up of Sinon stubs

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -41,6 +41,7 @@ module.exports = function() {
 		'test/lib/globals.js',
 		'test/lib/utils.js',
 		'test/lib/karma-overrides.js',
+		'test/lib/mocha.js',
 		'src/adapter/main.js',
 		'src/core/debounce.js',
 		'src/core/link.js',

--- a/test/lib/mocha.js
+++ b/test/lib/mocha.js
@@ -1,0 +1,19 @@
+/**
+ * Global "beforeEach" hook.
+ */
+beforeEach(() => {
+	// Nothing here, yet.
+});
+
+/**
+ * Global "afterEach" hook.
+ */
+afterEach(() => {
+	/**
+	 * As of Sinon v5, "sinon" is a default sandbox, which means we can
+	 * clean up all stubs transparently with a single call.
+	 *
+	 * See: https://sinonjs.org/releases/latest/sandbox/
+	 */
+	sinon.restore();
+});

--- a/test/plugins/test/embed.js
+++ b/test/plugins/test/embed.js
@@ -1,7 +1,5 @@
 var assert = chai.assert;
 
-var sandbox = sinon.createSandbox();
-
 function applyFirefoxHack(nativeEditor) {
 	// Hack for Firefox.
 	// If a contenteditable has been in the DOM before this test runs,
@@ -15,15 +13,12 @@ describe('Embed plugin', function() {
 		Utils.createCKEditor.call(this, done, {extraPlugins: 'ae_embed'});
 	});
 
-	afterEach(function(done) {
-		sandbox.restore();
-		Utils.destroyCKEditor.call(this, done);
-	});
+	afterEach(Utils.destroyCKEditor);
 
 	it('should not convert links inside content', function() {
 		var nativeEditor = this.nativeEditor;
 
-		var spy = sandbox.spy(nativeEditor, 'execCommand');
+		var spy = sinon.spy(nativeEditor, 'execCommand');
 
 		bender.tools.selection.setWithHtml(
 			nativeEditor,
@@ -43,7 +38,7 @@ describe('Embed plugin', function() {
 		var tweetReturnHtml =
 			'<blockquote class="twitter-tweet" align="center">Hello Earth! Can you hear me?</blockquote>';
 
-		sandbox
+		sinon
 			.stub(CKEDITOR.tools, 'jsonp')
 			.callsFake(function(fn, data, success, fail) {
 				success({html: tweetReturnHtml, provider_name: 'Twitter'});
@@ -69,7 +64,7 @@ describe('Embed plugin', function() {
 		var tweetReturnHtml =
 			'<blockquote class="twitter-tweet" align="center">Hello Earth! Can you hear me?</blockquote>';
 
-		sandbox
+		sinon
 			.stub(CKEDITOR.tools, 'jsonp')
 			.callsFake(function(fn, data, success, fail) {
 				success({html: tweetReturnHtml, provider_name: 'YouTube'});
@@ -95,7 +90,7 @@ describe('Embed plugin', function() {
 		var tweetReturnHtml =
 			'<blockquote class="twitter-tweet" align="center">Hello Earth! Can you hear me?</blockquote>';
 
-		sandbox
+		sinon
 			.stub(CKEDITOR.tools, 'jsonp')
 			.callsFake(function(fn, data, success, fail) {
 				success({
@@ -108,7 +103,7 @@ describe('Embed plugin', function() {
 
 		var isCalled = false;
 
-		sandbox.stub(nativeEditor, 'insertHtml').callsFake(function() {
+		sinon.stub(nativeEditor, 'insertHtml').callsFake(function() {
 			isCalled = true;
 			return;
 		});
@@ -125,7 +120,7 @@ describe('Embed plugin', function() {
 	it('should create a tag with url as href when url is pasted and there is a connection error', function() {
 		var url = 'https://foo.com';
 
-		sandbox
+		sinon
 			.stub(CKEDITOR.tools, 'jsonp')
 			.callsFake(function(fn, data, success, fail) {
 				fail({});
@@ -135,7 +130,7 @@ describe('Embed plugin', function() {
 
 		var isCalled = false;
 
-		sandbox.stub(nativeEditor, 'insertHtml').callsFake(function() {
+		sinon.stub(nativeEditor, 'insertHtml').callsFake(function() {
 			isCalled = true;
 			return;
 		});

--- a/test/ui/test/alloy-editor.js
+++ b/test/ui/test/alloy-editor.js
@@ -233,8 +233,6 @@ describe('AlloyEditor', function() {
 
 			happen.click(document.getElementById('link_foo'));
 
-			stub.restore();
-
 			assert.isTrue(stub.calledOnce);
 		});
 

--- a/test/ui/test/button-embed-edit.jsx
+++ b/test/ui/test/button-embed-edit.jsx
@@ -12,16 +12,10 @@ var KEY_ESC = 27;
 
 var getFixture = Utils.getFixture('test/ui/test/fixtures');
 
-var sandbox = sinon.createSandbox();
-
 describe('ButtonEmbedEdit Component', function() {
 	beforeEach(Utils.createAlloyEditor);
 
-	afterEach(function(done) {
-		sandbox.restore();
-
-		Utils.destroyAlloyEditor.call(this, done);
-	});
+	afterEach(Utils.destroyAlloyEditor);
 
 	it('focuses on the link input as soon as the component gets rendered', function(done) {
 		// On IE9 window.requestAnimationFrame does not exist. Avoid this test on IE9
@@ -30,7 +24,7 @@ describe('ButtonEmbedEdit Component', function() {
 			return;
 		}
 		// Make requestAnimationFrame synchronous to avoid unnecessary test delays
-		var stub = sandbox
+		sinon
 			.stub(window, 'requestAnimationFrame')
 			.callsFake(function(callback) {
 				callback();
@@ -40,8 +34,6 @@ describe('ButtonEmbedEdit Component', function() {
 			<ButtonEmbedEdit renderExclusive={true} />,
 			this.container
 		);
-
-		stub.restore();
 
 		assert.strictEqual(
 			document.activeElement,
@@ -54,7 +46,7 @@ describe('ButtonEmbedEdit Component', function() {
 	it('focuses on the link input as soon as the component gets rendered in older browsers', function() {
 		// Make setTimeout synchronous to avoid unnecessary test delays
 		var requestAnimationFrame = window.requestAnimationFrame;
-		var stub = sandbox
+		sinon
 			.stub(window, 'setTimeout')
 			.callsFake(function(callback) {
 				callback();
@@ -68,7 +60,6 @@ describe('ButtonEmbedEdit Component', function() {
 		);
 
 		window.requestAnimationFrame = requestAnimationFrame;
-		stub.restore();
 
 		assert.strictEqual(
 			document.activeElement,
@@ -164,7 +155,7 @@ describe('ButtonEmbedEdit Component', function() {
 	});
 
 	it('clears the link input when the remove button inside the link input is clicked', function() {
-		var cancelExclusive = sandbox.stub();
+		var cancelExclusive = sinon.stub();
 
 		var buttonEmbedEdit = this.render(
 			<ButtonEmbedEdit
@@ -193,7 +184,7 @@ describe('ButtonEmbedEdit Component', function() {
 	});
 
 	it('updates the embed content when the embed url is changed', function() {
-		sandbox
+		sinon
 			.stub(CKEDITOR.tools, 'jsonp')
 			.callsFake(function(fn, data, success, fail) {
 				success({
@@ -203,7 +194,7 @@ describe('ButtonEmbedEdit Component', function() {
 
 		var buttonEmbedEdit = this.render(
 			<ButtonEmbedEdit
-				cancelExclusive={sandbox.stub()}
+				cancelExclusive={sinon.stub()}
 				renderExclusive={true}
 			/>,
 			this.container
@@ -235,7 +226,7 @@ describe('ButtonEmbedEdit Component', function() {
 	});
 
 	it('changes the embed content when the KEY_ENTER is pressed inside the link input', function() {
-		sandbox
+		sinon
 			.stub(CKEDITOR.tools, 'jsonp')
 			.callsFake(function(fn, data, success, fail) {
 				success({
@@ -245,7 +236,7 @@ describe('ButtonEmbedEdit Component', function() {
 
 		var buttonEmbedEdit = this.render(
 			<ButtonEmbedEdit
-				cancelExclusive={sandbox.stub()}
+				cancelExclusive={sinon.stub()}
 				renderExclusive={true}
 			/>,
 			this.container
@@ -276,7 +267,7 @@ describe('ButtonEmbedEdit Component', function() {
 	});
 
 	it('close the toolbar when KEY_ESC is pressed inside the link input', function() {
-		var spy = sandbox.spy();
+		var spy = sinon.spy();
 
 		var buttonEmbedEdit = this.render(
 			<ButtonEmbedEdit cancelExclusive={spy} renderExclusive={true} />,


### PR DESCRIPTION
Sinon has a "sandbox" feature that allows you to create stubs anywhere and then clean them up with a single call to `sandbox.restore()`. I just learned that as of v5, the `sinon` object is itself a sandbox, which means that we can:

1. Remove the places where we manually set up a new sandbox and just call `sinon.stub()` etc directly.
2. Add a `sinon.restore()` call in a global "afterHook" and be sure that clean-up is never forgotten.
3. Remove existing scattered calls to `restore()`.

See:

    https://sinonjs.org/releases/latest/sandbox/

Test plan: `npm run build && npm run test:debug` and see all tests pass.