### PR TITLE
Fixes #1160 Add transitionend event to enable pointerEvents

### DIFF
--- a/src/components/base/widget-position.js
+++ b/src/components/base/widget-position.js
@@ -319,6 +319,7 @@ export default WrappedComponent =>
 				left: startPoint[0] + 'px',
 				top: startPoint[1] + 'px',
 				opacity: 0,
+				pointerEvents: 'none',
 			});
 
 			domElement.removeClass('alloy-editor-invisible');
@@ -332,6 +333,14 @@ export default WrappedComponent =>
 					opacity: 1,
 				});
 			});
+
+			if(domElement.$){
+				domElement.$.addEventListener('transitionend', () =>{
+					domElement.setStyles({
+						pointerEvents: '',
+					});
+				})
+			}
 		}
 
 		/**

--- a/src/components/base/widget-position.js
+++ b/src/components/base/widget-position.js
@@ -334,8 +334,8 @@ export default WrappedComponent =>
 				});
 			});
 
-			if(domElement.$){
-				domElement.$.addEventListener('transitionend', () =>{
+			if (domElement.$) {
+				domElement.$.addEventListener('transitionend', () => {
 					domElement.setStyles({
 						pointerEvents: '',
 					});


### PR DESCRIPTION
https://github.com/liferay/alloy-editor/issues/1160
https://issues.liferay.com/browse/LPS-91194

I included `pointerEvents: 'none'` to the style to prevent any unwanted button selections. Then applied a `transitionend` event listener. Only when the transition has completed will the pointerEvents be removed and allow the user to interact with the toolbar.
Let me know if there are any questions or comments about this.

Thank you.