### PR TITLE
Make it convenient to check out website as worktree

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ node_modules
 public
 sauce_connect.log
 test-results.xml
+/website/


### PR DESCRIPTION
So that you can run `git worktree add website origin/website` (or similar) and have a handy checkout of the website branch in a way that doesn't interfere with work on the master branch.