### PR TITLE
Update to react/react-dom 16.8.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "alloyeditor",
-  "version": "2.0.0-alpha.5",
+  "version": "2.0.0-beta.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -9543,25 +9543,25 @@
       }
     },
     "react": {
-      "version": "16.8.1",
-      "resolved": "https://registry.npmjs.org/react/-/react-16.8.1.tgz",
-      "integrity": "sha512-wLw5CFGPdo7p/AgteFz7GblI2JPOos0+biSoxf1FPsGxWQZdN/pj6oToJs1crn61DL3Ln7mN86uZ4j74p31ELQ==",
+      "version": "16.8.3",
+      "resolved": "https://registry.npmjs.org/react/-/react-16.8.3.tgz",
+      "integrity": "sha512-3UoSIsEq8yTJuSu0luO1QQWYbgGEILm+eJl2QN/VLDi7hL+EN18M3q3oVZwmVzzBJ3DkM7RMdRwBmZZ+b4IzSA==",
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
         "prop-types": "^15.6.2",
-        "scheduler": "^0.13.1"
+        "scheduler": "^0.13.3"
       }
     },
     "react-dom": {
-      "version": "16.8.1",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.8.1.tgz",
-      "integrity": "sha512-N74IZUrPt6UiDjXaO7UbDDFXeUXnVhZzeRLy/6iqqN1ipfjrhR60Bp5NuBK+rv3GMdqdIuwIl22u1SYwf330bg==",
+      "version": "16.8.3",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.8.3.tgz",
+      "integrity": "sha512-ttMem9yJL4/lpItZAQ2NTFAbV7frotHk5DZEHXUOws2rMmrsvh1Na7ThGT0dTzUIl6pqTOi5tYREfL8AEna3lA==",
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
         "prop-types": "^15.6.2",
-        "scheduler": "^0.13.1"
+        "scheduler": "^0.13.3"
       }
     },
     "read-pkg": {
@@ -10104,9 +10104,9 @@
       "dev": true
     },
     "scheduler": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.13.1.tgz",
-      "integrity": "sha512-VJKOkiKIN2/6NOoexuypwSrybx13MY7NSy9RNt8wPvZDMRT1CW6qlpF5jXRToXNHz3uWzbm2elNpZfXfGPqP9A==",
+      "version": "0.13.3",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.13.3.tgz",
+      "integrity": "sha512-UxN5QRYWtpR1egNWzJcVLk8jlegxAugswQc984lD3kU7NuobsO37/sRfbpTdBjtnD5TBNFA2Q2oLV5+UmPSmEQ==",
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"

--- a/package.json
+++ b/package.json
@@ -89,8 +89,8 @@
   "dependencies": {
     "clay-css": "2.5.1",
     "prop-types": "^15.6.2",
-    "react": "16.8.1",
-    "react-dom": "16.8.1",
+    "react": "^16.8.3",
+    "react-dom": "^16.8.3",
     "val-loader": "1.1.1"
   }
 }


### PR DESCRIPTION
As well as adding "^" to the version range, which should be totally safe with React because they follow semver very rigorously.

Test plan: sanity check by running `npm run build && npm run test:debug`