### PR TITLE
Update to eslint-config-liferay v3.0.0-rc.0

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+src/__generated__/*

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -65,6 +65,7 @@ module.exports = {
 		'no-for-of-loops/no-for-of-loops': 'error',
 		'no-unused-vars': ['error', {argsIgnorePattern: '^_'}],
 		'react/prop-types': 'warn',
+		'sort-keys': 'off',
 		'valid-jsdoc': 'warn',
 	},
 	settings: {

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -13,7 +13,7 @@ module.exports = {
 		},
 	},
 	extends: ['plugin:react/recommended', 'liferay', 'prettier'],
-	plugins: ['babel', 'no-for-of-loops'],
+	plugins: ['babel'],
 	rules: {
 		'require-jsdoc': 'warn',
 		'new-cap': [
@@ -62,8 +62,6 @@ module.exports = {
 		'babel/no-invalid-this': 'error',
 		'no-inner-declarations': 'off',
 		'no-invalid-this': 'off',
-		'no-for-of-loops/no-for-of-loops': 'error',
-		'no-unused-vars': ['error', {argsIgnorePattern: '^_'}],
 		'react/prop-types': 'warn',
 		'sort-keys': 'off',
 		'valid-jsdoc': 'warn',

--- a/package-lock.json
+++ b/package-lock.json
@@ -3726,20 +3726,35 @@
         }
       }
     },
-    "eslint-config-google": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/eslint-config-google/-/eslint-config-google-0.9.1.tgz",
-      "integrity": "sha512-5A83D+lH0PA81QMESKbLJd/a3ic8tPZtwUmqNrxMRo54nfFaUvtt89q/+icQ+fd66c2xQHn0KyFkzJDoAUfpZA==",
-      "dev": true
-    },
     "eslint-config-liferay": {
-      "version": "2.0.18",
-      "resolved": "https://registry.npmjs.org/eslint-config-liferay/-/eslint-config-liferay-2.0.18.tgz",
-      "integrity": "sha512-/LgEpL+e6o6NWhctGhG6k1ELJ+3qCGZuPYpyO/7CC68rrR+GZRfK6t+qYUJAYnUw1tu4yOQQ93nna3jqZYL9CA==",
+      "version": "3.0.0-rc.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-liferay/-/eslint-config-liferay-3.0.0-rc.0.tgz",
+      "integrity": "sha512-jJW8ZRQl3C+wonEp35wDkqvPC3RteMXUilWxefQzagr1siZjgzbP9O1f+yUGZozpOEQf08SWHpGHEZ81b9KpyA==",
       "dev": true,
       "requires": {
-        "eslint-config-google": "^0.9.1",
-        "eslint-plugin-liferayportal": "^1.0.0"
+        "eslint-config-prettier": "4.1.0",
+        "eslint-plugin-liferayportal": "^1.0.0",
+        "eslint-plugin-no-for-of-loops": "^1.0.0",
+        "eslint-plugin-no-only-tests": "^2.1.0",
+        "eslint-plugin-notice": "0.7.8",
+        "eslint-plugin-sort-destructure-keys": "^1.2.0"
+      },
+      "dependencies": {
+        "eslint-config-prettier": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-4.1.0.tgz",
+          "integrity": "sha512-zILwX9/Ocz4SV2vX7ox85AsrAgXV3f2o2gpIicdMIOra48WYqgUnWNH/cR/iHtmD2Vb3dLSC3LiEJnS05Gkw7w==",
+          "dev": true,
+          "requires": {
+            "get-stdin": "^6.0.0"
+          }
+        },
+        "get-stdin": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
+          "integrity": "sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==",
+          "dev": true
+        }
       }
     },
     "eslint-config-prettier": {
@@ -3783,6 +3798,23 @@
       "integrity": "sha1-oT2RqPGSL3/v7eqzUdwAVZlGAfY=",
       "dev": true
     },
+    "eslint-plugin-no-only-tests": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-no-only-tests/-/eslint-plugin-no-only-tests-2.1.0.tgz",
+      "integrity": "sha512-T02dNNDj7sKJNvH7YLKqgv4+BDupxKG4OgadF0AecDHrYTb9hlosxqCgZbFKt28C7Ueof6ziCtEh6rnPvN4YYA==",
+      "dev": true
+    },
+    "eslint-plugin-notice": {
+      "version": "0.7.8",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-notice/-/eslint-plugin-notice-0.7.8.tgz",
+      "integrity": "sha512-a18VwxiBp4TmXRVpx7T5D4ilHnMS1Gq/5OMUriCcJGHD72Cbji7qVk19DGOW9vBHnJJKeg0yU95a7/o8JQoMCw==",
+      "dev": true,
+      "requires": {
+        "find-root": "^1.1.0",
+        "lodash": ">=2.4.0",
+        "metric-lcs": "^0.1.2"
+      }
+    },
     "eslint-plugin-react": {
       "version": "7.12.4",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.12.4.tgz",
@@ -3796,6 +3828,15 @@
         "object.fromentries": "^2.0.0",
         "prop-types": "^15.6.2",
         "resolve": "^1.9.0"
+      }
+    },
+    "eslint-plugin-sort-destructure-keys": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-sort-destructure-keys/-/eslint-plugin-sort-destructure-keys-1.2.0.tgz",
+      "integrity": "sha512-2rvRzhImWcq9r0hBojlvzCKlT7lYLrHCH/N37GWu7SKdn3G0PbEIXLt5pdHY6I4F49bmBQr1+7cBMM8XWv0xgQ==",
+      "dev": true,
+      "requires": {
+        "natural-compare-lite": "^1.4.0"
       }
     },
     "eslint-rule-composer": {
@@ -4395,6 +4436,12 @@
         "make-dir": "^1.0.0",
         "pkg-dir": "^2.0.0"
       }
+    },
+    "find-root": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
+      "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==",
+      "dev": true
     },
     "find-up": {
       "version": "2.1.0",
@@ -7596,6 +7643,12 @@
       "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
       "dev": true
     },
+    "metric-lcs": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/metric-lcs/-/metric-lcs-0.1.2.tgz",
+      "integrity": "sha512-+TZ5dUDPKPJaU/rscTzxyN8ZkX7eAVLAiQU/e+YINleXPv03SCmJShaMT1If1liTH8OcmWXZs0CmzCBRBLcMpA==",
+      "dev": true
+    },
     "micromatch": {
       "version": "3.1.10",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
@@ -8020,6 +8073,12 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+      "dev": true
+    },
+    "natural-compare-lite": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare-lite/-/natural-compare-lite-1.4.0.tgz",
+      "integrity": "sha1-F7CVgZiJef3a/gIB6TG6kzyWy7Q=",
       "dev": true
     },
     "negotiator": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "chai": "4.2.0",
     "del": "^3.0.0",
     "eslint": "5.12.1",
-    "eslint-config-liferay": "2.0.18",
+    "eslint-config-liferay": "3.0.0-rc.0",
     "eslint-config-prettier": "3.6.0",
     "eslint-plugin-babel": "5.3.0",
     "eslint-plugin-no-for-of-loops": "1.0.0",

--- a/src/adapter/core.js
+++ b/src/adapter/core.js
@@ -44,14 +44,14 @@ extend(
 		 * @method initializer
 		 * @param {Object} config Configuration object literal for the editor.
 		 */
-		initializer: function(config) {
-			let node = this.get('srcNode');
+		initializer(config) {
+			const node = this.get('srcNode');
 
 			if (this.get('enableContentEditable')) {
 				node.setAttribute('contenteditable', 'true');
 			}
 
-			let editor = CKEDITOR.inline(node);
+			const editor = CKEDITOR.inline(node);
 
 			editor.config.allowedContent = this.get('allowedContent');
 
@@ -95,9 +95,9 @@ extend(
 				function() {
 					this._addReadOnlyLinkClickListener(editor);
 
-					let editable = editor.editable();
+					const editable = editor.editable();
 
-					let extraCommands = this.get('extraCommands');
+					const extraCommands = this.get('extraCommands');
 
 					const extraCommandKeys = Object.keys(extraCommands);
 					for (let i = 0; i < extraCommandKeys.length; i++) {
@@ -131,7 +131,7 @@ extend(
 		 * @protected
 		 * @method destructor
 		 */
-		destructor: function() {
+		destructor() {
 			this._destroyed = true;
 
 			if (this._editorUIElement) {
@@ -141,10 +141,10 @@ extend(
 				);
 			}
 
-			let nativeEditor = this.get('nativeEditor');
+			const nativeEditor = this.get('nativeEditor');
 
 			if (nativeEditor) {
-				let editable = nativeEditor.editable();
+				const editable = nativeEditor.editable();
 
 				if (editable) {
 					editable.removeClass('ae-editable');
@@ -171,9 +171,9 @@ extend(
 		 * @protected
 		 * @method _clearSelections
 		 */
-		_clearSelections: function() {
-			let nativeEditor = this.get('nativeEditor');
-			let isMSSelection = typeof window.getSelection != 'function';
+		_clearSelections() {
+			const nativeEditor = this.get('nativeEditor');
+			const isMSSelection = typeof window.getSelection != 'function';
 
 			if (isMSSelection) {
 				nativeEditor.document.$.selection.empty();
@@ -194,9 +194,9 @@ extend(
 		 * @method _addReadOnlyLinkClickListener
 		 * @param {Object} editor
 		 */
-		_addReadOnlyLinkClickListener: function(editor) {
+		_addReadOnlyLinkClickListener(editor) {
 			editor.editable().on('click', this._defaultReadOnlyClickFn, this, {
-				editor: editor,
+				editor,
 			});
 		},
 
@@ -211,10 +211,10 @@ extend(
 		 * @method _defaultReadOnlyClickFn
 		 * @param {Object} event The fired `click` event payload
 		 */
-		_defaultReadOnlyClickFn: function(event) {
-			let mouseEvent = event.data.$;
-			let hasCtrlKey = mouseEvent.ctrlKey || mouseEvent.metaKey;
-			let shouldOpen = this._editor.config.readOnly || hasCtrlKey;
+		_defaultReadOnlyClickFn(event) {
+			const mouseEvent = event.data.$;
+			const hasCtrlKey = mouseEvent.ctrlKey || mouseEvent.metaKey;
+			const shouldOpen = this._editor.config.readOnly || hasCtrlKey;
 
 			mouseEvent.preventDefault();
 
@@ -227,17 +227,17 @@ extend(
 					.editable()
 					.editor.fire('readOnlyClick', event.data) !== false
 			) {
-				let ckElement = new CKEDITOR.dom.elementPath(
+				const ckElement = new CKEDITOR.dom.elementPath(
 					event.data.getTarget(),
 					this
 				);
-				let link = ckElement.lastElement;
+				const link = ckElement.lastElement;
 
 				if (link) {
-					let href = link.$.attributes.href
+					const href = link.$.attributes.href
 						? link.$.attributes.href.value
 						: null;
-					let target = hasCtrlKey
+					const target = hasCtrlKey
 						? '_blank'
 						: link.$.attributes.target
 						? link.$.attributes.target.value
@@ -256,7 +256,7 @@ extend(
 		 * @method _getNativeEditor
 		 * @return {Object} The current instance of CKEditor.
 		 */
-		_getNativeEditor: function() {
+		_getNativeEditor() {
 			return this._editor;
 		},
 
@@ -270,7 +270,7 @@ extend(
 		 * @param {string} href The href to take the browser to
 		 * @param {string=} target Specifies where to display the link
 		 */
-		_redirectLink: function(href, target) {
+		_redirectLink(href, target) {
 			if (target && href) {
 				window.open(href, target);
 			} else if (href) {
@@ -286,12 +286,12 @@ extend(
 		 * @protected
 		 * @method _renderUI
 		 */
-		_renderUI: function() {
+		_renderUI() {
 			if (!this._destroyed) {
-				let editorUIElement = document.createElement('div');
+				const editorUIElement = document.createElement('div');
 				editorUIElement.className = 'ae-ui';
 
-				let uiNode = this.get('uiNode') || document.body;
+				const uiNode = this.get('uiNode') || document.body;
 
 				uiNode.appendChild(editorUIElement);
 
@@ -330,7 +330,7 @@ extend(
 		 * or the HTML element itself. If Id is passed, the HTML element will be retrieved from the DOM.
 		 * @return {HTMLElement} An HTML element.
 		 */
-		_toElement: function(value) {
+		_toElement(value) {
 			if (Lang.isString(value)) {
 				value = document.getElementById(value);
 			}
@@ -350,7 +350,7 @@ extend(
 		 * @param {Any} value The value to be checked
 		 * @return {Boolean} True if the current value is valid configuration, false otherwise
 		 */
-		_validateAllowedContent: function(value) {
+		_validateAllowedContent(value) {
 			return (
 				Lang.isString(value) ||
 				Lang.isObject(value) ||
@@ -368,7 +368,7 @@ extend(
 		 * @param {Any} value The value to be checked
 		 * @return {Boolean} True if the current value is valid toolbars configuration, false otherwise
 		 */
-		_validateToolbars: function(value) {
+		_validateToolbars(value) {
 			return Lang.isObject(value) || Lang.isNull(value);
 		},
 	},

--- a/src/adapter/main.js
+++ b/src/adapter/main.js
@@ -14,7 +14,7 @@ import extend from '../oop/oop';
 import '../plugins';
 
 // An object containing all currently registered plugins in AlloyEditor.
-let BRIDGE_BUTTONS = {};
+const BRIDGE_BUTTONS = {};
 
 /**
  * Creates an instance of AlloyEditor.
@@ -51,10 +51,10 @@ const getBasePath = function() {
 	let path = window.ALLOYEDITOR_BASEPATH || '';
 
 	if (!path) {
-		let scripts = document.getElementsByTagName('script');
+		const scripts = document.getElementsByTagName('script');
 
 		for (let i = 0; i < scripts.length; i++) {
-			let match = scripts[i].src.match(AlloyEditor.regexBasePath);
+			const match = scripts[i].src.match(AlloyEditor.regexBasePath);
 
 			if (match) {
 				path = match[1];
@@ -110,7 +110,7 @@ const loadLanguageResources = function(callback) {
 	if (!AlloyEditor._langResourceRequested) {
 		AlloyEditor._langResourceRequested = true;
 
-		let languages = [
+		const languages = [
 			'af',
 			'ar',
 			'bg',
@@ -179,11 +179,14 @@ const loadLanguageResources = function(callback) {
 			'zh',
 		];
 
-		let userLanguage = navigator.language || navigator.userLanguage || 'en';
+		const userLanguage =
+			navigator.language || navigator.userLanguage || 'en';
 
-		let parts = userLanguage.toLowerCase().match(/([a-z]+)(?:-([a-z]+))?/);
+		const parts = userLanguage
+			.toLowerCase()
+			.match(/([a-z]+)(?:-([a-z]+))?/);
 		let lang = parts[1];
-		let locale = parts[2];
+		const locale = parts[2];
 
 		if (languages.indexOf(lang + '-' + locale) >= 0) {
 			lang = lang + '-' + locale;
@@ -218,7 +221,7 @@ const loadLanguageResources = function(callback) {
  * @return {String} The full URL.
  */
 const getUrl = function(resource) {
-	let basePath = AlloyEditor.getBasePath();
+	const basePath = AlloyEditor.getBasePath();
 
 	// If this is not a full or absolute path.
 	if (resource.indexOf(':/') === -1 && resource.indexOf('/') !== 0) {

--- a/src/components/base/button-keystroke.js
+++ b/src/components/base/button-keystroke.js
@@ -34,7 +34,7 @@ export default WrappedComponent =>
 			if (!command) {
 				command = new CKEDITOR.command(nativeEditor, {
 					exec: function(editor) {
-						let keystrokeFn = keystroke.fn;
+						const keystrokeFn = keystroke.fn;
 
 						if (Lang.isString(keystrokeFn)) {
 							this[keystrokeFn].call(this, editor);

--- a/src/components/base/button-style.js
+++ b/src/components/base/button-style.js
@@ -26,7 +26,7 @@ export default WrappedComponent =>
 			let style = this.props.style;
 
 			if (Lang.isString(style)) {
-				let parts = style.split('.');
+				const parts = style.split('.');
 				let currentMember = this.context.editor.get('nativeEditor')
 					.config;
 				let property = parts.shift();

--- a/src/components/base/toolbar-buttons.js
+++ b/src/components/base/toolbar-buttons.js
@@ -48,16 +48,16 @@ export default WrappedComponent =>
 		 * @return {Array} An Array which contains the buttons that should be rendered.
 		 */
 		getToolbarButtons(buttons, additionalProps) {
-			let buttonProps = {};
+			const buttonProps = {};
 
-			let nativeEditor = this.context.editor.get('nativeEditor');
-			let buttonCfg = nativeEditor.config.buttonCfg || {};
+			const nativeEditor = this.context.editor.get('nativeEditor');
+			const buttonCfg = nativeEditor.config.buttonCfg || {};
 
 			if (Lang.isFunction(buttons)) {
 				buttons = buttons.call(this) || [];
 			}
 
-			let toolbarButtons = this.filterExclusive(
+			const toolbarButtons = this.filterExclusive(
 				buttons
 					.filter(function(button) {
 						return (

--- a/src/components/base/widget-exclusive.js
+++ b/src/components/base/widget-exclusive.js
@@ -104,7 +104,7 @@ export default WrappedComponent =>
 		 */
 		requestExclusive = itemExclusive => {
 			this.setState({
-				itemExclusive: itemExclusive,
+				itemExclusive,
 			});
 		};
 	};

--- a/src/components/base/widget-focus-manager.js
+++ b/src/components/base/widget-focus-manager.js
@@ -1,13 +1,13 @@
 import Lang from '../../oop/lang';
 import ReactDOM from 'react-dom';
 
-let DIRECTION_NONE = 0;
-let DIRECTION_NEXT = 1;
-let DIRECTION_PREV = -1;
+const DIRECTION_NONE = 0;
+const DIRECTION_NEXT = 1;
+const DIRECTION_PREV = -1;
 
-let ACTION_NONE = 0;
-let ACTION_MOVE_FOCUS = 1;
-let ACTION_DISMISS_FOCUS = 2;
+const ACTION_NONE = 0;
+const ACTION_MOVE_FOCUS = 1;
+const ACTION_DISMISS_FOCUS = 2;
 
 /**
  * WidgetFocusManager is a mixin that provides keyboard navigation inside a widget. To do this,
@@ -61,7 +61,7 @@ export default WrappedComponent =>
 		focus = event => {
 			if (!event || this._isValidTarget(event.target)) {
 				if (this._descendants && this._descendants.length) {
-					let activeDescendantEl = this._descendants[
+					const activeDescendantEl = this._descendants[
 						this._activeDescendant
 					];
 					// When user clicks with the mouse, the activeElement is already set and there
@@ -99,7 +99,7 @@ export default WrappedComponent =>
 		 */
 		handleKey = event => {
 			if (this._isValidTarget(event.target) && this._descendants) {
-				let action = this._getFocusAction(event);
+				const action = this._getFocusAction(event);
 
 				if (action.type) {
 					event.stopPropagation();
@@ -142,19 +142,19 @@ export default WrappedComponent =>
 		 * @return {Object} An action object with type and direction properties.
 		 */
 		_getFocusAction(event) {
-			let action = {
+			const action = {
 				type: ACTION_NONE,
 			};
 
 			if (this.props.keys) {
-				let direction = this._getFocusMoveDirection(event);
+				const direction = this._getFocusMoveDirection(event);
 
 				if (direction) {
 					action.direction = direction;
 					action.type = ACTION_MOVE_FOCUS;
 				}
 
-				let dismissAction = this._getFocusDismissAction(
+				const dismissAction = this._getFocusDismissAction(
 					event,
 					direction
 				);
@@ -185,7 +185,7 @@ export default WrappedComponent =>
 		 * @return {Object} A dismiss action with dismiss and direction properties.
 		 */
 		_getFocusDismissAction(event, focusMoveDirection) {
-			let dismissAction = {
+			const dismissAction = {
 				direction: focusMoveDirection,
 				dismiss: false,
 			};
@@ -281,7 +281,7 @@ export default WrappedComponent =>
 		 * @return {Boolean} A boolean value indicating if the element is valid.
 		 */
 		_isValidTarget(element) {
-			let tagName = element.tagName.toLowerCase();
+			const tagName = element.tagName.toLowerCase();
 
 			return (
 				tagName !== 'input' &&
@@ -300,7 +300,7 @@ export default WrappedComponent =>
 		 * @protected
 		 */
 		_moveFocus(direction) {
-			let numDescendants = this._descendants.length;
+			const numDescendants = this._descendants.length;
 
 			let descendant = this._descendants[this._activeDescendant];
 
@@ -337,10 +337,10 @@ export default WrappedComponent =>
 		 * @protected
 		 */
 		_refresh() {
-			let domNode = ReactDOM.findDOMNode(this);
+			const domNode = ReactDOM.findDOMNode(this);
 
 			if (domNode) {
-				let descendants = domNode.querySelectorAll(
+				const descendants = domNode.querySelectorAll(
 					this.props.descendants
 				);
 
@@ -350,7 +350,7 @@ export default WrappedComponent =>
 
 				Array.prototype.slice.call(descendants).forEach(
 					function(item) {
-						let dataTabIndex = item.getAttribute('data-tabindex');
+						const dataTabIndex = item.getAttribute('data-tabindex');
 
 						if (dataTabIndex) {
 							priorityDescendants.push(item);

--- a/src/components/base/widget-position.js
+++ b/src/components/base/widget-position.js
@@ -74,8 +74,8 @@ export default WrappedComponent =>
 			}
 
 			return {
-				x: x,
-				y: y,
+				x,
+				y,
 			};
 		}
 
@@ -98,7 +98,7 @@ export default WrappedComponent =>
 		 * CKEDITOR.SELECTION_BOTTOM_TO_TOP or CKEDITOR.SELECTION_TOP_TO_BOTTOM
 		 */
 		getInteractionPoint() {
-			let eventPayload = this.props.editorEvent
+			const eventPayload = this.props.editorEvent
 				? this.props.editorEvent.data
 				: null;
 
@@ -106,20 +106,20 @@ export default WrappedComponent =>
 				return;
 			}
 
-			let selectionData = eventPayload.selectionData;
+			const selectionData = eventPayload.selectionData;
 
-			let nativeEvent = eventPayload.nativeEvent;
+			const nativeEvent = eventPayload.nativeEvent;
 
-			let pos = {
+			const pos = {
 				x: eventPayload.nativeEvent.pageX,
 				y: selectionData.region.top,
 			};
 
 			let direction = selectionData.region.direction;
 
-			let endRect = selectionData.region.endRect;
+			const endRect = selectionData.region.endRect;
 
-			let startRect = selectionData.region.startRect;
+			const startRect = selectionData.region.startRect;
 
 			if (endRect && startRect && startRect.top === endRect.top) {
 				direction = CKEDITOR.SELECTION_BOTTOM_TO_TOP;
@@ -153,9 +153,9 @@ export default WrappedComponent =>
 			}
 
 			return {
-				direction: direction,
-				x: x,
-				y: y,
+				direction,
+				x,
+				y,
 			};
 		}
 
@@ -171,18 +171,18 @@ export default WrappedComponent =>
 		 * @return {Number} The calculated X point in page coordinates.
 		 */
 		_getXPoint(selectionData, eventX) {
-			let region = selectionData.region;
+			const region = selectionData.region;
 
-			let left = region.startRect ? region.startRect.left : region.left;
-			let right = region.endRect ? region.endRect.right : region.right;
+			const left = region.startRect ? region.startRect.left : region.left;
+			const right = region.endRect ? region.endRect.right : region.right;
 
 			let x;
 
 			if (left < eventX && right > eventX) {
 				x = eventX;
 			} else {
-				let leftDist = Math.abs(left - eventX);
-				let rightDist = Math.abs(right - eventX);
+				const leftDist = Math.abs(left - eventX);
+				const rightDist = Math.abs(right - eventX);
 
 				if (leftDist < rightDist) {
 					// user raised the mouse on left on the selection
@@ -210,7 +210,7 @@ export default WrappedComponent =>
 			let y = 0;
 
 			if (selectionData && nativeEvent) {
-				let elementTarget = new CKEDITOR.dom.element(
+				const elementTarget = new CKEDITOR.dom.element(
 					nativeEvent.target
 				);
 
@@ -244,9 +244,9 @@ export default WrappedComponent =>
 		 * @return {Array} An Array with left and top offsets in page coordinates.
 		 */
 		getWidgetXYPoint(left, top, direction) {
-			let domNode = ReactDOM.findDOMNode(this);
+			const domNode = ReactDOM.findDOMNode(this);
 
-			let gutter = this.props.gutter;
+			const gutter = this.props.gutter;
 
 			if (
 				direction === CKEDITOR.SELECTION_TOP_TO_BOTTOM ||
@@ -290,10 +290,10 @@ export default WrappedComponent =>
 		 * @return {Boolean} True if the widget is visible, false otherwise
 		 */
 		isVisible() {
-			let domNode = ReactDOM.findDOMNode(this);
+			const domNode = ReactDOM.findDOMNode(this);
 
 			if (domNode) {
-				let domElement = new CKEDITOR.dom.element(domNode);
+				const domElement = new CKEDITOR.dom.element(domNode);
 
 				return domElement.hasClass('alloy-editor-visible');
 			}
@@ -311,7 +311,7 @@ export default WrappedComponent =>
 		 * @param  {Object} endPoint The destination point for the movement.
 		 */
 		moveToPoint(startPoint, endPoint) {
-			let domElement = new CKEDITOR.dom.element(
+			const domElement = new CKEDITOR.dom.element(
 				ReactDOM.findDOMNode(this)
 			);
 
@@ -339,7 +339,7 @@ export default WrappedComponent =>
 					domElement.setStyles({
 						pointerEvents: '',
 					});
-				})
+				});
 			}
 		}
 
@@ -357,10 +357,10 @@ export default WrappedComponent =>
 			const scrollTop = uiNode ? uiNode.scrollTop : 0;
 
 			if (!this.isVisible() && domNode) {
-				let interactionPoint = this.getInteractionPoint();
+				const interactionPoint = this.getInteractionPoint();
 
 				if (interactionPoint) {
-					let domElement = new CKEDITOR.dom.element(domNode);
+					const domElement = new CKEDITOR.dom.element(domNode);
 
 					let finalX;
 					let finalY;
@@ -371,7 +371,7 @@ export default WrappedComponent =>
 					finalY = initialY = parseFloat(domElement.getStyle('top'));
 
 					if (this.props.constrainToViewport) {
-						let res = this.getConstrainedPosition({
+						const res = this.getConstrainedPosition({
 							height: parseFloat(domNode.offsetHeight),
 							left: finalX,
 							top: finalY,
@@ -406,28 +406,29 @@ export default WrappedComponent =>
 		 * @method updatePosition
 		 */
 		updatePosition() {
-			let interactionPoint = this.getInteractionPoint();
+			const interactionPoint = this.getInteractionPoint();
 
-			let domNode = ReactDOM.findDOMNode(this);
+			const domNode = ReactDOM.findDOMNode(this);
 
 			if (interactionPoint && domNode) {
-				let uiNode = this.context.editor.get('uiNode') || document.body;
-				let uiNodeStyle = getComputedStyle(uiNode);
-				let uiNodeMarginLeft = parseInt(
+				const uiNode =
+					this.context.editor.get('uiNode') || document.body;
+				const uiNodeStyle = getComputedStyle(uiNode);
+				const uiNodeMarginLeft = parseInt(
 					uiNodeStyle.getPropertyValue('margin-left'),
 					10
 				);
-				let uiNodeMarginRight = parseInt(
+				const uiNodeMarginRight = parseInt(
 					uiNodeStyle.getPropertyValue('margin-right'),
 					10
 				);
-				let totalWidth =
+				const totalWidth =
 					uiNodeMarginLeft + uiNode.clientWidth + uiNodeMarginRight;
 
-				let scrollTop =
+				const scrollTop =
 					uiNode.tagName !== 'BODY' ? uiNode.scrollTop : 0;
 
-				let xy = this.getWidgetXYPoint(
+				const xy = this.getWidgetXYPoint(
 					interactionPoint.x,
 					interactionPoint.y,
 					interactionPoint.direction

--- a/src/components/buttons/button-embed-edit.jsx
+++ b/src/components/buttons/button-embed-edit.jsx
@@ -93,7 +93,7 @@ class ButtonEmbedEdit extends React.Component {
 		return {
 			element: embed,
 			initialLink: {
-				href: href,
+				href,
 			},
 			linkHref: href,
 		};

--- a/src/components/buttons/button-icon.jsx
+++ b/src/components/buttons/button-icon.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import EditorContext from '../../adapter/editor-context';
 
-export default function ButtonIcon({symbol, className = ''}) {
+export default function ButtonIcon({className = '', symbol}) {
 	return (
 		<EditorContext.Consumer>
 			{({editor}) => {

--- a/src/components/buttons/button-image.jsx
+++ b/src/components/buttons/button-image.jsx
@@ -116,8 +116,8 @@ class ButtonImage extends React.Component {
 				editor.fire('actionPerformed', this);
 
 				const imageData = {
-					el: el,
-					file: file,
+					el,
+					file,
 				};
 
 				editor.fire('imageAdd', imageData);

--- a/src/components/buttons/button-link-autocomplete-list.jsx
+++ b/src/components/buttons/button-link-autocomplete-list.jsx
@@ -179,12 +179,12 @@ class ButtonLinkAutocompleteList extends React.Component {
 		const promise = Promise.resolve(this.props.data(this.props.term));
 
 		promise.then(items => {
-			if (items.length) {
-				!this.props.expanded && this.props.toggleDropdown();
+			if (items.length && !this.props.expanded) {
+				this.props.toggleDropdown();
 			}
 
 			this.setState({
-				items: items,
+				items,
 			});
 		});
 	}

--- a/src/components/buttons/button-link-edit.jsx
+++ b/src/components/buttons/button-link-edit.jsx
@@ -230,8 +230,8 @@ class ButtonLinkEdit extends React.Component {
 			autocompleteSelected: false,
 			element: link,
 			initialLink: {
-				href: href,
-				target: target,
+				href,
+				target,
 			},
 			linkHref: href,
 			linkTarget: target,

--- a/src/components/buttons/button-spacing.jsx
+++ b/src/components/buttons/button-spacing.jsx
@@ -94,7 +94,7 @@ class ButtonSpacing extends React.Component {
 
 		const buttonStylesProps = {
 			activeStyle: activeSpacing,
-			editor: editor,
+			editor,
 			onDismiss: toggleDropdown,
 			showRemoveStylesItem: false,
 			styles: spacings,

--- a/src/components/buttons/button-twitter.jsx
+++ b/src/components/buttons/button-twitter.jsx
@@ -109,7 +109,7 @@ class ButtonTwitter extends React.Component {
 			.getSelectedText()
 			.substring(0, MAX_TWEET_LENGTH);
 		const url = this.props.url;
-		let via = this.props.via;
+		const via = this.props.via;
 		let twitterHref =
 			'https://twitter.com/intent/tweet?text=' + selectedText;
 

--- a/src/components/main.jsx
+++ b/src/components/main.jsx
@@ -131,8 +131,8 @@ class UI extends React.Component {
 		}
 
 		editor.fire('editorUpdate', {
-			prevProps: prevProps,
-			prevState: prevState,
+			prevProps,
+			prevState,
 			props: this.props,
 			state: this.state,
 		});

--- a/src/components/toolbars/toolbar-add.jsx
+++ b/src/components/toolbars/toolbar-add.jsx
@@ -9,8 +9,8 @@ import WidgetFocusManager from '../base/widget-focus-manager';
 import WidgetPosition from '../base/widget-position';
 import ButtonIcon from '../buttons/button-icon.jsx';
 
-let POSITION_LEFT = 1;
-let POSITION_RIGHT = 2;
+const POSITION_LEFT = 1;
+const POSITION_RIGHT = 2;
 
 /**
  * The ToolbarAdd class provides functionality for adding content to the editor.
@@ -90,8 +90,8 @@ class ToolbarAdd extends React.Component {
 			return null;
 		}
 
-		let buttons = this._getButtons();
-		let className = this._getToolbarClassName();
+		const buttons = this._getButtons();
+		const className = this._getToolbarClassName();
 
 		return (
 			<div
@@ -185,19 +185,19 @@ class ToolbarAdd extends React.Component {
 			}
 
 			if (region) {
-				let domNode = ReactDOM.findDOMNode(this);
+				const domNode = ReactDOM.findDOMNode(this);
 
-				let domElement = new CKEDITOR.dom.element(domNode);
+				const domElement = new CKEDITOR.dom.element(domNode);
 
-				let startRect = region.startRect || region;
+				const startRect = region.startRect || region;
 
-				let nativeEditor = this.context.editor.get('nativeEditor');
+				const nativeEditor = this.context.editor.get('nativeEditor');
 
-				let clientRect = nativeEditor.editable().getClientRect();
+				const clientRect = nativeEditor.editable().getClientRect();
 
 				let offsetLeft;
 
-				let position =
+				const position =
 					this.props.config.position || this.props.position;
 
 				if (position === POSITION_LEFT) {

--- a/src/components/toolbars/toolbar-styles.jsx
+++ b/src/components/toolbars/toolbar-styles.jsx
@@ -65,10 +65,10 @@ class ToolbarStyles extends React.Component {
 	 * @return {Object|null} The content which should be rendered.
 	 */
 	render() {
-		let currentSelection = this._getCurrentSelection();
+		const currentSelection = this._getCurrentSelection();
 
 		if (currentSelection) {
-			let getArrowBoxClassesFn = this._getSelectionFunction(
+			const getArrowBoxClassesFn = this._getSelectionFunction(
 				currentSelection.getArrowBoxClasses
 			);
 			let arrowBoxClasses;
@@ -79,7 +79,7 @@ class ToolbarStyles extends React.Component {
 				arrowBoxClasses = this.getArrowBoxClasses();
 			}
 
-			let cssClasses = 'ae-toolbar-styles ' + arrowBoxClasses;
+			const cssClasses = 'ae-toolbar-styles ' + arrowBoxClasses;
 
 			let buttons = currentSelection.buttons;
 
@@ -89,14 +89,14 @@ class ToolbarStyles extends React.Component {
 					buttons['simple'];
 			}
 
-			let buttonsGroup = this.getToolbarButtonGroups(buttons, {
+			const buttonsGroup = this.getToolbarButtonGroups(buttons, {
 				manualSelection: this.props.editorEvent
 					? this.props.editorEvent.data.manualSelection
 					: null,
 				selectionType: currentSelection.name,
 			});
 
-			let hasGroups =
+			const hasGroups =
 				buttonsGroup.filter(function(button) {
 					return Array.isArray(button);
 				}).length > 0;
@@ -154,7 +154,7 @@ class ToolbarStyles extends React.Component {
 		if (Lang.isFunction(selectionFn)) {
 			selectionFunction = selectionFn;
 		} else if (Lang.isString(selectionFn)) {
-			let parts = selectionFn.split('.');
+			const parts = selectionFn.split('.');
 			let currentMember = window;
 			let property = parts.shift();
 
@@ -185,14 +185,14 @@ class ToolbarStyles extends React.Component {
 	 * @return {Object} The matched selection configuration.
 	 */
 	_getCurrentSelection() {
-		let eventPayload = this.props.editorEvent
+		const eventPayload = this.props.editorEvent
 			? this.props.editorEvent.data
 			: null;
 		let selection;
 
 		if (eventPayload) {
 			this.props.config.selections.some(function(item) {
-				let testFn = this._getSelectionFunction(item.test);
+				const testFn = this._getSelectionFunction(item.test);
 				let result;
 
 				if (testFn) {
@@ -229,13 +229,13 @@ class ToolbarStyles extends React.Component {
 			return;
 		}
 
-		let currentSelection = this._getCurrentSelection();
+		const currentSelection = this._getCurrentSelection();
 		let result;
 
 		// If current selection has a function called `setPosition`, call it
 		// and check the returned value. If false, fallback to the default positioning logic.
 		if (currentSelection) {
-			let setPositionFn = this._getSelectionFunction(
+			const setPositionFn = this._getSelectionFunction(
 				currentSelection.setPosition
 			);
 

--- a/src/components/uibridge/button.jsx
+++ b/src/components/uibridge/button.jsx
@@ -3,7 +3,7 @@ import EditorContext from '../../adapter/editor-context';
 
 /* istanbul ignore if */
 if (!CKEDITOR.plugins.get('ae_buttonbridge')) {
-	let BUTTON_DEFS = {};
+	const BUTTON_DEFS = {};
 
 	/**
 	 * Generates a ButtonBridge React class for a given button definition if it has not been
@@ -37,30 +37,30 @@ if (!CKEDITOR.plugins.get('ae_buttonbridge')) {
 				toFeature() {}
 
 				render() {
-					let editor = this.context.editor.get('nativeEditor');
+					const editor = this.context.editor.get('nativeEditor');
 
-					let buttonClassName = 'ae-button ae-button-bridge';
+					const buttonClassName = 'ae-button ae-button-bridge';
 
-					let buttonDisplayName =
+					const buttonDisplayName =
 						BUTTON_DEFS[editor.name][buttonName].name ||
 						BUTTON_DEFS[editor.name][buttonName].command ||
 						buttonName;
 
-					let buttonLabel =
+					const buttonLabel =
 						BUTTON_DEFS[editor.name][buttonName].label;
 
-					let buttonType = 'button-' + buttonDisplayName;
+					const buttonType = 'button-' + buttonDisplayName;
 
-					let iconClassName = 'ae-icon-' + buttonDisplayName;
+					const iconClassName = 'ae-icon-' + buttonDisplayName;
 
-					let iconStyle = {};
+					const iconStyle = {};
 
-					let cssStyle = CKEDITOR.skin.getIconStyle(
+					const cssStyle = CKEDITOR.skin.getIconStyle(
 						buttonDisplayName
 					);
 
 					if (cssStyle) {
-						let cssStyleParts = cssStyle.split(';');
+						const cssStyleParts = cssStyle.split(';');
 
 						iconStyle.backgroundImage = cssStyleParts[0].substring(
 							cssStyleParts[0].indexOf(':') + 1
@@ -87,12 +87,12 @@ if (!CKEDITOR.plugins.get('ae_buttonbridge')) {
 				}
 
 				_handleClick = () => {
-					let editor = this.context.editor.get('nativeEditor');
+					const editor = this.context.editor.get('nativeEditor');
 
-					let buttonCommand =
+					const buttonCommand =
 						BUTTON_DEFS[editor.name][buttonName].command;
 
-					let buttonOnClick =
+					const buttonOnClick =
 						BUTTON_DEFS[editor.name][buttonName].onClick;
 
 					if (buttonOnClick) {
@@ -138,17 +138,17 @@ if (!CKEDITOR.plugins.get('ae_buttonbridge')) {
 		 * @method init
 		 * @param {Object} editor The CKEditor instance being initialized
 		 */
-		beforeInit: function(editor) {
+		beforeInit(editor) {
 			editor.ui.addButton = function(buttonName, buttonDefinition) {
 				this.add(buttonName, CKEDITOR.UI_BUTTON, buttonDefinition);
 			};
 
 			editor.ui.addHandler(CKEDITOR.UI_BUTTON, {
 				add: generateButtonBridge,
-				create: function(buttonDefinition) {
-					let buttonName =
+				create(buttonDefinition) {
+					const buttonName =
 						'buttonBridge' + ((Math.random() * 1e9) >>> 0);
-					let ButtonBridge = generateButtonBridge(
+					const ButtonBridge = generateButtonBridge(
 						buttonName,
 						buttonDefinition
 					);

--- a/src/components/uibridge/menu-button.jsx
+++ b/src/components/uibridge/menu-button.jsx
@@ -4,7 +4,7 @@ import EditorContext from '../../adapter/editor-context';
 
 /* istanbul ignore if */
 if (!CKEDITOR.plugins.get('ae_menubuttonbridge')) {
-	let MENUBUTTON_DEFS = {};
+	const MENUBUTTON_DEFS = {};
 
 	/**
 	 * Generates a MenuButtonBridge React class for a given menuButton definition if it has not been
@@ -42,25 +42,26 @@ if (!CKEDITOR.plugins.get('ae_menubuttonbridge')) {
 				toFeature() {}
 
 				render() {
-					let editor = this.context.editor.get('nativeEditor');
+					const editor = this.context.editor.get('nativeEditor');
 
-					let panelMenuButtonDisplayName =
+					const panelMenuButtonDisplayName =
 						MENUBUTTON_DEFS[editor.name][menuButtonName].name ||
 						MENUBUTTON_DEFS[editor.name][menuButtonName].command ||
 						menuButtonName;
 
-					let buttonClassName = 'ae-button ae-button-bridge';
+					const buttonClassName = 'ae-button ae-button-bridge';
 
-					let iconClassName = 'ae-icon-' + panelMenuButtonDisplayName;
+					const iconClassName =
+						'ae-icon-' + panelMenuButtonDisplayName;
 
-					let iconStyle = {};
+					const iconStyle = {};
 
-					let cssStyle = CKEDITOR.skin.getIconStyle(
+					const cssStyle = CKEDITOR.skin.getIconStyle(
 						panelMenuButtonDisplayName
 					);
 
 					if (cssStyle) {
-						let cssStyleParts = cssStyle.split(';');
+						const cssStyleParts = cssStyle.split(';');
 
 						iconStyle.backgroundImage = cssStyleParts[0].substring(
 							cssStyleParts[0].indexOf(':') + 1
@@ -105,27 +106,27 @@ if (!CKEDITOR.plugins.get('ae_menubuttonbridge')) {
 				}
 
 				_getMenuItems() {
-					let editor = this.context.editor.get('nativeEditor');
-					let items = menuButtonDefinition.onMenu();
-					let menuItems = Object.keys(items).map(function(key) {
-						let menuItem = editor.getMenuItem(key);
+					const editor = this.context.editor.get('nativeEditor');
+					const items = menuButtonDefinition.onMenu();
+					const menuItems = Object.keys(items).map(function(key) {
+						const menuItem = editor.getMenuItem(key);
 
 						if (!menuItem) {
 							return null;
 						}
 
-						let menuItemDefinition =
+						const menuItemDefinition =
 							menuItem.definition || menuItem;
-						let menuItemState = items[key];
+						const menuItemState = items[key];
 
-						let className =
+						const className =
 							'ae-toolbar-element ' +
 							(menuItemState === CKEDITOR.TRISTATE_ON
 								? 'active'
 								: '');
-						let disabled =
+						const disabled =
 							menuItemState === CKEDITOR.TRISTATE_DISABLED;
-						let onClick = function() {
+						const onClick = function() {
 							if (menuItemDefinition.command) {
 								editor.execCommand(menuItemDefinition.command);
 							} else if (menuItemDefinition.onClick) {
@@ -185,7 +186,7 @@ if (!CKEDITOR.plugins.get('ae_menubuttonbridge')) {
 		 * @method init
 		 * @param {Object} editor The CKEditor instance being initialized
 		 */
-		beforeInit: function(editor) {
+		beforeInit(editor) {
 			editor.ui.addMenuButton = function(
 				menuButtonName,
 				menuButtonDefinition
@@ -199,10 +200,10 @@ if (!CKEDITOR.plugins.get('ae_menubuttonbridge')) {
 
 			editor.ui.addHandler(CKEDITOR.UI_MENUBUTTON, {
 				add: generateMenuButtonBridge,
-				create: function(menuButtonDefinition) {
-					let menuButtonName =
+				create(menuButtonDefinition) {
+					const menuButtonName =
 						'buttonBridge' + ((Math.random() * 1e9) >>> 0);
-					let MenuButtonBridge = generateMenuButtonBridge(
+					const MenuButtonBridge = generateMenuButtonBridge(
 						menuButtonName,
 						menuButtonDefinition
 					);

--- a/src/components/uibridge/menu.jsx
+++ b/src/components/uibridge/menu.jsx
@@ -20,15 +20,15 @@ if (!CKEDITOR.plugins.get('ae_menubridge')) {
 		 * @method init
 		 * @param {Object} editor The CKEditor instance being initialized
 		 */
-		beforeInit: function(editor) {
+		beforeInit(editor) {
 			// Do nothing if the real menu plugin is present
 			if (CKEDITOR.plugins.get('menu')) {
 				return;
 			}
 
-			let groups = [];
-			let groupsOrder = (editor._.menuGroups = {});
-			let menuItems = (editor._.menuItems = {});
+			const groups = [];
+			const groupsOrder = (editor._.menuGroups = {});
+			const menuItems = (editor._.menuItems = {});
 
 			for (let i = 0; i < groups.length; i++) {
 				groupsOrder[groups[i]] = i + 1;
@@ -57,8 +57,8 @@ if (!CKEDITOR.plugins.get('ae_menubridge')) {
 			editor.addMenuItem = function(name, definition) {
 				if (groupsOrder[definition.group]) {
 					menuItems[name] = {
-						name: name,
-						definition: definition,
+						name,
+						definition,
 					};
 				}
 			};
@@ -70,7 +70,7 @@ if (!CKEDITOR.plugins.get('ae_menubridge')) {
 			 * @param {Object} definitions Object where keys are used as itemName and corresponding values as definition for a {@link #addMenuItem} call.
 			 */
 			editor.addMenuItems = function(definitions) {
-				for (let itemName in definitions) {
+				for (const itemName in definitions) {
 					if (definitions.hasOwnProperty(itemName)) {
 						this.addMenuItem(itemName, definitions[itemName]);
 					}

--- a/src/components/uibridge/panel-menu-button.jsx
+++ b/src/components/uibridge/panel-menu-button.jsx
@@ -4,7 +4,7 @@ import EditorContext from '../../adapter/editor-context';
 
 /* istanbul ignore if */
 if (!CKEDITOR.plugins.get('ae_panelmenubuttonbridge')) {
-	let PANEL_MENU_DEFS = {};
+	const PANEL_MENU_DEFS = {};
 
 	/**
 	 * Generates a PanelMenuButtonBridge React class for a given panelmenubutton definition if it has not been
@@ -16,7 +16,7 @@ if (!CKEDITOR.plugins.get('ae_panelmenubuttonbridge')) {
 	 * @param {Object} panelMenuButtonDefinition The panel button definition
 	 * @return {Object} The generated or already existing React PanelMenuButton Class
 	 */
-	let generatePanelMenuButtonBridge = function(
+	const generatePanelMenuButtonBridge = function(
 		panelMenuButtonName,
 		panelMenuButtonDefinition,
 		editor
@@ -41,27 +41,28 @@ if (!CKEDITOR.plugins.get('ae_panelmenubuttonbridge')) {
 				createPanel() {}
 
 				render() {
-					let editor = this.context.editor.get('nativeEditor');
+					const editor = this.context.editor.get('nativeEditor');
 
-					let panelMenuButtonDisplayName =
+					const panelMenuButtonDisplayName =
 						PANEL_MENU_DEFS[editor.name][panelMenuButtonName]
 							.name ||
 						PANEL_MENU_DEFS[editor.name][panelMenuButtonName]
 							.command ||
 						panelMenuButtonName;
 
-					let buttonClassName = 'ae-button ae-button-bridge';
+					const buttonClassName = 'ae-button ae-button-bridge';
 
-					let iconClassName = 'ae-icon-' + panelMenuButtonDisplayName;
+					const iconClassName =
+						'ae-icon-' + panelMenuButtonDisplayName;
 
-					let iconStyle = {};
+					const iconStyle = {};
 
-					let cssStyle = CKEDITOR.skin.getIconStyle(
+					const cssStyle = CKEDITOR.skin.getIconStyle(
 						panelMenuButtonDisplayName
 					);
 
 					if (cssStyle) {
-						let cssStyleParts = cssStyle.split(';');
+						const cssStyleParts = cssStyle.split(';');
 
 						iconStyle.backgroundImage = cssStyleParts[0].substring(
 							cssStyleParts[0].indexOf(':') + 1
@@ -109,20 +110,20 @@ if (!CKEDITOR.plugins.get('ae_panelmenubuttonbridge')) {
 				}
 
 				_getPanel() {
-					let editor = this.context.editor.get('nativeEditor');
+					const editor = this.context.editor.get('nativeEditor');
 
-					let panelMenuButtonOnBlock =
+					const panelMenuButtonOnBlock =
 						PANEL_MENU_DEFS[editor.name][panelMenuButtonName]
 							.onBlock;
 
-					let panel = {
+					const panel = {
 						hide: this.props.toggleDropdown,
 						show: this.props.toggleDropdown,
 					};
 
-					let blockElement = new CKEDITOR.dom.element('div');
+					const blockElement = new CKEDITOR.dom.element('div');
 
-					let block = {
+					const block = {
 						element: blockElement,
 						keys: {},
 					};
@@ -188,7 +189,7 @@ if (!CKEDITOR.plugins.get('ae_panelmenubuttonbridge')) {
 		 * @method init
 		 * @param {Object} editor The CKEditor instance being initialized
 		 */
-		beforeInit: function(editor) {
+		beforeInit(editor) {
 			editor.ui.addPanelMenuButton = function(
 				panelMenuButtonName,
 				panelMenuButtonDefinition
@@ -202,10 +203,10 @@ if (!CKEDITOR.plugins.get('ae_panelmenubuttonbridge')) {
 
 			editor.ui.addHandler(CKEDITOR.UI_PANELBUTTON, {
 				add: generatePanelMenuButtonBridge,
-				create: function(panelMenuButtonDefinition) {
-					let panelMenuButtonName =
+				create(panelMenuButtonDefinition) {
+					const panelMenuButtonName =
 						'panelMenuButtonBridge' + ((Math.random() * 1e9) >>> 0);
-					let PanelMenuButtonBridge = generatePanelMenuButtonBridge(
+					const PanelMenuButtonBridge = generatePanelMenuButtonBridge(
 						panelMenuButtonName,
 						panelMenuButtonDefinition
 					);

--- a/src/components/uibridge/richcombo.jsx
+++ b/src/components/uibridge/richcombo.jsx
@@ -5,7 +5,7 @@ import EditorContext from '../../adapter/editor-context';
 
 /* istanbul ignore if */
 if (!CKEDITOR.plugins.get('ae_richcombobridge')) {
-	let RICH_COMBO_DEFS = {};
+	const RICH_COMBO_DEFS = {};
 
 	/**
 	 * Generates a RichComboBridge React class for a given richcombo definition if it has not been
@@ -17,7 +17,7 @@ if (!CKEDITOR.plugins.get('ae_richcombobridge')) {
 	 * @param {Object} richComboDefinition The rich combo definition
 	 * @return {Object} The generated or already existing React RichCombo Class
 	 */
-	let generateRichComboBridge = function(
+	const generateRichComboBridge = function(
 		richComboName,
 		richComboDefinition,
 		editor
@@ -62,16 +62,16 @@ if (!CKEDITOR.plugins.get('ae_richcombobridge')) {
 
 				add(value, preview, title) {
 					this._items.push({
-						preview: preview,
-						title: title,
-						value: value,
+						preview,
+						title,
+						value,
 					});
 				}
 
 				componentWillMount() {
-					let editor = this.context.editor.get('nativeEditor');
+					const editor = this.context.editor.get('nativeEditor');
 
-					let editorCombo =
+					const editorCombo =
 						RICH_COMBO_DEFS[editor.name][richComboName];
 
 					this._items = [];
@@ -98,9 +98,9 @@ if (!CKEDITOR.plugins.get('ae_richcombobridge')) {
 				}
 
 				render() {
-					let editor = this.context.editor.get('nativeEditor');
+					const editor = this.context.editor.get('nativeEditor');
 
-					let richComboLabel =
+					const richComboLabel =
 						RICH_COMBO_DEFS[editor.name][richComboName]
 							.currentValue || richComboDefinition.label;
 
@@ -132,7 +132,7 @@ if (!CKEDITOR.plugins.get('ae_richcombobridge')) {
 				}
 
 				_cacheValue(value) {
-					let editor = this.context.editor.get('nativeEditor');
+					const editor = this.context.editor.get('nativeEditor');
 
 					RICH_COMBO_DEFS[editor.name][
 						richComboName
@@ -140,11 +140,11 @@ if (!CKEDITOR.plugins.get('ae_richcombobridge')) {
 				}
 
 				_getItems() {
-					let richCombo = this;
+					const richCombo = this;
 
-					let items = this._items.map(
+					const items = this._items.map(
 						function(item) {
-							let className =
+							const className =
 								'ae-toolbar-element ' +
 								(item.value === this.state.value
 									? 'active'
@@ -169,13 +169,13 @@ if (!CKEDITOR.plugins.get('ae_richcombobridge')) {
 				}
 
 				_onClick = event => {
-					let editor = this.context.editor.get('nativeEditor');
+					const editor = this.context.editor.get('nativeEditor');
 
-					let editorCombo =
+					const editorCombo =
 						RICH_COMBO_DEFS[editor.name][richComboName];
 
 					if (editorCombo.onClick) {
-						let newValue = event.currentTarget.getAttribute(
+						const newValue = event.currentTarget.getAttribute(
 							'data-value'
 						);
 
@@ -193,7 +193,7 @@ if (!CKEDITOR.plugins.get('ae_richcombobridge')) {
 					this._cacheValue(value);
 
 					this.setState({
-						value: value,
+						value,
 					});
 				}
 			};
@@ -231,7 +231,7 @@ if (!CKEDITOR.plugins.get('ae_richcombobridge')) {
 		 * @method init
 		 * @param {Object} editor The CKEditor instance being initialized
 		 */
-		beforeInit: function(editor) {
+		beforeInit(editor) {
 			editor.ui.addRichCombo = function(
 				richComboName,
 				richComboDefinition
@@ -245,10 +245,10 @@ if (!CKEDITOR.plugins.get('ae_richcombobridge')) {
 
 			editor.ui.addHandler(CKEDITOR.UI_RICHCOMBO, {
 				add: generateRichComboBridge,
-				create: function(richComboDefinition) {
-					let richComboName =
+				create(richComboDefinition) {
+					const richComboName =
 						'richComboBridge' + ((Math.random() * 1e9) >>> 0);
-					let RichComboBridge = generateRichComboBridge(
+					const RichComboBridge = generateRichComboBridge(
 						richComboName,
 						richComboDefinition
 					);

--- a/src/components/uibridge/uibridge.js
+++ b/src/components/uibridge/uibridge.js
@@ -15,13 +15,13 @@ if (!CKEDITOR.plugins.get('ae_uibridge')) {
 		 * @method beforeInit
 		 * @param {Object} editor The current editor instance
 		 */
-		beforeInit: function(editor) {
-			let originalUIAddFn = editor.ui.add;
+		beforeInit(editor) {
+			const originalUIAddFn = editor.ui.add;
 
 			editor.ui.add = function(name, type, definition) {
 				originalUIAddFn.call(this, name, type, definition);
 
-				let typeHandler = this._.handlers[type];
+				const typeHandler = this._.handlers[type];
 
 				if (typeHandler && typeHandler.add) {
 					typeHandler.add(name, definition, editor);

--- a/src/core/debounce.js
+++ b/src/core/debounce.js
@@ -16,9 +16,9 @@
 function debounce(callback, timeout, context, args = []) {
 	let debounceHandle;
 
-	let callFn = function(...callArgs) {
+	const callFn = function(...callArgs) {
 		/* eslint-disable babel/no-invalid-this */
-		let callContext = context || this;
+		const callContext = context || this;
 		/* eslint-enable babel/no-invalid-this */
 
 		clearTimeout(debounceHandle);

--- a/src/core/link.js
+++ b/src/core/link.js
@@ -1,6 +1,6 @@
-let REGEX_BOOKMARK_SCHEME = /^#.*/i;
-let REGEX_EMAIL_SCHEME = /^[a-z0-9\u0430-\u044F._-]+@/i;
-let REGEX_URI_SCHEME = /^(?:[a-z][a-z0-9+\-.]*):|^\//i;
+const REGEX_BOOKMARK_SCHEME = /^#.*/i;
+const REGEX_EMAIL_SCHEME = /^[a-z0-9\u0430-\u044F._-]+@/i;
+const REGEX_URI_SCHEME = /^(?:[a-z][a-z0-9+\-.]*):|^\//i;
 
 /**
  * Link class utility. Provides methods for create, delete and update links.
@@ -27,23 +27,23 @@ Link.prototype = {
 	 * @method advanceSelection
 	 * @param {CKEDITOR.dom.element} link The link element which link style should be removed.
 	 */
-	advanceSelection: function(link) {
+	advanceSelection(link) {
 		link = link || this.getFromSelection();
 
-		let range = this._editor.getSelection().getRanges()[0];
+		const range = this._editor.getSelection().getRanges()[0];
 
 		if (link) {
 			range.moveToElementEditEnd(link);
 
-			let nextNode = range.getNextEditableNode();
+			const nextNode = range.getNextEditableNode();
 
 			if (
 				nextNode &&
 				!this._editor.element.equals(nextNode.getCommonAncestor(link))
 			) {
-				let whitespace = /\s/.exec(nextNode.getText());
+				const whitespace = /\s/.exec(nextNode.getText());
 
-				let offset = whitespace ? whitespace.index + 1 : 0;
+				const offset = whitespace ? whitespace.index + 1 : 0;
 
 				range.setStart(nextNode, offset);
 				range.setEnd(nextNode, offset);
@@ -63,20 +63,20 @@ Link.prototype = {
 	 * @param {Object} modifySelection A config object with an advance attribute to indicate if the selection should be moved after the link creation.
 	 * @param {String} URI The URI of the link.
 	 */
-	create: function(URI, attrs, modifySelection) {
-		let selection = this._editor.getSelection();
+	create(URI, attrs, modifySelection) {
+		const selection = this._editor.getSelection();
 
-		let range = selection.getRanges()[0];
+		const range = selection.getRanges()[0];
 
 		if (range.collapsed) {
-			let text = new CKEDITOR.dom.text(URI, this._editor.document);
+			const text = new CKEDITOR.dom.text(URI, this._editor.document);
 			range.insertNode(text);
 			range.selectNodeContents(text);
 		}
 
 		URI = this._getCompleteURI(URI);
 
-		let linkAttrs = CKEDITOR.tools.merge(
+		const linkAttrs = CKEDITOR.tools.merge(
 			{
 				'data-cke-saved-href': URI,
 				href: URI,
@@ -84,7 +84,7 @@ Link.prototype = {
 			attrs
 		);
 
-		let style = new CKEDITOR.style({
+		const style = new CKEDITOR.style({
 			attributes: linkAttrs,
 			element: 'a',
 		});
@@ -107,22 +107,22 @@ Link.prototype = {
 	 * @method getFromSelection
 	 * @return {CKEDITOR.dom.element} The retrieved link or null if not found.
 	 */
-	getFromSelection: function() {
-		let selection = this._editor.getSelection();
+	getFromSelection() {
+		const selection = this._editor.getSelection();
 
-		let selectedElement = selection.getSelectedElement();
+		const selectedElement = selection.getSelectedElement();
 
 		if (selectedElement && selectedElement.is('a')) {
 			return selectedElement;
 		}
 
 		if (selectedElement && CKEDITOR.env.ie) {
-			let children = selectedElement.getChildren();
+			const children = selectedElement.getChildren();
 
-			let count = children.count();
+			const count = children.count();
 
 			for (let i = 0; i < count; i++) {
-				let node = children.getItem(i);
+				const node = children.getItem(i);
 
 				if (node.is('a')) {
 					return node;
@@ -130,7 +130,7 @@ Link.prototype = {
 			}
 		}
 
-		let range = selection.getRanges()[0];
+		const range = selection.getRanges()[0];
 
 		if (range) {
 			range.shrink(CKEDITOR.SHRINK_TEXT);
@@ -152,8 +152,8 @@ Link.prototype = {
 	 * @param {CKEDITOR.dom.element} link The link element which link style should be removed.
 	 * @param {Object} modifySelection A config object with an advance attribute to indicate if the selection should be moved after the link creation.
 	 */
-	remove: function(link, modifySelection) {
-		let editor = this._editor;
+	remove(link, modifySelection) {
+		const editor = this._editor;
 
 		if (link) {
 			if (modifySelection && modifySelection.advance) {
@@ -162,7 +162,7 @@ Link.prototype = {
 
 			link.remove(editor);
 		} else {
-			let style = new CKEDITOR.style({
+			const style = new CKEDITOR.style({
 				alwaysRemoveElement: 1,
 				element: 'a',
 				type: CKEDITOR.STYLE_INLINE,
@@ -172,7 +172,7 @@ Link.prototype = {
 			//  We need to force the selection to be the whole link element
 			//  to remove it properly.
 
-			let selection = editor.getSelection();
+			const selection = editor.getSelection();
 			selection.selectElement(selection.getStartElement());
 
 			editor.removeStyle(style);
@@ -189,22 +189,22 @@ Link.prototype = {
 	 * @param {Object|String} attrs The attributes to update or remove. Attributes with null values will be removed.
 	 * @param {Object} modifySelection A config object with an advance attribute to indicate if the selection should be moved after the link creation.
 	 */
-	update: function(attrs, link, modifySelection) {
-		let instance = this;
+	update(attrs, link, modifySelection) {
+		const instance = this;
 
 		link = link || this.getFromSelection();
 
 		if (typeof attrs === 'string') {
-			let uri = instance._getCompleteURI(attrs);
+			const uri = instance._getCompleteURI(attrs);
 
 			link.setAttributes({
 				'data-cke-saved-href': uri,
 				href: uri,
 			});
 		} else if (typeof attrs === 'object') {
-			let removeAttrs = [];
+			const removeAttrs = [];
 
-			let setAttrs = {};
+			const setAttrs = {};
 
 			Object.keys(attrs).forEach(function(key) {
 				if (attrs[key] === null) {
@@ -215,7 +215,7 @@ Link.prototype = {
 					removeAttrs.push(key);
 				} else {
 					if (key === 'href') {
-						let uri = instance._getCompleteURI(attrs[key]);
+						const uri = instance._getCompleteURI(attrs[key]);
 
 						setAttrs['data-cke-saved-href'] = uri;
 						setAttrs[key] = uri;
@@ -248,7 +248,7 @@ Link.prototype = {
 	 * @protected
 	 * @return {String} The URI updated with the protocol.
 	 */
-	_getCompleteURI: function(URI) {
+	_getCompleteURI(URI) {
 		if (REGEX_BOOKMARK_SCHEME.test(URI)) {
 			return URI;
 		} else if (REGEX_EMAIL_SCHEME.test(URI)) {

--- a/src/core/plugins.js
+++ b/src/core/plugins.js
@@ -4,17 +4,17 @@
 // in which it is happening
 //
 // @param {Object} plugin The plugin to wrap lifecycle methods
-let wrapPluginLifecycle = function(plugin) {
-	let methods = ['beforeInit', 'init', 'afterInit'];
+const wrapPluginLifecycle = function(plugin) {
+	const methods = ['beforeInit', 'init', 'afterInit'];
 
 	methods.forEach(function(methodName) {
 		if (plugin[methodName]) {
 			plugin[methodName] = CKEDITOR.tools.override(
 				plugin[methodName],
 				function(originalPluginMethod) {
-					let payload = {
+					const payload = {
 						phase: methodName,
-						plugin: plugin,
+						plugin,
 					};
 
 					return function(editor) {
@@ -37,7 +37,7 @@ let wrapPluginLifecycle = function(plugin) {
 //
 // @param {string|Array<string>} requires The requires object
 // @return {string} The filtered requires object
-let filterUnwantedDependencies = function(requires) {
+const filterUnwantedDependencies = function(requires) {
 	if (typeof requires === 'string') {
 		requires = requires.split(',');
 	}
@@ -76,7 +76,7 @@ CKEDITOR.plugins.load = CKEDITOR.tools.override(CKEDITOR.plugins.load, function(
 		pluginsLoad.call(this, names, function(plugins) {
 			if (callback) {
 				Object.keys(plugins).forEach(function(pluginName) {
-					let plugin = plugins[pluginName];
+					const plugin = plugins[pluginName];
 
 					if (plugin.requires) {
 						plugin.requires = filterUnwantedDependencies(

--- a/src/core/selection-region.js
+++ b/src/core/selection-region.js
@@ -27,7 +27,7 @@ if (!CKEDITOR.plugins.get('ae_selectionregion')) {
 		 * @param {Number} x X point in page coordinates.
 		 * @param {Number} y Y point in page coordinates.
 		 */
-		createSelectionFromPoint: function(x, y) {
+		createSelectionFromPoint(x, y) {
 			this.createSelectionFromRange(x, y, x, y);
 		},
 
@@ -42,7 +42,7 @@ if (!CKEDITOR.plugins.get('ae_selectionregion')) {
 		 * @param {Number} endX X coordinate of the second point.
 		 * @param {Number} endY Y coordinate of the second point.
 		 */
-		createSelectionFromRange: function(startX, startY, endX, endY) {
+		createSelectionFromRange(startX, startY, endX, endY) {
 			let end;
 			let endContainer;
 			let endOffset;
@@ -84,14 +84,14 @@ if (!CKEDITOR.plugins.get('ae_selectionregion')) {
 
 				this.getSelection().selectRanges([range]);
 			} else if (typeof document.body.createTextRange === 'function') {
-				let selection = this.getSelection();
+				const selection = this.getSelection();
 
 				selection.unlock();
 
 				range = document.body.createTextRange();
 				range.moveToPoint(startX, startY);
 
-				let endRange = range.duplicate();
+				const endRange = range.duplicate();
 				endRange.moveToPoint(endX, endY);
 
 				range.setEndPoint('EndToEnd', endRange);
@@ -113,8 +113,8 @@ if (!CKEDITOR.plugins.get('ae_selectionregion')) {
 		 * - right
 		 * - top
 		 */
-		getCaretRegion: function() {
-			let selection = this.getSelection();
+		getCaretRegion() {
+			const selection = this.getSelection();
 
 			let region = {
 				bottom: 0,
@@ -123,13 +123,13 @@ if (!CKEDITOR.plugins.get('ae_selectionregion')) {
 				top: 0,
 			};
 
-			let bookmarks = selection.createBookmarks();
+			const bookmarks = selection.createBookmarks();
 
 			if (!bookmarks.length) {
 				return region;
 			}
 
-			let bookmarkNodeEl = bookmarks[0].startNode.$;
+			const bookmarkNodeEl = bookmarks[0].startNode.$;
 
 			bookmarkNodeEl.style.display = 'inline-block';
 
@@ -137,7 +137,9 @@ if (!CKEDITOR.plugins.get('ae_selectionregion')) {
 
 			bookmarkNodeEl.parentNode.removeChild(bookmarkNodeEl);
 
-			let scrollPos = new CKEDITOR.dom.window(window).getScrollPosition();
+			const scrollPos = new CKEDITOR.dom.window(
+				window
+			).getScrollPosition();
 
 			region.bottom = scrollPos.y + region.bottom;
 			region.left = scrollPos.x + region.left;
@@ -158,14 +160,14 @@ if (!CKEDITOR.plugins.get('ae_selectionregion')) {
 		 * - text - The selected text
 		 * - region - The data, returned from {{#crossLink "CKEDITOR.plugins.ae_selectionregion/getSelectionRegion:method"}}{{/crossLink}}
 		 */
-		getSelectionData: function() {
-			let selection = this.getSelection();
+		getSelectionData() {
+			const selection = this.getSelection();
 
 			if (!selection.getNative()) {
 				return null;
 			}
 
-			let result = {
+			const result = {
 				element: selection.getSelectedElement(),
 				text: selection.getSelectedText(),
 			};
@@ -189,8 +191,8 @@ if (!CKEDITOR.plugins.get('ae_selectionregion')) {
 		 * - height - The height of the selection region
 		 * - width - The width of the selection region
 		 */
-		getSelectionRegion: function() {
-			let region = this.getClientRectsRegion();
+		getSelectionRegion() {
+			const region = this.getClientRectsRegion();
 
 			region.direction = this.getSelectionDirection();
 
@@ -208,17 +210,15 @@ if (!CKEDITOR.plugins.get('ae_selectionregion')) {
 		 * @method isSelectionEmpty
 		 * @return {Boolean} Returns true if the current selection is empty, false otherwise.
 		 */
-		isSelectionEmpty: function() {
-			let ranges;
+		isSelectionEmpty() {
+			const selection = this.getSelection();
 
-			let selection = this.getSelection();
+			if (selection.getType() === CKEDITOR.SELECTION_NONE) {
+				return true;
+			}
 
-			return (
-				selection.getType() === CKEDITOR.SELECTION_NONE ||
-				((ranges = selection.getRanges()) &&
-					ranges.length === 1 &&
-					ranges[0].collapsed)
-			);
+			const ranges = selection.getRanges();
+			return ranges && ranges.length === 1 && ranges[0].collapsed;
 		},
 
 		/**
@@ -250,11 +250,11 @@ if (!CKEDITOR.plugins.get('ae_selectionregion')) {
 		 *
 		 * If there is no native selection, the objects will be filled with 0.
 		 */
-		getClientRectsRegion: function() {
-			let selection = this.getSelection();
-			let nativeSelection = selection.getNative();
+		getClientRectsRegion() {
+			const selection = this.getSelection();
+			const nativeSelection = selection.getNative();
 
-			let defaultRect = {
+			const defaultRect = {
 				bottom: 0,
 				height: 0,
 				left: 0,
@@ -295,7 +295,7 @@ if (!CKEDITOR.plugins.get('ae_selectionregion')) {
 				region = this.getCaretRegion();
 			} else {
 				for (let i = 0, length = clientRects.length; i < length; i++) {
-					let item = clientRects[i];
+					const item = clientRects[i];
 
 					if (item.left < left) {
 						left = item.left;
@@ -314,7 +314,7 @@ if (!CKEDITOR.plugins.get('ae_selectionregion')) {
 					}
 				}
 
-				let scrollPos = new CKEDITOR.dom.window(
+				const scrollPos = new CKEDITOR.dom.window(
 					window
 				).getScrollPosition();
 
@@ -324,8 +324,8 @@ if (!CKEDITOR.plugins.get('ae_selectionregion')) {
 				region.top = scrollPos.y + top;
 
 				if (clientRects.length) {
-					let endRect = clientRects[clientRects.length - 1];
-					let startRect = clientRects[0];
+					const endRect = clientRects[clientRects.length - 1];
+					const startRect = clientRects[0];
 
 					region.endRect = {
 						bottom: scrollPos.y + endRect.bottom,
@@ -361,10 +361,10 @@ if (!CKEDITOR.plugins.get('ae_selectionregion')) {
 		 * - CKEDITOR.SELECTION_TOP_TO_BOTTOM;
 		 * - CKEDITOR.SELECTION_BOTTOM_TO_TOP;
 		 */
-		getSelectionDirection: function() {
+		getSelectionDirection() {
 			let direction = CKEDITOR.SELECTION_TOP_TO_BOTTOM;
-			let selection = this.getSelection();
-			let nativeSelection = selection.getNative();
+			const selection = this.getSelection();
+			const nativeSelection = selection.getNative();
 
 			if (!nativeSelection) {
 				return direction;
@@ -376,7 +376,7 @@ if (!CKEDITOR.plugins.get('ae_selectionregion')) {
 				(anchorNode = nativeSelection.anchorNode) &&
 				anchorNode.compareDocumentPosition
 			) {
-				let position = anchorNode.compareDocumentPosition(
+				const position = anchorNode.compareDocumentPosition(
 					nativeSelection.focusNode
 				);
 
@@ -395,11 +395,9 @@ if (!CKEDITOR.plugins.get('ae_selectionregion')) {
 	};
 
 	CKEDITOR.plugins.add('ae_selectionregion', {
-		init: function(editor) {
+		init(editor) {
 			let attr;
-			let hasOwnProperty;
-
-			hasOwnProperty = Object.prototype.hasOwnProperty;
+			const hasOwnProperty = Object.prototype.hasOwnProperty;
 
 			for (attr in SelectionRegion.prototype) {
 				if (

--- a/src/core/table.js
+++ b/src/core/table.js
@@ -1,4 +1,4 @@
-let IE_NON_DIRECTLY_EDITABLE_ELEMENT = {
+const IE_NON_DIRECTLY_EDITABLE_ELEMENT = {
 	table: 1,
 	col: 1,
 	colgroup: 1,
@@ -39,21 +39,21 @@ Table.prototype = {
 	 * @param {Object} config Table configuration object
 	 * @return {Object} The created table
 	 */
-	create: function(config) {
-		let editor = this._editor;
-		let table = this._createElement('table');
+	create(config) {
+		const editor = this._editor;
+		const table = this._createElement('table');
 
 		config = config || {};
 
 		// Generate the rows and cols.
-		let tbody = table.append(this._createElement('tbody'));
-		let rows = config.rows || 1;
-		let cols = config.cols || 1;
+		const tbody = table.append(this._createElement('tbody'));
+		const rows = config.rows || 1;
+		const cols = config.cols || 1;
 
 		for (let i = 0; i < rows; i++) {
-			let row = tbody.append(this._createElement('tr'));
+			const row = tbody.append(this._createElement('tr'));
 			for (let j = 0; j < cols; j++) {
-				let cell = row.append(this._createElement('td'));
+				const cell = row.append(this._createElement('td'));
 
 				cell.appendBogus();
 			}
@@ -65,8 +65,8 @@ Table.prototype = {
 		// Insert the table element if we're creating one.
 		editor.insertElement(table);
 
-		let firstCell = new CKEDITOR.dom.element(table.$.rows[0].cells[0]);
-		let range = editor.createRange();
+		const firstCell = new CKEDITOR.dom.element(table.$.rows[0].cells[0]);
+		const range = editor.createRange();
 		range.moveToPosition(firstCell, CKEDITOR.POSITION_AFTER_START);
 		range.select();
 
@@ -81,15 +81,15 @@ Table.prototype = {
 	 * @method getFromSelection
 	 * @return {CKEDITOR.dom.element} The retrieved table or null if not found.
 	 */
-	getFromSelection: function() {
+	getFromSelection() {
 		let table;
-		let selection = this._editor.getSelection();
-		let selected = selection.getSelectedElement();
+		const selection = this._editor.getSelection();
+		const selected = selection.getSelectedElement();
 
 		if (selected && selected.is('table')) {
 			table = selected;
 		} else {
-			let ranges = selection.getRanges();
+			const ranges = selection.getRanges();
 
 			if (ranges.length > 0) {
 				// Webkit could report the following range on cell selection (#4948):
@@ -124,7 +124,7 @@ Table.prototype = {
 	 * @param {CKEDITOR.dom.element} el The table element to test if editable
 	 * @return {Boolean}
 	 */
-	isEditable: function(el) {
+	isEditable(el) {
 		if (!CKEDITOR.env.ie || !el.is(IE_NON_DIRECTLY_EDITABLE_ELEMENT)) {
 			return !el.isReadOnly();
 		}
@@ -145,21 +145,21 @@ Table.prototype = {
 	 * @param {CKEDITOR.dom.element} table The table to gather the heading from. If null, it will be retrieved from the current selection.
 	 * @return {String} The heading of the table. Expected values are `CKEDITOR.Table.NONE`, `CKEDITOR.Table.ROW`, `CKEDITOR.Table.COL` and `CKEDITOR.Table.BOTH`.
 	 */
-	getHeading: function(table) {
+	getHeading(table) {
 		table = table || this.getFromSelection();
 
 		if (!table) {
 			return null;
 		}
 
-		let rowHeadingSettings = table.$.tHead !== null;
+		const rowHeadingSettings = table.$.tHead !== null;
 
 		let colHeadingSettings = true;
 
 		// Check if all of the first cells in every row are TH
 		for (let row = 0; row < table.$.rows.length; row++) {
 			// If just one cell isn't a TH then it isn't a header column
-			let cell = table.$.rows[row].cells[0];
+			const cell = table.$.rows[row].cells[0];
 
 			if (cell && cell.nodeName.toLowerCase() !== 'th') {
 				colHeadingSettings = false;
@@ -191,8 +191,8 @@ Table.prototype = {
 	 * @method remove
 	 * @param {CKEDITOR.dom.element} table The table element which table style should be removed.
 	 */
-	remove: function(table) {
-		let editor = this._editor;
+	remove(table) {
+		const editor = this._editor;
 
 		if (table) {
 			table.remove();
@@ -201,8 +201,8 @@ Table.prototype = {
 
 			if (table) {
 				// If the table's parent has only one child remove it as well (unless it's a table cell, or the editable element) (#5416, #6289, #12110)
-				let parent = table.getParent();
-				let editable = editor.editable();
+				const parent = table.getParent();
+				const editable = editor.editable();
 
 				if (
 					parent.getChildCount() === 1 &&
@@ -212,7 +212,7 @@ Table.prototype = {
 					table = parent;
 				}
 
-				let range = editor.createRange();
+				const range = editor.createRange();
 				range.moveToPosition(table, CKEDITOR.POSITION_BEFORE_START);
 				table.remove();
 			}
@@ -228,7 +228,7 @@ Table.prototype = {
 	 * @param {Object} table The table to which the attributes should be assigned
 	 * @param {Object} attrs The attributes which have to be assigned to the table
 	 */
-	setAttributes: function(table, attrs) {
+	setAttributes(table, attrs) {
 		if (attrs) {
 			Object.keys(attrs).forEach(function(attr) {
 				table.setAttribute(attr, attrs[attr]);
@@ -245,33 +245,33 @@ Table.prototype = {
 	 * @param {CKEDITOR.dom.element} table The table element to which the heading should be set. If null, it will be retrieved from the current selection.
 	 * @param {String} heading The table heading to be set. Accepted values are: `CKEDITOR.Table.NONE`, `CKEDITOR.Table.ROW`, `CKEDITOR.Table.COL` and `CKEDITOR.Table.BOTH`.
 	 */
-	setHeading: function(table, heading) {
+	setHeading(table, heading) {
 		table = table || this.getFromSelection();
 
 		let i;
 		let newCell;
 		let tableHead;
-		let tableBody = table.getElementsByTag('tbody').getItem(0);
+		const tableBody = table.getElementsByTag('tbody').getItem(0);
 
 		let tableHeading = this.getHeading(table);
-		let hadColHeading =
+		const hadColHeading =
 			tableHeading === Table.HEADING_COL ||
 			tableHeading === Table.HEADING_BOTH;
 
-		let needColHeading =
+		const needColHeading =
 			heading === Table.HEADING_COL || heading === Table.HEADING_BOTH;
-		let needRowHeading =
+		const needRowHeading =
 			heading === Table.HEADING_ROW || heading === Table.HEADING_BOTH;
 
 		// If we need row heading and don't have a <thead> element yet, move the
 		// first row of the table to the head and convert the nodes to <th> ones.
 		if (!table.$.tHead && needRowHeading) {
-			let tableFirstRow = tableBody.getElementsByTag('tr').getItem(0);
-			let tableFirstRowChildCount = tableFirstRow.getChildCount();
+			const tableFirstRow = tableBody.getElementsByTag('tr').getItem(0);
+			const tableFirstRowChildCount = tableFirstRow.getChildCount();
 
 			// Change TD to TH:
 			for (i = 0; i < tableFirstRowChildCount; i++) {
-				let cell = tableFirstRow.getChild(i);
+				const cell = tableFirstRow.getChild(i);
 
 				// Skip bookmark nodes. (#6155)
 				if (
@@ -293,11 +293,11 @@ Table.prototype = {
 			// Move the row out of the THead and put it in the TBody:
 			tableHead = this._createElement(table.$.tHead);
 
-			let previousFirstRow = tableBody.getFirst();
+			const previousFirstRow = tableBody.getFirst();
 
 			while (tableHead.getChildCount() > 0) {
-				let newFirstRow = tableHead.getFirst();
-				let newFirstRowChildCount = newFirstRow.getChildCount();
+				const newFirstRow = tableHead.getFirst();
+				const newFirstRowChildCount = newFirstRow.getChildCount();
 
 				for (i = 0; i < newFirstRowChildCount; i++) {
 					newCell = newFirstRow.getChild(i);
@@ -315,7 +315,7 @@ Table.prototype = {
 		}
 
 		tableHeading = this.getHeading(table);
-		let hasColHeading =
+		const hasColHeading =
 			tableHeading === Table.HEADING_COL ||
 			tableHeading === Table.HEADING_BOTH;
 
@@ -337,7 +337,7 @@ Table.prototype = {
 		// row back into a `<td>` element.
 		if (hadColHeading && !needColHeading) {
 			for (i = 0; i < table.$.rows.length; i++) {
-				let row = new CKEDITOR.dom.element(table.$.rows[i]);
+				const row = new CKEDITOR.dom.element(table.$.rows[i]);
 
 				if (row.getParent().getName() === 'tbody') {
 					newCell = new CKEDITOR.dom.element(row.$.cells[0]);
@@ -358,24 +358,24 @@ Table.prototype = {
 	 * @param {String} name The tag name from which an element should be created
 	 * @return {CKEDITOR.dom.element} Instance of CKEDITOR DOM element class
 	 */
-	_createElement: function(name) {
+	_createElement(name) {
 		return new CKEDITOR.dom.element(name, this._editor.document);
 	},
 };
 
 CKEDITOR.on('instanceReady', function(event) {
-	let headingCommands = [
+	const headingCommands = [
 		Table.HEADING_NONE,
 		Table.HEADING_ROW,
 		Table.HEADING_COL,
 		Table.HEADING_BOTH,
 	];
 
-	let tableUtils = new Table(event.editor);
+	const tableUtils = new Table(event.editor);
 
 	headingCommands.forEach(function(heading) {
 		event.editor.addCommand('tableHeading' + heading, {
-			exec: function(_editor) {
+			exec(_editor) {
 				tableUtils.setHeading(null, heading);
 			},
 		});

--- a/src/core/tools.js
+++ b/src/core/tools.js
@@ -24,7 +24,7 @@ CKEDITOR.tools.jsonp = function(
 	callback,
 	errorCallback
 ) {
-	let callbackKey = CKEDITOR.tools.getNextNumber();
+	const callbackKey = CKEDITOR.tools.getNextNumber();
 
 	urlParams = urlParams || {};
 	urlParams.callback = 'CKEDITOR._.jsonpCallbacks[' + callbackKey + ']';
@@ -83,12 +83,12 @@ CKEDITOR.tools.jsonp = function(
 CKEDITOR.tools.merge =
 	CKEDITOR.tools.merge ||
 	function(...args) {
-		let result = {};
+		const result = {};
 
 		for (let i = 0; i < args.length; ++i) {
-			let obj = args[i];
+			const obj = args[i];
 
-			for (let key in obj) {
+			for (const key in obj) {
 				if (Object.prototype.hasOwnProperty.call(obj, key)) {
 					result[key] = obj[key];
 				}
@@ -108,7 +108,7 @@ CKEDITOR.tools.merge =
  * @static
  */
 CKEDITOR.tools.simulate = function(element, event) {
-	let eventInstance = document.createEvent('Events');
+	const eventInstance = document.createEvent('Events');
 	eventInstance.initEvent(event, true, false);
 	element.dispatchEvent(eventInstance);
 };

--- a/src/core/uicore.js
+++ b/src/core/uicore.js
@@ -62,16 +62,16 @@ if (!CKEDITOR.plugins.get('ae_uicore')) {
 		 * @param {Object} editor The current CKEditor instance.
 		 * @protected
 		 */
-		init: function(editor) {
+		init(editor) {
 			let ariaState = [];
 
-			let ariaElement = this._createAriaElement(editor.id);
+			const ariaElement = this._createAriaElement(editor.id);
 
-			let uiTasksTimeout = editor.config.uicore
+			const uiTasksTimeout = editor.config.uicore
 				? editor.config.uicore.timeout
 				: 50;
 
-			let handleUI = CKEDITOR.tools.debounce(function(event) {
+			const handleUI = CKEDITOR.tools.debounce(function(event) {
 				ariaState = [];
 
 				if (
@@ -79,23 +79,23 @@ if (!CKEDITOR.plugins.get('ae_uicore')) {
 					event.data.$.keyCode !== 27 ||
 					editor.config.allowEsc
 				) {
-					let selectionData = editor.getSelectionData();
+					const selectionData = editor.getSelectionData();
 
 					if (selectionData) {
 						editor.fire('editorInteraction', {
 							nativeEvent: event.data.$,
-							selectionData: selectionData,
+							selectionData,
 						});
 					}
 				}
 			}, uiTasksTimeout);
 
-			let handleAria = CKEDITOR.tools.debounce(function(_event) {
+			const handleAria = CKEDITOR.tools.debounce(function(_event) {
 				ariaElement.innerHTML = ariaState.join('. ');
 			}, uiTasksTimeout);
 
-			let handleMouseLeave = CKEDITOR.tools.debounce(function(event) {
-				let aeUINodes = document.querySelectorAll('.ae-ui');
+			const handleMouseLeave = CKEDITOR.tools.debounce(function(event) {
+				const aeUINodes = document.querySelectorAll('.ae-ui');
 
 				let found;
 
@@ -124,7 +124,7 @@ if (!CKEDITOR.plugins.get('ae_uicore')) {
 			});
 
 			editor.once('contentDom', function() {
-				let editable = editor.editable();
+				const editable = editor.editable();
 
 				const focusHandler = editable.attachListener(
 					editable,
@@ -161,8 +161,8 @@ if (!CKEDITOR.plugins.get('ae_uicore')) {
 		 * @protected
 		 * @return {HTMLElement} The created and applied to DOM element.
 		 */
-		_createAriaElement: function(id) {
-			let statusElement = document.createElement('div');
+		_createAriaElement(id) {
+			const statusElement = document.createElement('div');
 
 			statusElement.className = 'ae-sr-only';
 

--- a/src/oop/attribute.js
+++ b/src/oop/attribute.js
@@ -23,8 +23,8 @@ Attribute.prototype = {
 	 * @param {String} attr The attribute which value should be retrieved.
 	 * @return {Any} The value of the attribute.
 	 */
-	get: function(attr) {
-		let currentAttr = this.constructor.ATTRS[attr];
+	get(attr) {
+		const currentAttr = this.constructor.ATTRS[attr];
 
 		if (!currentAttr) {
 			return;
@@ -52,8 +52,8 @@ Attribute.prototype = {
 	 * @param {String} attr The attribute which value should be set.
 	 * @param {Any} value The value which should be set to the attribute.
 	 */
-	set: function(attr, value) {
-		let currentAttr = this.constructor.ATTRS[attr];
+	set(attr, value) {
+		const currentAttr = this.constructor.ATTRS[attr];
 
 		if (!currentAttr) {
 			return;
@@ -98,7 +98,7 @@ Attribute.prototype = {
 	 * @protected
 	 * @return {Any} The returned value from the called function
 	 */
-	_callStringOrFunction: function(stringOrFunction, args) {
+	_callStringOrFunction(stringOrFunction, args) {
 		let result = null;
 
 		if (!Lang.isArray(args)) {
@@ -127,17 +127,17 @@ Attribute.prototype = {
 	 * @param {String} attr The name of the attribute which have to be initialized.
 	 * @protected
 	 */
-	_init: function(attr) {
+	_init(attr) {
 		let value;
 
-		let currentAttr = this.constructor.ATTRS[attr];
+		const currentAttr = this.constructor.ATTRS[attr];
 
 		// Check if there is default value or passed one via configuration object
-		let hasDefaultValue = Object.prototype.hasOwnProperty.call(
+		const hasDefaultValue = Object.prototype.hasOwnProperty.call(
 			currentAttr,
 			'value'
 		);
-		let hasPassedValueViaConfig = Object.prototype.hasOwnProperty.call(
+		const hasPassedValueViaConfig = Object.prototype.hasOwnProperty.call(
 			this.__config__,
 			attr
 		);
@@ -209,7 +209,7 @@ Attribute.prototype = {
 	 * @protected
 	 * @return {Boolean} Returns true if the attribute has been initialized, false otherwise.
 	 */
-	_isInitialized: function(attr) {
+	_isInitialized(attr) {
 		return Object.prototype.hasOwnProperty.call(this.__ATTRS__, attr);
 	},
 };

--- a/src/oop/base.js
+++ b/src/oop/base.js
@@ -24,7 +24,7 @@ extend(Base, Attribute, {
 	 * @method init
 	 * @param {Object} config Configuration object
 	 */
-	init: function(config) {
+	init(config) {
 		this._callChain('initializer', config);
 	},
 
@@ -35,7 +35,7 @@ extend(Base, Attribute, {
 	 * @memberof Base
 	 * @method destroy
 	 */
-	destroy: function() {
+	destroy() {
 		this._callChain('destructor');
 	},
 
@@ -49,7 +49,7 @@ extend(Base, Attribute, {
 	 * @param {String} wat  The method, which should be invoked
 	 * @protected
 	 */
-	_callChain: function(wat, args) {
+	_callChain(wat, args) {
 		let arr = [];
 
 		let ctor = this.constructor;
@@ -67,7 +67,7 @@ extend(Base, Attribute, {
 		args = Lang.isArray(args) ? args : [args];
 
 		for (let i = 0; i < arr.length; i++) {
-			let item = arr[i];
+			const item = arr[i];
 
 			item.apply(this, args);
 		}

--- a/src/oop/lang.js
+++ b/src/oop/lang.js
@@ -13,7 +13,7 @@ const Lang = {
 	 * @return {Boolean} True if the passed value is an array, false otherwise.
 	 * @static
 	 */
-	isArray: function(value) {
+	isArray(value) {
 		return Object.prototype.toString.call(value) === '[object Array]';
 	},
 
@@ -26,7 +26,7 @@ const Lang = {
 	 * @return {Boolean} True if the passed value is boolean, false otherwise.
 	 * @static
 	 */
-	isBoolean: function(value) {
+	isBoolean(value) {
 		return typeof value === 'boolean';
 	},
 
@@ -39,7 +39,7 @@ const Lang = {
 	 * @return {Boolean} True if the passed value is a function, false otherwise.
 	 * @static
 	 */
-	isFunction: function(value) {
+	isFunction(value) {
 		return typeof value === 'function';
 	},
 
@@ -52,7 +52,7 @@ const Lang = {
 	 * @return {Boolean} True if the passed value is NULL, false otherwise.
 	 * @static
 	 */
-	isNull: function(value) {
+	isNull(value) {
 		return value === null;
 	},
 
@@ -65,7 +65,7 @@ const Lang = {
 	 * @return {Boolean} True if the passed value is number, false otherwise.
 	 * @static
 	 */
-	isNumber: function(value) {
+	isNumber(value) {
 		return typeof value === 'number' && isFinite(value);
 	},
 
@@ -78,8 +78,8 @@ const Lang = {
 	 * @return {Boolean} True if the passed value is an object, false otherwise.
 	 * @static
 	 */
-	isObject: function(value) {
-		let valueType = typeof value;
+	isObject(value) {
+		const valueType = typeof value;
 
 		return value && (valueType === 'object' || Lang.isFunction(value));
 	},
@@ -93,7 +93,7 @@ const Lang = {
 	 * @return {Boolean} True if the passed value is a string, false otherwise.
 	 * @static
 	 */
-	isString: function(value) {
+	isString(value) {
 		return typeof value === 'string';
 	},
 
@@ -108,10 +108,10 @@ const Lang = {
 	 * @return {Object} The modified receiver.
 	 * @static
 	 */
-	mix: function(receiver, supplier) {
-		let hasOwnProperty = Object.prototype.hasOwnProperty;
+	mix(receiver, supplier) {
+		const hasOwnProperty = Object.prototype.hasOwnProperty;
 
-		for (let key in supplier) {
+		for (const key in supplier) {
 			if (hasOwnProperty.call(supplier, key)) {
 				receiver[key] = supplier[key];
 			}
@@ -127,7 +127,7 @@ const Lang = {
 	 * @return {Integer} The converted value.
 	 * @static
 	 */
-	toInt: function(value) {
+	toInt(value) {
 		return parseInt(value, 10);
 	},
 };

--- a/src/oop/oop.js
+++ b/src/oop/oop.js
@@ -18,9 +18,9 @@ const extend = function(receiver, supplier, protoProps, staticProps) {
 		throw new Error('extend failed, verify dependencies');
 	}
 
-	let supplierProto = supplier.prototype;
+	const supplierProto = supplier.prototype;
 
-	let receiverProto = Object.create(supplierProto);
+	const receiverProto = Object.create(supplierProto);
 	receiver.prototype = receiverProto;
 
 	receiverProto.constructor = receiver;

--- a/src/plugins/addimages.js
+++ b/src/plugins/addimages.js
@@ -1,4 +1,4 @@
-let isIE = CKEDITOR.env.ie;
+const isIE = CKEDITOR.env.ie;
 
 if (!CKEDITOR.plugins.get('ae_addimages')) {
 	/**
@@ -39,11 +39,11 @@ if (!CKEDITOR.plugins.get('ae_addimages')) {
 		 * @method init
 		 * @param {Object} editor The current editor instance
 		 */
-		init: function(editor) {
+		init(editor) {
 			editor.once(
 				'contentDom',
 				function() {
-					let editable = editor.editable();
+					const editable = editor.editable();
 
 					editable.attachListener(
 						editable,
@@ -51,7 +51,7 @@ if (!CKEDITOR.plugins.get('ae_addimages')) {
 						this._onDragEnter,
 						this,
 						{
-							editor: editor,
+							editor,
 						}
 					);
 
@@ -61,7 +61,7 @@ if (!CKEDITOR.plugins.get('ae_addimages')) {
 						this._onDragOver,
 						this,
 						{
-							editor: editor,
+							editor,
 						}
 					);
 
@@ -71,7 +71,7 @@ if (!CKEDITOR.plugins.get('ae_addimages')) {
 						this._onDragDrop,
 						this,
 						{
-							editor: editor,
+							editor,
 						}
 					);
 
@@ -81,7 +81,7 @@ if (!CKEDITOR.plugins.get('ae_addimages')) {
 						this._onPaste,
 						this,
 						{
-							editor: editor,
+							editor,
 						}
 					);
 				}.bind(this)
@@ -100,11 +100,11 @@ if (!CKEDITOR.plugins.get('ae_addimages')) {
 		 * @param {Object} editor The current editor instance
 		 * @protected
 		 */
-		_handleFiles: function(files, editor) {
+		_handleFiles(files, editor) {
 			let file;
 			let i;
 
-			let imageFiles = [];
+			const imageFiles = [];
 
 			for (i = 0; i < files.length; i++) {
 				file = files[i];
@@ -114,8 +114,8 @@ if (!CKEDITOR.plugins.get('ae_addimages')) {
 				}
 			}
 
-			let result = editor.fire('beforeImageAdd', {
-				imageFiles: imageFiles,
+			const result = editor.fire('beforeImageAdd', {
+				imageFiles,
 			});
 
 			if (result) {
@@ -140,15 +140,15 @@ if (!CKEDITOR.plugins.get('ae_addimages')) {
 		 * @param {CKEDITOR.dom.event} event dragdrop event, as received natively from CKEditor
 		 * @protected
 		 */
-		_onDragDrop: function(event) {
-			let nativeEvent = event.data.$;
+		_onDragDrop(event) {
+			const nativeEvent = event.data.$;
 
-			let transferFiles = nativeEvent.dataTransfer.files;
+			const transferFiles = nativeEvent.dataTransfer.files;
 
 			if (transferFiles.length > 0) {
 				new CKEDITOR.dom.event(nativeEvent).preventDefault();
 
-				let editor = event.listenerData.editor;
+				const editor = event.listenerData.editor;
 
 				event.listenerData.editor.createSelectionFromPoint(
 					nativeEvent.clientX,
@@ -168,7 +168,7 @@ if (!CKEDITOR.plugins.get('ae_addimages')) {
 		 * @param {DOM event} event dragenter event, as received natively from CKEditor
 		 * @protected
 		 */
-		_onDragEnter: function(event) {
+		_onDragEnter(event) {
 			if (isIE) {
 				this._preventEvent(event);
 			}
@@ -183,7 +183,7 @@ if (!CKEDITOR.plugins.get('ae_addimages')) {
 		 * @param {DOM event} event dragover event, as received natively from CKEditor
 		 * @protected
 		 */
-		_onDragOver: function(event) {
+		_onDragOver(event) {
 			if (isIE) {
 				this._preventEvent(event);
 			}
@@ -199,7 +199,7 @@ if (!CKEDITOR.plugins.get('ae_addimages')) {
 		 * @param {CKEDITOR.dom.event} event A `paste` event, as received natively from CKEditor
 		 * @protected
 		 */
-		_onPaste: function(event) {
+		_onPaste(event) {
 			if (
 				event.data &&
 				event.data.$ &&
@@ -207,10 +207,10 @@ if (!CKEDITOR.plugins.get('ae_addimages')) {
 				event.data.$.clipboardData.items &&
 				event.data.$.clipboardData.items.length > 0
 			) {
-				let pastedData = event.data.$.clipboardData.items[0];
+				const pastedData = event.data.$.clipboardData.items[0];
 
 				if (pastedData.type.indexOf('image') === 0) {
-					let imageFile = pastedData.getAsFile();
+					const imageFile = pastedData.getAsFile();
 
 					this._processFile(imageFile, event.listenerData.editor);
 				}
@@ -226,7 +226,7 @@ if (!CKEDITOR.plugins.get('ae_addimages')) {
 		 * @param {DOM event} event The event to be prevented.
 		 * @protected
 		 */
-		_preventEvent: function(event) {
+		_preventEvent(event) {
 			event = new CKEDITOR.dom.event(event.data.$);
 
 			event.preventDefault();
@@ -244,21 +244,21 @@ if (!CKEDITOR.plugins.get('ae_addimages')) {
 		 * @param {DOM event} event The event to be prevented.
 		 * @protected
 		 */
-		_processFile: function(file, editor) {
-			let reader = new FileReader();
+		_processFile(file, editor) {
+			const reader = new FileReader();
 
 			reader.addEventListener('loadend', function() {
-				let bin = reader.result;
+				const bin = reader.result;
 
-				let el = CKEDITOR.dom.element.createFromHtml(
+				const el = CKEDITOR.dom.element.createFromHtml(
 					'<img src="' + bin + '">'
 				);
 
 				editor.insertElement(el);
 
-				let imageData = {
-					el: el,
-					file: file,
+				const imageData = {
+					el,
+					file,
 				};
 
 				editor.fire('imageAdd', imageData);

--- a/src/plugins/autolink.js
+++ b/src/plugins/autolink.js
@@ -5,24 +5,24 @@ if (!CKEDITOR.plugins.get('ae_autolink')) {
 		document.execCommand('AutoUrlDetect', false, false);
 	}
 
-	let KEY_BACK = 8;
+	const KEY_BACK = 8;
 
-	let KEY_COMMA = 188;
+	const KEY_COMMA = 188;
 
-	let KEY_ENTER = 13;
+	const KEY_ENTER = 13;
 
-	let KEY_SEMICOLON = 186;
+	const KEY_SEMICOLON = 186;
 
-	let KEY_SPACE = 32;
+	const KEY_SPACE = 32;
 
-	let DELIMITERS = [KEY_COMMA, KEY_ENTER, KEY_SEMICOLON, KEY_SPACE];
+	const DELIMITERS = [KEY_COMMA, KEY_ENTER, KEY_SEMICOLON, KEY_SPACE];
 
-	let REGEX_LAST_WORD = /[^\s]+/gim;
+	const REGEX_LAST_WORD = /[^\s]+/gim;
 
-	let REGEX_URL =
+	const REGEX_URL =
 		'((([A - Za - z]{ 3, 9}: (?: \\/\\/)?)(?:[-;:&=\\+\\$,\\w]+@)?[A-Za-z0-9.-]+|(https?\\:\\/\\/|www.|[-;:&=.\\+\\$,\\w]+@)[A-Za-z0-9.-]+)((?:\\/[\\+~%\\/.\\w-_]*)?\\??(?:[-\\+=&;%@.\\w_]*)#?(?:[\\w]*))((.*):(\\d*)\\/?(.*))?)';
 
-	let REGEX_EMAIL = /[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,4}/i;
+	const REGEX_EMAIL = /[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,4}/i;
 
 	/**
 	 * CKEditor plugin which automatically generates links when user types text which looks like URL.
@@ -40,11 +40,11 @@ if (!CKEDITOR.plugins.get('ae_autolink')) {
 		 * @method init
 		 * @param {Object} editor The current editor instance
 		 */
-		init: function(editor) {
+		init(editor) {
 			editor.once(
 				'contentDom',
 				function() {
-					let editable = editor.editable();
+					const editable = editor.editable();
 
 					editable.attachListener(
 						editable,
@@ -52,7 +52,7 @@ if (!CKEDITOR.plugins.get('ae_autolink')) {
 						this._onKeyUp,
 						this,
 						{
-							editor: editor,
+							editor,
 						}
 					);
 				}.bind(this)
@@ -79,7 +79,7 @@ if (!CKEDITOR.plugins.get('ae_autolink')) {
 							return;
 						}
 
-						let instance = this;
+						const instance = this;
 
 						event.data.dataValue = event.data.dataValue.replace(
 							RegExp(REGEX_URL, 'gim'),
@@ -120,10 +120,10 @@ if (!CKEDITOR.plugins.get('ae_autolink')) {
 		 * @protected
 		 * @return {String} The last word introduced by user
 		 */
-		_getLastWord: function(editor) {
-			let range = editor.getSelection().getRanges()[0];
+		_getLastWord(editor) {
+			const range = editor.getSelection().getRanges()[0];
 
-			let offset = range.startOffset;
+			const offset = range.startOffset;
 
 			let previousText = '';
 
@@ -169,7 +169,7 @@ if (!CKEDITOR.plugins.get('ae_autolink')) {
 
 			let lastWord = '';
 
-			let match = previousText.match(REGEX_LAST_WORD);
+			const match = previousText.match(REGEX_LAST_WORD);
 
 			if (match) {
 				lastWord = match.pop();
@@ -188,7 +188,7 @@ if (!CKEDITOR.plugins.get('ae_autolink')) {
 		 * @protected
 		 * @return {Boolean} Returns true if the email is a valid Email, false otherwise
 		 */
-		_isValidEmail: function(email) {
+		_isValidEmail(email) {
 			return REGEX_EMAIL.test(email);
 		},
 
@@ -202,7 +202,7 @@ if (!CKEDITOR.plugins.get('ae_autolink')) {
 		 * @protected
 		 * @return {Boolean} Returns true if the link is a valid URL, false otherwise
 		 */
-		_isValidURL: function(link) {
+		_isValidURL(link) {
 			return RegExp(REGEX_URL, 'i').test(link);
 		},
 
@@ -216,12 +216,12 @@ if (!CKEDITOR.plugins.get('ae_autolink')) {
 		 * @param {EventFacade} event EventFacade object
 		 * @protected
 		 */
-		_onKeyDown: function(event) {
-			let nativeEvent = event.data.$;
+		_onKeyDown(event) {
+			const nativeEvent = event.data.$;
 
-			let editor = event.listenerData.editor;
+			const editor = event.listenerData.editor;
 
-			let editable = editor.editable();
+			const editable = editor.editable();
 
 			editable.removeListener('keydown', this._onKeyDown);
 
@@ -245,15 +245,15 @@ if (!CKEDITOR.plugins.get('ae_autolink')) {
 		 * @param {EventFacade} event EventFacade object
 		 * @protected
 		 */
-		_onKeyUp: function(event) {
-			let nativeEvent = event.data.$;
+		_onKeyUp(event) {
+			const nativeEvent = event.data.$;
 
 			this._currentKeyCode = nativeEvent.keyCode;
 
 			if (DELIMITERS.indexOf(this._currentKeyCode) !== -1) {
-				let editor = event.listenerData.editor;
+				const editor = event.listenerData.editor;
 
-				let lastWord = this._getLastWord(editor);
+				const lastWord = this._getLastWord(editor);
 
 				if (this._isValidURL(lastWord)) {
 					this._replaceContentByLink(editor, lastWord);
@@ -271,21 +271,21 @@ if (!CKEDITOR.plugins.get('ae_autolink')) {
 		 * @param {String} content The text that has to be replaced by an link element
 		 * @protected
 		 */
-		_replaceContentByLink: function(editor, content) {
+		_replaceContentByLink(editor, content) {
 			let range = editor.createRange();
-			let node = CKEDITOR.dom.element.get(this._startContainer);
-			let offset = this._offset;
+			const node = CKEDITOR.dom.element.get(this._startContainer);
+			const offset = this._offset;
 
 			// Select the content, so CKEDITOR.Link can properly replace it
 			range.setStart(node, offset - content.length);
 			range.setEnd(node, offset);
 			range.select();
 
-			let ckLink = new CKEDITOR.Link(editor);
+			const ckLink = new CKEDITOR.Link(editor);
 			ckLink.create(content);
 			this._ckLink = ckLink;
 
-			let linkNode = ckLink.getFromSelection();
+			const linkNode = ckLink.getFromSelection();
 			editor.fire('autolinkAdd', linkNode);
 
 			this._subscribeToKeyEvent(editor);
@@ -297,12 +297,12 @@ if (!CKEDITOR.plugins.get('ae_autolink')) {
 			// If user pressed `Enter`, get the next editable node at position 0,
 			// otherwise set the cursor at the next character of the link (the white space)
 			if (this._currentKeyCode === KEY_ENTER) {
-				let nextEditableNode = range.getNextEditableNode();
+				const nextEditableNode = range.getNextEditableNode();
 
 				range.setStart(nextEditableNode, 0);
 				range.setEnd(nextEditableNode, 0);
 			} else {
-				let enclosedNode = range.getEnclosedNode();
+				const enclosedNode = range.getEnclosedNode();
 
 				range.setStart(enclosedNode, 0);
 				range.setEnd(enclosedNode, 0);
@@ -327,15 +327,15 @@ if (!CKEDITOR.plugins.get('ae_autolink')) {
 		 * @method _removeLink
 		 * @protected
 		 */
-		_removeLink: function(editor) {
-			let range = editor.getSelection().getRanges()[0];
-			let caretOffset = range.startOffset;
+		_removeLink(editor) {
+			const range = editor.getSelection().getRanges()[0];
+			const caretOffset = range.startOffset;
 
 			// Select the link, so CKEDITOR.Link can properly remove it
-			let linkNode =
+			const linkNode =
 				this._startContainer.getNext() || this._startContainer;
 
-			let newRange = editor.createRange();
+			const newRange = editor.createRange();
 			newRange.setStart(linkNode, 0);
 			newRange.setEndAfter(linkNode);
 			newRange.select();
@@ -357,8 +357,8 @@ if (!CKEDITOR.plugins.get('ae_autolink')) {
 		 * @method _subscribeToKeyEvent
 		 * @protected
 		 */
-		_subscribeToKeyEvent: function(editor) {
-			let editable = editor.editable();
+		_subscribeToKeyEvent(editor) {
+			const editable = editor.editable();
 
 			// Change the priority of keydown listener - 1 means the highest priority.
 			// In Chrome on pressing `Enter` the listener is not being invoked.
@@ -369,7 +369,7 @@ if (!CKEDITOR.plugins.get('ae_autolink')) {
 				this._onKeyDown,
 				this,
 				{
-					editor: editor,
+					editor,
 				},
 				1
 			);

--- a/src/plugins/autolist.js
+++ b/src/plugins/autolist.js
@@ -1,9 +1,9 @@
 if (!CKEDITOR.plugins.get('ae_autolist')) {
-	let KEY_BACK = 8;
+	const KEY_BACK = 8;
 
-	let KEY_SPACE = 32;
+	const KEY_SPACE = 32;
 
-	let DEFAULT_CONFIG = [
+	const DEFAULT_CONFIG = [
 		{
 			regex: /^\*$/,
 			type: 'bulletedlist',
@@ -30,11 +30,11 @@ if (!CKEDITOR.plugins.get('ae_autolist')) {
 		 * @method init
 		 * @param {Object} editor The current editor instance
 		 */
-		init: function(editor) {
+		init(editor) {
 			editor.once(
 				'contentDom',
 				function() {
-					let editable = editor.editable();
+					const editable = editor.editable();
 
 					editable.attachListener(
 						editable,
@@ -42,7 +42,7 @@ if (!CKEDITOR.plugins.get('ae_autolist')) {
 						this._onKeyDown,
 						this,
 						{
-							editor: editor,
+							editor,
 						}
 					);
 				}.bind(this)
@@ -58,12 +58,12 @@ if (!CKEDITOR.plugins.get('ae_autolist')) {
 		 * @param {Event} event Event object
 		 * @protected
 		 */
-		_checkForBackspaceAndUndo: function(event) {
-			let editor = event.listenerData.editor;
+		_checkForBackspaceAndUndo(event) {
+			const editor = event.listenerData.editor;
 
-			let nativeEvent = event.data.$;
+			const nativeEvent = event.data.$;
 
-			let editable = editor.editable();
+			const editable = editor.editable();
 
 			editable.removeListener('keydown', this._checkForBackspaceAndUndo);
 
@@ -84,34 +84,34 @@ if (!CKEDITOR.plugins.get('ae_autolist')) {
 		 * @protected
 		 * @return {Object|null} Returns an object which contains the detected list config if any
 		 */
-		_getListConfig: function(editor) {
-			let configRegex = editor.config.autolist || DEFAULT_CONFIG;
+		_getListConfig(editor) {
+			const configRegex = editor.config.autolist || DEFAULT_CONFIG;
 
-			let range = editor.getSelection().getRanges()[0];
+			const range = editor.getSelection().getRanges()[0];
 
-			let textContainer = range.endContainer.getText();
+			const textContainer = range.endContainer.getText();
 
-			let bullet = textContainer.substring(0, range.startOffset);
+			const bullet = textContainer.substring(0, range.startOffset);
 
-			let text = textContainer.substring(
+			const text = textContainer.substring(
 				range.startOffset,
 				textContainer.length
 			);
 
 			let index = 0;
 
-			let regexLen = configRegex.length;
+			const regexLen = configRegex.length;
 
 			let autolistCfg = null;
 
 			while (!autolistCfg && regexLen > index) {
-				let regexItem = configRegex[index];
+				const regexItem = configRegex[index];
 
 				if (regexItem.regex.test(bullet)) {
 					autolistCfg = {
-						bullet: bullet,
-						editor: editor,
-						text: text,
+						bullet,
+						editor,
+						text,
 						type: regexItem.type,
 					};
 
@@ -133,15 +133,15 @@ if (!CKEDITOR.plugins.get('ae_autolist')) {
 		 * @param {Object} listConfig Object that contains bullet, text and type for creating the list
 		 * @protected
 		 */
-		_createList: function(listConfig) {
-			let editor = listConfig.editor;
+		_createList(listConfig) {
+			const editor = listConfig.editor;
 
-			let range = editor.getSelection().getRanges()[0];
+			const range = editor.getSelection().getRanges()[0];
 
 			range.endContainer.setText(listConfig.text);
 			editor.execCommand(listConfig.type);
 
-			let editable = editor.editable();
+			const editable = editor.editable();
 
 			// Subscribe to keydown in order to check if the next key press is `Backspace`.
 			// If so, the creation of the list will be discarded.
@@ -151,7 +151,7 @@ if (!CKEDITOR.plugins.get('ae_autolist')) {
 				this._checkForBackspaceAndUndo,
 				this,
 				{
-					editor: editor,
+					editor,
 					bullet: listConfig.bullet,
 				},
 				1
@@ -168,11 +168,13 @@ if (!CKEDITOR.plugins.get('ae_autolist')) {
 		 * @param {Event} event Event object
 		 * @protected
 		 */
-		_onKeyDown: function(event) {
-			let nativeEvent = event.data.$;
+		_onKeyDown(event) {
+			const nativeEvent = event.data.$;
 
 			if (nativeEvent.keyCode === KEY_SPACE) {
-				let listConfig = this._getListConfig(event.listenerData.editor);
+				const listConfig = this._getListConfig(
+					event.listenerData.editor
+				);
 
 				if (listConfig) {
 					event.data.preventDefault();

--- a/src/plugins/dragresize.js
+++ b/src/plugins/dragresize.js
@@ -7,48 +7,48 @@
  * - Escape while dragging cancels resize
  */
 if (!CKEDITOR.plugins.get('ae_dragresize')) {
-	let IMAGE_HANDLES = {
+	const IMAGE_HANDLES = {
 		both: ['tl', 'tm', 'tr', 'lm', 'rm', 'bl', 'bm', 'br'],
 		height: ['tl', 'tm', 'tr', 'bl', 'bm', 'br'],
 		scale: ['tl', 'tr', 'bl', 'br'],
 		width: ['tl', 'tr', 'lm', 'rm', 'bl', 'br'],
 	};
 
-	let POSITION_ELEMENT_FN = {
-		bl: function(handle, left, top, box) {
+	const POSITION_ELEMENT_FN = {
+		bl(handle, left, top, box) {
 			positionElement(handle, -3 + left, box.height - 4 + top);
 		},
-		bm: function(handle, left, top, box) {
+		bm(handle, left, top, box) {
 			positionElement(
 				handle,
 				Math.round(box.width / 2) - 3 + left,
 				box.height - 4 + top
 			);
 		},
-		br: function(handle, left, top, box) {
+		br(handle, left, top, box) {
 			positionElement(handle, box.width - 4 + left, box.height - 4 + top);
 		},
-		lm: function(handle, left, top, box) {
+		lm(handle, left, top, box) {
 			positionElement(
 				handle,
 				-3 + left,
 				Math.round(box.height / 2) - 3 + top
 			);
 		},
-		tl: function(handle, left, top, _box) {
+		tl(handle, left, top, _box) {
 			positionElement(handle, left - 3, top - 3);
 		},
-		tm: function(handle, left, top, box) {
+		tm(handle, left, top, box) {
 			positionElement(
 				handle,
 				Math.round(box.width / 2) - 3 + left,
 				-3 + top
 			);
 		},
-		tr: function(handle, left, top, box) {
+		tr(handle, left, top, box) {
 			positionElement(handle, box.width - 4 + left, -3 + top);
 		},
-		rm: function(handle, left, top, box) {
+		rm(handle, left, top, box) {
 			positionElement(
 				handle,
 				box.width - 4 + left,
@@ -57,13 +57,13 @@ if (!CKEDITOR.plugins.get('ae_dragresize')) {
 		},
 	};
 
-	let IMAGE_SNAP_TO_SIZE = 7;
+	const IMAGE_SNAP_TO_SIZE = 7;
 
-	let isFirefox = 'MozAppearance' in document.documentElement.style;
+	const isFirefox = 'MozAppearance' in document.documentElement.style;
 
-	let isWebKit = 'WebkitAppearance' in document.documentElement.style;
+	const isWebKit = 'WebkitAppearance' in document.documentElement.style;
 
-	let enablePlugin = isWebKit || isFirefox;
+	const enablePlugin = isWebKit || isFirefox;
 
 	if (enablePlugin) {
 		// CSS is added in a compressed form
@@ -76,12 +76,12 @@ if (!CKEDITOR.plugins.get('ae_dragresize')) {
 	 * Initializes the plugin
 	 */
 	CKEDITOR.plugins.add('ae_dragresize', {
-		onLoad: function() {
+		onLoad() {
 			if (!enablePlugin) {
 				return;
 			}
 		},
-		init: function(editor) {
+		init(editor) {
 			if (!enablePlugin) {
 				return;
 			}
@@ -93,16 +93,16 @@ if (!CKEDITOR.plugins.get('ae_dragresize')) {
 	});
 
 	function init(editor) {
-		let window = editor.window.$;
+		const window = editor.window.$;
 
-		let document = editor.document.$;
+		const document = editor.document.$;
 
 		if (isFirefox) {
 			// Disable the native image resizing
 			document.execCommand('enableObjectResizing', false, false);
 		}
 
-		let snapToSize =
+		const snapToSize =
 			typeof IMAGE_SNAP_TO_SIZE === 'undefined'
 				? null
 				: IMAGE_SNAP_TO_SIZE;
@@ -110,12 +110,12 @@ if (!CKEDITOR.plugins.get('ae_dragresize')) {
 		editor.config.imageScaleResize =
 			editor.config.imageScaleResize || 'both';
 
-		let resizer = new Resizer(editor, {
+		const resizer = new Resizer(editor, {
 			imageScaleResize: editor.config.imageScaleResize,
-			snapToSize: snapToSize,
+			snapToSize,
 		});
 
-		let mouseDownListener = function(e) {
+		const mouseDownListener = function(e) {
 			if (resizer.isHandle(e.target)) {
 				resizer.initDrag(e);
 			}
@@ -124,7 +124,7 @@ if (!CKEDITOR.plugins.get('ae_dragresize')) {
 		document.addEventListener('mousedown', mouseDownListener, false);
 
 		function selectionChange() {
-			let selection = editor.getSelection();
+			const selection = editor.getSelection();
 
 			if (!selection) return;
 			// If an element is selected and that element is an IMG
@@ -175,7 +175,7 @@ if (!CKEDITOR.plugins.get('ae_dragresize')) {
 		});
 
 		editor.on('destroy', function() {
-			let resizeElement = document.getElementById('ckimgrsz');
+			const resizeElement = document.getElementById('ckimgrsz');
 
 			if (resizeElement) {
 				resizeElement.remove();
@@ -207,10 +207,10 @@ if (!CKEDITOR.plugins.get('ae_dragresize')) {
 	}
 
 	Resizer.prototype = {
-		init: function() {
-			let instance = this;
+		init() {
+			const instance = this;
 
-			let container = (this.container = this.document.createElement(
+			const container = (this.container = this.document.createElement(
 				'div'
 			));
 
@@ -218,7 +218,7 @@ if (!CKEDITOR.plugins.get('ae_dragresize')) {
 			this.preview = this.document.createElement('span');
 			container.appendChild(this.preview);
 
-			let handles = (this.handles = {});
+			const handles = (this.handles = {});
 
 			IMAGE_HANDLES[this.cfg.imageScaleResize].forEach(function(
 				handleName
@@ -228,30 +228,30 @@ if (!CKEDITOR.plugins.get('ae_dragresize')) {
 				] = instance.createHandle(handleName);
 			});
 
-			for (let n in handles) {
+			for (const n in handles) {
 				if (handles.hasOwnProperty(n)) {
 					container.appendChild(handles[n]);
 				}
 			}
 		},
-		createHandle: function(name) {
-			let el = this.document.createElement('i');
+		createHandle(name) {
+			const el = this.document.createElement('i');
 			el.classList.add(name);
 			return el;
 		},
-		isHandle: function(el) {
-			let handles = this.handles;
-			for (let n in handles) {
+		isHandle(el) {
+			const handles = this.handles;
+			for (const n in handles) {
 				if (handles[n] === el) {
 					return true;
 				}
 			}
 			return false;
 		},
-		show: function(el) {
+		show(el) {
 			let uiNode = this.editor.config.uiNode;
 
-			let scrollTop = uiNode ? uiNode.scrollTop : 0;
+			const scrollTop = uiNode ? uiNode.scrollTop : 0;
 
 			this.el = el;
 			if (this.cfg.snapToSize) {
@@ -260,7 +260,7 @@ if (!CKEDITOR.plugins.get('ae_dragresize')) {
 				);
 				this.otherImages.splice(this.otherImages.indexOf(el), 1);
 			}
-			let box = (this.box = getBoundingBox(this.window, el));
+			const box = (this.box = getBoundingBox(this.window, el));
 			positionElement(this.container, box.left, box.top + scrollTop);
 
 			uiNode = uiNode || document.body;
@@ -270,9 +270,9 @@ if (!CKEDITOR.plugins.get('ae_dragresize')) {
 			this.el.classList.add('ckimgrsz');
 			this.showHandles();
 		},
-		hide: function() {
+		hide() {
 			// Remove class from all img.ckimgrsz
-			let elements = this.document.getElementsByClassName('ckimgrsz');
+			const elements = this.document.getElementsByClassName('ckimgrsz');
 			for (let i = 0; i < elements.length; ++i) {
 				elements[i].classList.remove('ckimgrsz');
 			}
@@ -281,13 +281,13 @@ if (!CKEDITOR.plugins.get('ae_dragresize')) {
 				this.container.parentNode.removeChild(this.container);
 			}
 		},
-		initDrag: function(e) {
+		initDrag(e) {
 			if (e.button !== 0) {
 				// right-click or middle-click
 				return;
 			}
-			let resizer = this;
-			let drag = new DragEvent(this.window, this.document);
+			const resizer = this;
+			const drag = new DragEvent(this.window, this.document);
 			drag.onStart = function() {
 				resizer.showPreview();
 				resizer.isDragging = true;
@@ -296,7 +296,7 @@ if (!CKEDITOR.plugins.get('ae_dragresize')) {
 			drag.onDrag = function() {
 				resizer.calculateSize(this);
 				resizer.updatePreview();
-				let box = resizer.previewBox;
+				const box = resizer.previewBox;
 				resizer.updateHandles(box, box.left, box.top);
 			};
 			drag.onRelease = function() {
@@ -314,12 +314,12 @@ if (!CKEDITOR.plugins.get('ae_dragresize')) {
 			};
 			drag.start(e);
 		},
-		updateHandles: function(box, left, top) {
+		updateHandles(box, left, top) {
 			left = left || 0;
 			top = top || 0;
-			let handles = this.handles;
+			const handles = this.handles;
 
-			for (let handle in handles) {
+			for (const handle in handles) {
 				if (handles.hasOwnProperty(handle)) {
 					POSITION_ELEMENT_FN[handle](
 						handles[handle],
@@ -330,45 +330,45 @@ if (!CKEDITOR.plugins.get('ae_dragresize')) {
 				}
 			}
 		},
-		showHandles: function() {
-			let handles = this.handles;
+		showHandles() {
+			const handles = this.handles;
 			this.updateHandles(this.box);
-			for (let n in handles) {
+			for (const n in handles) {
 				if (handles.hasOwnProperty(n)) {
 					handles[n].style.display = 'block';
 				}
 			}
 		},
-		hideHandles: function() {
-			let handles = this.handles;
-			for (let n in handles) {
+		hideHandles() {
+			const handles = this.handles;
+			for (const n in handles) {
 				if (handles.hasOwnProperty(n)) {
 					handles[n].style.display = 'none';
 				}
 			}
 		},
-		showPreview: function() {
+		showPreview() {
 			this.preview.style.backgroundImage = 'url("' + this.el.src + '")';
 			this.calculateSize();
 			this.updatePreview();
 			this.preview.style.display = 'block';
 		},
-		updatePreview: function() {
-			let box = this.previewBox;
+		updatePreview() {
+			const box = this.previewBox;
 			positionElement(this.preview, box.left, box.top);
 			this.preview.style.width = this.previewBox.width + 'px';
 			this.preview.style.height = this.previewBox.height + 'px';
 		},
-		hidePreview: function() {
-			let box = getBoundingBox(this.window, this.preview);
+		hidePreview() {
+			const box = getBoundingBox(this.window, this.preview);
 			this.result = {
 				width: box.width,
 				height: box.height,
 			};
 			this.preview.style.display = 'none';
 		},
-		calculateSize: function(data) {
-			let box = (this.previewBox = {
+		calculateSize(data) {
+			const box = (this.previewBox = {
 				top: 0,
 				left: 0,
 				width: this.box.width,
@@ -377,7 +377,7 @@ if (!CKEDITOR.plugins.get('ae_dragresize')) {
 
 			if (!data) return;
 
-			let attr = data.target.className;
+			const attr = data.target.className;
 
 			if (~attr.indexOf('r')) {
 				box.width = Math.max(32, this.box.width + data.delta.x);
@@ -393,7 +393,7 @@ if (!CKEDITOR.plugins.get('ae_dragresize')) {
 			}
 			// if dragging corner, enforce aspect ratio (unless shift key is being held)
 			if (attr.indexOf('m') < 0 && !data.keys.shift) {
-				let ratio = this.box.width / this.box.height;
+				const ratio = this.box.width / this.box.height;
 				if (box.width / box.height > ratio) {
 					box.height = Math.round(box.width / ratio);
 				} else {
@@ -401,12 +401,12 @@ if (!CKEDITOR.plugins.get('ae_dragresize')) {
 				}
 			}
 
-			let snapToSize = this.cfg.snapToSize;
+			const snapToSize = this.cfg.snapToSize;
 
 			if (snapToSize) {
-				let others = this.otherImages;
+				const others = this.otherImages;
 				for (let i = 0; i < others.length; i++) {
-					let other = getBoundingBox(this.window, others[i]);
+					const other = getBoundingBox(this.window, others[i]);
 					if (
 						Math.abs(box.width - other.width) <= snapToSize &&
 						Math.abs(box.height - other.height) <= snapToSize
@@ -426,7 +426,7 @@ if (!CKEDITOR.plugins.get('ae_dragresize')) {
 				box.top = this.box.height - box.height;
 			}
 		},
-		resizeComplete: function() {
+		resizeComplete() {
 			resizeElement.call(
 				this,
 				this.el,
@@ -447,7 +447,7 @@ if (!CKEDITOR.plugins.get('ae_dragresize')) {
 	}
 
 	DragEvent.prototype = {
-		start: function(e) {
+		start(e) {
 			e.preventDefault();
 			e.stopPropagation();
 			this.target = e.target;
@@ -457,7 +457,7 @@ if (!CKEDITOR.plugins.get('ae_dragresize')) {
 				y: e.clientY,
 			};
 			this.update(e);
-			let events = this.events;
+			const events = this.events;
 			this.document.addEventListener(
 				'mousemove',
 				events.mousemove,
@@ -466,9 +466,11 @@ if (!CKEDITOR.plugins.get('ae_dragresize')) {
 			this.document.addEventListener('keydown', events.keydown, false);
 			this.document.addEventListener('mouseup', events.mouseup, false);
 			this.document.body.classList.add('dragging-' + this.attr);
-			this.onStart && this.onStart();
+			if (this.onStart) {
+				this.onStart();
+			}
 		},
-		update: function(e) {
+		update(e) {
 			this.currentPos = {
 				x: e.clientX,
 				y: e.clientY,
@@ -483,28 +485,32 @@ if (!CKEDITOR.plugins.get('ae_dragresize')) {
 				alt: e.altKey,
 			};
 		},
-		mousemove: function(e) {
+		mousemove(e) {
 			this.update(e);
-			this.onDrag && this.onDrag();
+			if (this.onDrag) {
+				this.onDrag();
+			}
 			if (e.which === 0) {
 				// mouse button released outside window; mouseup wasn't fired (Chrome)
 				this.mouseup(e);
 			}
 		},
-		keydown: function(e) {
+		keydown(e) {
 			// escape key cancels dragging
 			if (e.keyCode === 27) {
 				this.release();
 			}
 		},
-		mouseup: function(e) {
+		mouseup(e) {
 			this.update(e);
 			this.release();
-			this.onComplete && this.onComplete();
+			if (this.onComplete) {
+				this.onComplete();
+			}
 		},
-		release: function() {
+		release() {
 			this.document.body.classList.remove('dragging-' + this.attr);
-			let events = this.events;
+			const events = this.events;
 			this.document.removeEventListener(
 				'mousemove',
 				events.mousemove,
@@ -512,15 +518,17 @@ if (!CKEDITOR.plugins.get('ae_dragresize')) {
 			);
 			this.document.removeEventListener('keydown', events.keydown, false);
 			this.document.removeEventListener('mouseup', events.mouseup, false);
-			this.onRelease && this.onRelease();
+			if (this.onRelease) {
+				this.onRelease();
+			}
 		},
 	};
 
 	// helper functions
 	function toArray(obj) {
-		let len = obj.length;
+		const len = obj.length;
 
-		let arr = new Array(len);
+		const arr = new Array(len);
 		for (let i = 0; i < len; i++) {
 			arr[i] = obj[i];
 		}
@@ -542,7 +550,7 @@ if (!CKEDITOR.plugins.get('ae_dragresize')) {
 	}
 
 	function resizeElement(el, width, height) {
-		let imageScaleResize = this.editor.config.imageScaleResize;
+		const imageScaleResize = this.editor.config.imageScaleResize;
 		if (imageScaleResize === 'both') {
 			el.style.width = String(width) + 'px';
 			el.style.height = String(height) + 'px';
@@ -559,7 +567,7 @@ if (!CKEDITOR.plugins.get('ae_dragresize')) {
 	}
 
 	function getBoundingBox(window, el) {
-		let rect = el.getBoundingClientRect();
+		const rect = el.getBoundingClientRect();
 		return {
 			left: rect.left + window.pageXOffset,
 			top: rect.top + window.pageYOffset,

--- a/src/plugins/dragresize_ie.js
+++ b/src/plugins/dragresize_ie.js
@@ -3,7 +3,7 @@
  * - Show gripper to resize images on IE
  */
 if (!CKEDITOR.plugins.get('ae_dragresize_ie')) {
-	let alignmentsObj = {
+	const alignmentsObj = {
 		center: 1,
 		left: 0,
 		right: 2,
@@ -13,30 +13,30 @@ if (!CKEDITOR.plugins.get('ae_dragresize_ie')) {
 	 * Set cursor css depend on imageScaleResize config
 	 **/
 
-	let cursor = {
+	const cursor = {
 		both: 'nwse-resize',
 		height: 'ns-resize',
 		scale: 'nwse-resize',
 		width: 'ew-resize',
 	};
 
-	let regexPercent = /^\s*(\d+%)\s*$/i;
+	const regexPercent = /^\s*(\d+%)\s*$/i;
 
-	let template = '<img alt="" src="" />';
+	const template = '<img alt="" src="" />';
 
 	CKEDITOR.plugins.add('ae_dragresize_ie', {
 		hidpi: true,
 
 		icons: 'image',
 
-		init: function(editor) {
-			let image = widgetDef(editor);
+		init(editor) {
+			const image = widgetDef(editor);
 
 			// Register the widget.
 			editor.widgets.add('image', image);
 		},
 
-		onLoad: function() {
+		onLoad() {
 			CKEDITOR.addCss(
 				'.cke_image_resizer_nwse-resize{' +
 					'cursor: nwse-resize;' +
@@ -183,17 +183,17 @@ if (!CKEDITOR.plugins.get('ae_dragresize_ie')) {
 			editor.widgets.initOn(imageData.data.el, 'image');
 		});
 
-		let alignClasses = editor.config.image2_alignClasses;
+		const alignClasses = editor.config.image2_alignClasses;
 
-		let captionedClass = editor.config.image2_captionedClass;
+		const captionedClass = editor.config.image2_captionedClass;
 
 		return {
-			init: function() {
-				let helpers = CKEDITOR.plugins.image2;
+			init() {
+				const helpers = CKEDITOR.plugins.image2;
 
-				let image = this.parts.image;
+				const image = this.parts.image;
 
-				let data = {
+				const data = {
 					alt: image.getAttribute('alt') || '',
 					hasCaption: !!this.parts.caption,
 					height: image.getAttribute('height') || '',
@@ -208,7 +208,7 @@ if (!CKEDITOR.plugins.get('ae_dragresize_ie')) {
 				// If we used 'a' in widget#parts definition, it could happen that
 				// selected element is a child of widget.parts#caption. Since there's no clever
 				// way to solve it with CSS selectors, it's done like that. (#11783).
-				let link = image.getAscendant('a');
+				const link = image.getAscendant('a');
 
 				if (link && this.wrapper.contains(link)) {
 					this.parts.link = link;
@@ -219,7 +219,7 @@ if (!CKEDITOR.plugins.get('ae_dragresize_ie')) {
 				// Note: Center alignment is detected during upcast, so only left/right cases
 				// are checked below.
 				if (!data.align) {
-					let alignElement = data.hasCaption ? this.element : image;
+					const alignElement = data.hasCaption ? this.element : image;
 
 					// Read the initial left/right alignment from the class set on element.
 					if (alignClasses) {
@@ -259,7 +259,7 @@ if (!CKEDITOR.plugins.get('ae_dragresize_ie')) {
 
 			// Overrides default method to handle internal mutability of Image2.
 			// @see CKEDITOR.plugins.widget#addClass
-			addClass: function(className) {
+			addClass(className) {
 				getStyleableElement(this).addClass(className);
 			},
 
@@ -268,8 +268,8 @@ if (!CKEDITOR.plugins.get('ae_dragresize_ie')) {
 			// This widget converts style-driven dimensions to attributes.
 			contentTransformations: [['img[width]: sizeToAttribute']],
 
-			data: function() {
-				let features = this.features;
+			data() {
+				const features = this.features;
 
 				// Image can't be captioned when figcaption is disallowed (#11004).
 				if (
@@ -321,7 +321,7 @@ if (!CKEDITOR.plugins.get('ae_dragresize_ie')) {
 					!this.oldData.hasCaption &&
 					this.data.hasCaption
 				) {
-					for (let c in this.data.classes) {
+					for (const c in this.data.classes) {
 						if (this.data.classes.hasOwnProperty(c)) {
 							this.parts.image.removeClass(c);
 						}
@@ -355,20 +355,20 @@ if (!CKEDITOR.plugins.get('ae_dragresize_ie')) {
 			// Overrides default method to handle internal mutability of Image2.
 			// @see CKEDITOR.plugins.widget#getClasses
 			getClasses: (function() {
-				let classRegex = new RegExp(
+				const classRegex = new RegExp(
 					'^(' +
 						[].concat(captionedClass, alignClasses).join('|') +
 						')$'
 				);
 
 				return function() {
-					let classes = this.repository.parseElementClasses(
+					const classes = this.repository.parseElementClasses(
 						getStyleableElement(this).getAttribute('class')
 					);
 
 					// Neither config.image2_captionedClass nor config.image2_alignClasses
 					// do not belong to style classes.
-					for (let c in classes) {
+					for (const c in classes) {
 						if (classRegex.test(c)) {
 							delete classes[c];
 						}
@@ -378,15 +378,15 @@ if (!CKEDITOR.plugins.get('ae_dragresize_ie')) {
 				};
 			})(),
 
-			getLabel: function() {
-				let label = (this.data.alt || '') + ' ' + this.pathName;
+			getLabel() {
+				const label = (this.data.alt || '') + ' ' + this.pathName;
 
 				return label;
 			},
 
 			// Overrides default method to handle internal mutability of Image2.
 			// @see CKEDITOR.plugins.widget#hasClass
-			hasClass: function(className) {
+			hasClass(className) {
 				return getStyleableElement(this).hasClass(className);
 			},
 
@@ -397,7 +397,7 @@ if (!CKEDITOR.plugins.get('ae_dragresize_ie')) {
 
 			// Overrides default method to handle internal mutability of Image2.
 			// @see CKEDITOR.plugins.widget#removeClass
-			removeClass: function(className) {
+			removeClass(className) {
 				getStyleableElement(this).removeClass(className);
 			},
 
@@ -406,7 +406,7 @@ if (!CKEDITOR.plugins.get('ae_dragresize_ie')) {
 			styleableElements: 'img figure',
 
 			// Template of the widget: plain image.
-			template: template,
+			template,
 
 			upcast: upcastWidgetElement(editor),
 		};
@@ -426,10 +426,10 @@ if (!CKEDITOR.plugins.get('ae_dragresize_ie')) {
 		 * @param {CKEDITOR.dom.element} image
 		 * @return {Boolean}
 		 */
-		checkHasNaturalRatio: function(image) {
-			let $ = image.$;
+		checkHasNaturalRatio(image) {
+			const $ = image.$;
 
-			let natural = this.getNatural(image);
+			const natural = this.getNatural(image);
 
 			// The reason for two alternative comparisons is that the rounding can come from
 			// both dimensions, e.g. there are two cases:
@@ -451,7 +451,7 @@ if (!CKEDITOR.plugins.get('ae_dragresize_ie')) {
 		 * @param {CKEDITOR.dom.element} image
 		 * @return {Object}
 		 */
-		getNatural: function(image) {
+		getNatural(image) {
 			let dimensions;
 
 			if (image.$.naturalWidth) {
@@ -460,7 +460,7 @@ if (!CKEDITOR.plugins.get('ae_dragresize_ie')) {
 					width: image.$.naturalWidth,
 				};
 			} else {
-				let img = new Image();
+				const img = new Image();
 
 				img.src = image.getAttribute('src');
 
@@ -480,19 +480,19 @@ if (!CKEDITOR.plugins.get('ae_dragresize_ie')) {
 	// @param {CKEDITOR.editor} editor
 	// @returns {Function}
 	function upcastWidgetElement(editor) {
-		let isCenterWrapper = centerWrapperChecker(editor);
+		const isCenterWrapper = centerWrapperChecker(editor);
 
-		let captionedClass = editor.config.image2_captionedClass;
+		const captionedClass = editor.config.image2_captionedClass;
 
 		// @param {CKEDITOR.htmlParser.element} el
 		// @param {Object} data
 		return function(el, data) {
-			let dimensions = {
+			const dimensions = {
 				height: 1,
 				width: 1,
 			};
 
-			let name = el.name;
+			const name = el.name;
 
 			let image;
 
@@ -515,7 +515,7 @@ if (!CKEDITOR.plugins.get('ae_dragresize_ie')) {
 			//    than ENTER_P.
 			if (isCenterWrapper(el)) {
 				if (name == 'div') {
-					let figure = el.getFirst('figure');
+					const figure = el.getFirst('figure');
 
 					// Case #1.
 					if (figure) {
@@ -547,9 +547,9 @@ if (!CKEDITOR.plugins.get('ae_dragresize_ie')) {
 
 			// If there's an image, then cool, we got a widget.
 			// Now just remove dimension attributes expressed with %.
-			for (let d in dimensions) {
+			for (const d in dimensions) {
 				if (dimensions.hasOwnProperty(d)) {
-					let dimension = image.attributes[d];
+					const dimension = image.attributes[d];
 
 					if (dimension && dimension.match(regexPercent)) {
 						delete image.attributes[d];
@@ -566,24 +566,24 @@ if (!CKEDITOR.plugins.get('ae_dragresize_ie')) {
 	//
 	// @param {CKEDITOR.editor}
 	function downcastWidgetElement(editor) {
-		let alignClasses = editor.config.image2_alignClasses;
+		const alignClasses = editor.config.image2_alignClasses;
 
 		// @param {CKEDITOR.htmlParser.element} el
 		return function(el) {
 			// In case of <a><img/></a>, <img/> is the element to hold
 			// inline styles or classes (image2_alignClasses).
-			let attrsHolder = el.name == 'a' ? el.getFirst() : el;
+			const attrsHolder = el.name == 'a' ? el.getFirst() : el;
 
 			delete attrsHolder.attributes.contenteditable;
 
-			let attrs = attrsHolder.attributes;
+			const attrs = attrsHolder.attributes;
 
-			let align = this.data.align;
+			const align = this.data.align;
 
 			// De-wrap the image from resize handle wrapper.
 			// Only block widgets have one.
 			if (!this.inline) {
-				let resizeWrapper = el.getFirst('span');
+				const resizeWrapper = el.getFirst('span');
 
 				if (resizeWrapper) {
 					resizeWrapper.replaceWith(
@@ -596,7 +596,7 @@ if (!CKEDITOR.plugins.get('ae_dragresize_ie')) {
 			}
 
 			if (align && align != 'none') {
-				let styles = CKEDITOR.tools.parseCssText(attrs.style || '');
+				const styles = CKEDITOR.tools.parseCssText(attrs.style || '');
 
 				// When the widget is captioned (<figure>) and internally centering is done
 				// with widget's wrapper style/class, in the external data representation,
@@ -657,11 +657,11 @@ if (!CKEDITOR.plugins.get('ae_dragresize_ie')) {
 	// @param {CKEDITOR.editor} editor
 	// @returns {Function}
 	function centerWrapperChecker(editor) {
-		let captionedClass = editor.config.image2_captionedClass;
+		const captionedClass = editor.config.image2_captionedClass;
 
-		let alignClasses = editor.config.image2_alignClasses;
+		const alignClasses = editor.config.image2_alignClasses;
 
-		let validChildren = {
+		const validChildren = {
 			a: 1,
 			figure: 1,
 			img: 1,
@@ -681,14 +681,14 @@ if (!CKEDITOR.plugins.get('ae_dragresize_ie')) {
 				return false;
 			}
 
-			let children = el.children;
+			const children = el.children;
 
 			// Centering wrapper can have only one child.
 			if (children.length !== 1) {
 				return false;
 			}
 
-			let child = children[0];
+			const child = children[0];
 
 			// Only <figure> or <img /> can be first (only) child of centering wrapper,
 			// regardless of its type.
@@ -762,16 +762,16 @@ if (!CKEDITOR.plugins.get('ae_dragresize_ie')) {
 	//
 	// @param {CKEDITOR.plugins.widget} widget
 	function setDimensions(widget) {
-		let data = widget.data;
+		const data = widget.data;
 
-		let dimensions = {
+		const dimensions = {
 			height: data.height,
 			width: data.width,
 		};
 
-		let image = widget.parts.image;
+		const image = widget.parts.image;
 
-		for (let d in dimensions) {
+		for (const d in dimensions) {
 			if (dimensions[d]) {
 				image.setAttribute(d, dimensions[d]);
 			} else {
@@ -784,14 +784,14 @@ if (!CKEDITOR.plugins.get('ae_dragresize_ie')) {
 	//
 	// @param {CKEDITOR.plugins.widget} widget
 	function setupResizer(widget) {
-		let editor = widget.editor;
+		const editor = widget.editor;
 
-		let editable = editor.editable();
+		const editable = editor.editable();
 
-		let doc = editor.document;
+		const doc = editor.document;
 
 		// Store the resizer in a widget for testing (#11004).
-		let resizer = (widget.resizer = doc.createElement('span'));
+		const resizer = (widget.resizer = doc.createElement('span'));
 
 		resizer.addClass('cke_image_resizer');
 		resizer.addClass(
@@ -801,11 +801,11 @@ if (!CKEDITOR.plugins.get('ae_dragresize_ie')) {
 
 		// Inline widgets don't need a resizer wrapper as an image spans the entire widget.
 		if (!widget.inline) {
-			let imageOrLink = widget.parts.link || widget.parts.image;
+			const imageOrLink = widget.parts.link || widget.parts.image;
 
-			let oldResizeWrapper = imageOrLink.getParent();
+			const oldResizeWrapper = imageOrLink.getParent();
 
-			let resizeWrapper = doc.createElement('span');
+			const resizeWrapper = doc.createElement('span');
 
 			resizeWrapper.addClass('cke_image_resizer_wrapper');
 			resizeWrapper.append(imageOrLink);
@@ -823,28 +823,28 @@ if (!CKEDITOR.plugins.get('ae_dragresize_ie')) {
 
 		// Calculate values of size variables and mouse offsets.
 		resizer.on('mousedown', function(evt) {
-			let image = widget.parts.image;
+			const image = widget.parts.image;
 
 			// "factor" can be either 1 or -1. I.e.: For right-aligned images, we need to
 			// subtract the difference to get proper width, etc. Without "factor",
 			// resizer starts working the opposite way.
-			let factor = widget.data.align == 'right' ? -1 : 1;
+			const factor = widget.data.align == 'right' ? -1 : 1;
 
 			// The x-coordinate of the mouse relative to the screen
 			// when button gets pressed.
-			let startX = evt.data.$.screenX;
+			const startX = evt.data.$.screenX;
 
-			let startY = evt.data.$.screenY;
+			const startY = evt.data.$.screenY;
 
 			// The initial dimensions and aspect ratio of the image.
-			let startWidth = image.$.clientWidth;
+			const startWidth = image.$.clientWidth;
 
-			let startHeight = image.$.clientHeight;
+			const startHeight = image.$.clientHeight;
 
-			let listeners = [];
+			const listeners = [];
 
 			// A class applied to editable during resizing.
-			let cursorClass = 'cke_image_s' + (!~factor ? 'w' : 'e');
+			const cursorClass = 'cke_image_s' + (!~factor ? 'w' : 'e');
 
 			let nativeEvt;
 			let newWidth;
@@ -872,9 +872,9 @@ if (!CKEDITOR.plugins.get('ae_dragresize_ie')) {
 			// Attaches an event to a global document if inline editor.
 			// Additionally, if classic (`iframe`-based) editor, also attaches the same event to `iframe`'s document.
 			function attachToDocuments(name, callback, collection) {
-				let globalDoc = CKEDITOR.document;
+				const globalDoc = CKEDITOR.document;
 
-				let listeners = [];
+				const listeners = [];
 
 				if (!doc.equals(globalDoc)) {
 					listeners.push(globalDoc.on(name, callback));
@@ -907,7 +907,7 @@ if (!CKEDITOR.plugins.get('ae_dragresize_ie')) {
 			// 	                <------->
 			// 	                moveDiffX
 			function onMouseMove(evt) {
-				let imageScaleResize = editor.config.imageScaleResize;
+				const imageScaleResize = editor.config.imageScaleResize;
 
 				nativeEvt = evt.data.$;
 
@@ -988,18 +988,18 @@ if (!CKEDITOR.plugins.get('ae_dragresize_ie')) {
 		});
 
 		widget.parts.image.on('click', function() {
-			let selection = editor.getSelection();
+			const selection = editor.getSelection();
 
 			if (selection) {
-				let element = selection.getStartElement();
+				const element = selection.getStartElement();
 
 				if (element) {
-					let widgetElement = element.findOne('img');
+					const widgetElement = element.findOne('img');
 
 					if (widgetElement) {
-						let region = element.getClientRect();
+						const region = element.getClientRect();
 
-						let scrollPosition = new CKEDITOR.dom.window(
+						const scrollPosition = new CKEDITOR.dom.window(
 							window
 						).getScrollPosition();
 						region.left -= scrollPosition.x;
@@ -1011,7 +1011,7 @@ if (!CKEDITOR.plugins.get('ae_dragresize_ie')) {
 							nativeEvent: event,
 							selectionData: {
 								element: widgetElement,
-								region: region,
+								region,
 							},
 						});
 					}
@@ -1027,7 +1027,7 @@ if (!CKEDITOR.plugins.get('ae_dragresize_ie')) {
 	// @param {CKEDITOR.editor}
 	// @returns {Object}
 	function getWidgetAllowedContent(editor) {
-		let rules = {
+		const rules = {
 			figcaption: true,
 			figure: {
 				classes: '!' + editor.config.image2_captionedClass,
@@ -1048,9 +1048,9 @@ if (!CKEDITOR.plugins.get('ae_dragresize_ie')) {
 	// @param {CKEDITOR.editor}
 	// @returns {Object}
 	function getWidgetFeatures(editor) {
-		let alignClasses = editor.config.image2_alignClasses;
+		const alignClasses = editor.config.image2_alignClasses;
 
-		let features = {
+		const features = {
 			align: {
 				requiredContent:
 					'img' +

--- a/src/plugins/dragresize_ie11.js
+++ b/src/plugins/dragresize_ie11.js
@@ -8,22 +8,22 @@
 		return;
 	}
 
-	let template = '<img alt="" src="" />';
+	const template = '<img alt="" src="" />';
 
-	let templateBlock = new CKEDITOR.template(
+	const templateBlock = new CKEDITOR.template(
 		'<figure class="{captionedClass}">' +
 			template +
 			'<figcaption>{captionPlaceholder}</figcaption>' +
 			'</figure>'
 	);
 
-	let alignmentsObj = {left: 0, center: 1, right: 2};
+	const alignmentsObj = {left: 0, center: 1, right: 2};
 
-	let regexPercent = /^\s*(\d+%)\s*$/i;
+	const regexPercent = /^\s*(\d+%)\s*$/i;
 
 	CKEDITOR.plugins.add('ae_dragresize_ie11', {
 		requires: 'widget',
-		onLoad: function() {
+		onLoad() {
 			CKEDITOR.addCss(
 				'.cke_image_nocaption{' +
 					// This is to remove unwanted space so resize
@@ -89,11 +89,11 @@
 			);
 		},
 
-		init: function(editor) {
+		init(editor) {
 			// Adapts configuration from original image plugin. Should be removed
 			// when we'll rename ae_dragresize_ie11 to image.
 
-			let image = widgetDef(editor);
+			const image = widgetDef(editor);
 
 			// Register the widget.
 			editor.widgets.add('image', image);
@@ -101,18 +101,18 @@
 			// Add a listener to handle selection change events and properly detect editor
 			// interactions on the widgets without messing with widget native selection
 			editor.on('selectionChange', function(_event) {
-				let selection = editor.getSelection();
+				const selection = editor.getSelection();
 
 				if (selection) {
-					let element = selection.getSelectedElement();
+					const element = selection.getSelectedElement();
 
 					if (element) {
-						let widgetElement = element.findOne('img');
+						const widgetElement = element.findOne('img');
 
 						if (widgetElement) {
-							let region = element.getClientRect();
+							const region = element.getClientRect();
 
-							let scrollPosition = new CKEDITOR.dom.window(
+							const scrollPosition = new CKEDITOR.dom.window(
 								window
 							).getScrollPosition();
 							region.left -= scrollPosition.x;
@@ -124,7 +124,7 @@
 								nativeEvent: {},
 								selectionData: {
 									element: widgetElement,
-									region: region,
+									region,
 								},
 							});
 						}
@@ -133,13 +133,13 @@
 			});
 		},
 
-		afterInit: function(editor) {
+		afterInit(editor) {
 			// Integrate with align commands (justify plugin).
-			let align = {left: 1, right: 1, center: 1, block: 1};
+			const align = {left: 1, right: 1, center: 1, block: 1};
 
-			let integrate = alignCommandIntegrator(editor);
+			const integrate = alignCommandIntegrator(editor);
 
-			for (let value in align) {
+			for (const value in align) {
 				if (align.hasOwnProperty(value)) {
 					integrate(value);
 				}
@@ -240,9 +240,9 @@
 	// @param {CKEDITOR.editor}
 	// @returns {Object}
 	function widgetDef(editor) {
-		let alignClasses = editor.config.ae_dragresize_ie11_alignClasses;
+		const alignClasses = editor.config.ae_dragresize_ie11_alignClasses;
 
-		let captionedClass = editor.config.ae_dragresize_ie11_captionedClass;
+		const captionedClass = editor.config.ae_dragresize_ie11_captionedClass;
 
 		function deflate() {
 			if (this.deflated) return;
@@ -257,9 +257,9 @@
 		}
 
 		function inflate() {
-			let editable = editor.editable();
+			const editable = editor.editable();
 
-			let doc = editor.document;
+			const doc = editor.document;
 
 			// Create a new widget. This widget will be either captioned
 			// non-captioned, block or inline according to what is the
@@ -279,7 +279,7 @@
 					!new CKEDITOR.dom.elementPath(this.widget.wrapper, editable)
 						.block
 				) {
-					let block = doc.createElement(
+					const block = doc.createElement(
 						editor.activeEnterMode == CKEDITOR.ENTER_P ? 'p' : 'div'
 					);
 					block.replace(this.widget.wrapper);
@@ -330,10 +330,10 @@
 			},
 
 			// Template of the widget: plain image.
-			template: template,
+			template,
 
-			data: function() {
-				let features = this.features;
+			data() {
+				const features = this.features;
 
 				// Image can't be captioned when figcaption is disallowed (#11004).
 				if (
@@ -355,8 +355,8 @@
 					element: this.element,
 					oldData: this.oldData,
 					newData: this.data,
-					deflate: deflate,
-					inflate: inflate,
+					deflate,
+					inflate,
 				});
 
 				// Update widget.parts.link since it will not auto-update unless widget
@@ -384,7 +384,7 @@
 					!this.oldData.hasCaption &&
 					this.data.hasCaption
 				) {
-					for (let c in this.data.classes) {
+					for (const c in this.data.classes) {
 						if (this.data.classes.hasOwnProperty(c)) {
 							this.parts.image.removeClass(c);
 						}
@@ -400,12 +400,12 @@
 				this.oldData = CKEDITOR.tools.extend({}, this.data);
 			},
 
-			init: function() {
-				let helpers = CKEDITOR.plugins.ae_dragresize_ie11;
+			init() {
+				const helpers = CKEDITOR.plugins.ae_dragresize_ie11;
 
-				let image = this.parts.image;
+				const image = this.parts.image;
 
-				let data = {
+				const data = {
 					hasCaption: !!this.parts.caption,
 					src: image.getAttribute('src'),
 					alt: image.getAttribute('alt') || '',
@@ -421,7 +421,7 @@
 				// If we used 'a' in widget#parts definition, it could happen that
 				// selected element is a child of widget.parts#caption. Since there's no clever
 				// way to solve it with CSS selectors, it's done like that. (#11783).
-				let link = image.getAscendant('a');
+				const link = image.getAscendant('a');
 
 				if (link && this.wrapper.contains(link)) this.parts.link = link;
 
@@ -430,7 +430,7 @@
 				// Note: Center alignment is detected during upcast, so only left/right cases
 				// are checked below.
 				if (!data.align) {
-					let alignElement = data.hasCaption ? this.element : image;
+					const alignElement = data.hasCaption ? this.element : image;
 
 					// Read the initial left/right alignment from the class set on element.
 					if (alignClasses) {
@@ -464,7 +464,7 @@
 
 					// Get rid of cke_widget_* classes in data. Otherwise
 					// they might appear in link dialog.
-					let advanced = data.link.advanced;
+					const advanced = data.link.advanced;
 					if (advanced && advanced.advCSSClasses) {
 						advanced.advCSSClasses = CKEDITOR.tools.trim(
 							advanced.advCSSClasses.replace(/cke_\S+/, '')
@@ -504,39 +504,39 @@
 
 			// Overrides default method to handle internal mutability of ae_dragresize_ie11.
 			// @see CKEDITOR.plugins.widget#addClass
-			addClass: function(className) {
+			addClass(className) {
 				getStyleableElement(this).addClass(className);
 			},
 
 			// Overrides default method to handle internal mutability of ae_dragresize_ie11.
 			// @see CKEDITOR.plugins.widget#hasClass
-			hasClass: function(className) {
+			hasClass(className) {
 				return getStyleableElement(this).hasClass(className);
 			},
 
 			// Overrides default method to handle internal mutability of ae_dragresize_ie11.
 			// @see CKEDITOR.plugins.widget#removeClass
-			removeClass: function(className) {
+			removeClass(className) {
 				getStyleableElement(this).removeClass(className);
 			},
 
 			// Overrides default method to handle internal mutability of ae_dragresize_ie11.
 			// @see CKEDITOR.plugins.widget#getClasses
 			getClasses: (function() {
-				let classRegex = new RegExp(
+				const classRegex = new RegExp(
 					'^(' +
 						[].concat(captionedClass, alignClasses).join('|') +
 						')$'
 				);
 
 				return function() {
-					let classes = this.repository.parseElementClasses(
+					const classes = this.repository.parseElementClasses(
 						getStyleableElement(this).getAttribute('class')
 					);
 
 					// Neither config.ae_dragresize_ie11_captionedClass nor config.ae_dragresize_ie11_alignClasses
 					// do not belong to style classes.
-					for (let c in classes) {
+					for (const c in classes) {
 						if (classRegex.test(c)) delete classes[c];
 					}
 
@@ -547,8 +547,8 @@
 			upcast: upcastWidgetElement(editor),
 			downcast: downcastWidgetElement(editor),
 
-			getLabel: function() {
-				let label = (this.data.alt || '') + ' ' + this.pathName;
+			getLabel() {
+				const label = (this.data.alt || '') + ' ' + this.pathName;
 
 				return this.editor.lang.widget.label.replace(/%1/, label);
 			},
@@ -562,25 +562,25 @@
 	 * @singleton
 	 */
 	CKEDITOR.plugins.ae_dragresize_ie11 = {
-		stateShifter: function(editor) {
+		stateShifter(editor) {
 			// Tag name used for centering non-captioned widgets.
-			let doc = editor.document;
+			const doc = editor.document;
 
-			let alignClasses = editor.config.ae_dragresize_ie11_alignClasses;
+			const alignClasses = editor.config.ae_dragresize_ie11_alignClasses;
 
-			let captionedClass =
+			const captionedClass =
 				editor.config.ae_dragresize_ie11_captionedClass;
 
-			let editable = editor.editable();
+			const editable = editor.editable();
 
 			// The order that stateActions get executed. It matters!
 
-			let shiftables = ['hasCaption', 'align', 'link'];
+			const shiftables = ['hasCaption', 'align', 'link'];
 
 			// Atomic procedures, one per state variable.
-			let stateActions = {
-				align: function(shift, oldValue, newValue) {
-					let el = shift.element;
+			const stateActions = {
+				align(shift, oldValue, newValue) {
+					const el = shift.element;
 
 					// Alignment changed.
 					if (
@@ -630,7 +630,7 @@
 					}
 				},
 
-				hasCaption: function(shift, oldValue, newValue) {
+				hasCaption(shift, oldValue, newValue) {
 					// This action is for real state change only.
 					if (!shift.changed.hasCaption) return;
 
@@ -647,9 +647,9 @@
 					// There was no caption, but the caption is to be added.
 					if (newValue) {
 						// Create new <figure> from widget template.
-						let figure = CKEDITOR.dom.element.createFromHtml(
+						const figure = CKEDITOR.dom.element.createFromHtml(
 							templateBlock.output({
-								captionedClass: captionedClass,
+								captionedClass,
 								captionPlaceholder:
 									editor.lang.ae_dragresize_ie11
 										.captionPlaceholder,
@@ -678,13 +678,13 @@
 					}
 				},
 
-				link: function(shift, oldValue, newValue) {
+				link(shift, oldValue, newValue) {
 					if (shift.changed.link) {
-						let img = shift.element.is('img')
+						const img = shift.element.is('img')
 							? shift.element
 							: shift.element.findOne('img');
 
-						let link = shift.element.is('a')
+						const link = shift.element.is('a')
 							? shift.element
 							: shift.element.findOne('a');
 
@@ -694,7 +694,7 @@
 						// If element is <a><img/></a>, it will be unlinked
 						// so <img/> becomes a new widget.element.
 
-						let needsDeflate =
+						const needsDeflate =
 							(shift.element.is('a') && !newValue) ||
 							(shift.element.is('img') && newValue);
 
@@ -710,7 +710,7 @@
 								newEl = wrapInLink(img, shift.newData.link);
 
 							// Set and remove all attributes associated with this state.
-							let attributes = CKEDITOR.plugins.ae_dragresize_ie11.getLinkAttributesGetter()(
+							const attributes = CKEDITOR.plugins.ae_dragresize_ie11.getLinkAttributesGetter()(
 								editor,
 								newValue
 							);
@@ -730,7 +730,7 @@
 			};
 
 			function wrapInCentering(editor, element) {
-				let attribsAndStyles = {};
+				const attribsAndStyles = {};
 
 				if (alignClasses)
 					attribsAndStyles.attributes = {class: alignClasses[1]};
@@ -738,7 +738,7 @@
 
 				// There's no gentle way to center inline element with CSS, so create p/div
 				// that wraps widget contents and does the trick either with style or class.
-				let center = doc.createElement(
+				const center = doc.createElement(
 					editor.activeEnterMode == CKEDITOR.ENTER_P ? 'p' : 'div',
 					attribsAndStyles
 				);
@@ -751,7 +751,7 @@
 			}
 
 			function unwrapFromCentering(element) {
-				let imageOrLink = element.findOne('a,img');
+				const imageOrLink = element.findOne('a,img');
 
 				imageOrLink.replace(element);
 
@@ -765,7 +765,7 @@
 			// @param {Object} linkData
 			// @returns {CKEDITOR.dom.element}
 			function wrapInLink(img, linkData) {
-				let link = doc.createElement('a', {
+				const link = doc.createElement('a', {
 					attributes: {
 						href: linkData.url,
 					},
@@ -783,7 +783,7 @@
 			// @param {CKEDITOR.dom.element} link
 			// @returns {CKEDITOR.dom.element}
 			function unwrapFromLink(link) {
-				let img = link.findOne('img');
+				const img = link.findOne('img');
 
 				img.replace(link);
 
@@ -792,7 +792,7 @@
 
 			function replaceSafely(replacing, replaced) {
 				if (replaced.getParent()) {
-					let range = editor.createRange();
+					const range = editor.createRange();
 
 					range.moveToPosition(
 						replaced,
@@ -846,10 +846,10 @@
 		 * @param {CKEDITOR.dom.element} image
 		 * @return {Boolean}
 		 */
-		checkHasNaturalRatio: function(image) {
-			let $ = image.$;
+		checkHasNaturalRatio(image) {
+			const $ = image.$;
 
-			let natural = this.getNatural(image);
+			const natural = this.getNatural(image);
 
 			// The reason for two alternative comparisons is that the rounding can come from
 			// both dimensions, e.g. there are two cases:
@@ -871,7 +871,7 @@
 		 * @param {CKEDITOR.dom.element} image
 		 * @return {Object}
 		 */
-		getNatural: function(image) {
+		getNatural(image) {
 			let dimensions;
 
 			if (image.$.naturalWidth) {
@@ -880,7 +880,7 @@
 					height: image.$.naturalHeight,
 				};
 			} else {
-				let img = new Image();
+				const img = new Image();
 				img.src = image.getAttribute('src');
 
 				dimensions = {
@@ -908,7 +908,7 @@
 		 * @return {Function} A function that gets (composes) link attributes.
 		 * @since 4.5.5
 		 */
-		getLinkAttributesGetter: function() {
+		getLinkAttributesGetter() {
 			// #13885
 			return CKEDITOR.plugins.link.getLinkAttributes;
 		},
@@ -932,18 +932,18 @@
 		 * @return {Function} A function that parses attributes.
 		 * @since 4.5.5
 		 */
-		getLinkAttributesParser: function() {
+		getLinkAttributesParser() {
 			// #13885
 			return CKEDITOR.plugins.link.parseLinkAttributes;
 		},
 	};
 
 	function setWrapperAlign(widget, alignClasses) {
-		let wrapper = widget.wrapper;
+		const wrapper = widget.wrapper;
 
-		let align = widget.data.align;
+		const align = widget.data.align;
 
-		let hasCaption = widget.data.hasCaption;
+		const hasCaption = widget.data.hasCaption;
 
 		if (alignClasses) {
 			// Remove all align classes first.
@@ -977,7 +977,7 @@
 				wrapper.removeStyle('text-align');
 			}
 
-			let image = wrapper.$.querySelector('img');
+			const image = wrapper.$.querySelector('img');
 
 			image.removeAttribute('style');
 		}
@@ -989,16 +989,16 @@
 	// @param {CKEDITOR.editor} editor
 	// @returns {Function}
 	function upcastWidgetElement(editor) {
-		let isCenterWrapper = centerWrapperChecker(editor);
+		const isCenterWrapper = centerWrapperChecker(editor);
 
-		let captionedClass = editor.config.ae_dragresize_ie11_captionedClass;
+		const captionedClass = editor.config.ae_dragresize_ie11_captionedClass;
 
 		// @param {CKEDITOR.htmlParser.element} el
 		// @param {Object} data
 		return function(el, data) {
-			let dimensions = {width: 1, height: 1};
+			const dimensions = {width: 1, height: 1};
 
-			let name = el.name;
+			const name = el.name;
 
 			let image;
 
@@ -1019,7 +1019,7 @@
 			//    than ENTER_P.
 			if (isCenterWrapper(el)) {
 				if (name == 'div') {
-					let figure = el.getFirst('figure');
+					const figure = el.getFirst('figure');
 
 					// Case #1.
 					if (figure) {
@@ -1049,9 +1049,9 @@
 
 			// If there's an image, then cool, we got a widget.
 			// Now just remove dimension attributes expressed with %.
-			for (let d in dimensions) {
+			for (const d in dimensions) {
 				if (dimensions.hasOwnProperty(d)) {
-					let dimension = image.attributes[d];
+					const dimension = image.attributes[d];
 					if (dimension && dimension.match(regexPercent))
 						delete image.attributes[d];
 				}
@@ -1066,22 +1066,22 @@
 	//
 	// @param {CKEDITOR.editor}
 	function downcastWidgetElement(editor) {
-		let alignClasses = editor.config.ae_dragresize_ie11_alignClasses;
+		const alignClasses = editor.config.ae_dragresize_ie11_alignClasses;
 
 		// @param {CKEDITOR.htmlParser.element} el
 		return function(el) {
 			// In case of <a><img/></a>, <img/> is the element to hold
 			// inline styles or classes (ae_dragresize_ie11_alignClasses).
-			let attrsHolder = el.name == 'a' ? el.getFirst() : el;
+			const attrsHolder = el.name == 'a' ? el.getFirst() : el;
 
-			let attrs = attrsHolder.attributes;
+			const attrs = attrsHolder.attributes;
 
-			let align = this.data.align;
+			const align = this.data.align;
 
 			// De-wrap the image from resize handle wrapper.
 			// Only block widgets have one.
 			if (!this.inline) {
-				let resizeWrapper = el.getFirst('span');
+				const resizeWrapper = el.getFirst('span');
 
 				if (resizeWrapper)
 					resizeWrapper.replaceWith(
@@ -1090,7 +1090,7 @@
 			}
 
 			if (align && align != 'none') {
-				let styles = CKEDITOR.tools.parseCssText(attrs.style || '');
+				const styles = CKEDITOR.tools.parseCssText(attrs.style || '');
 
 				// When the widget is captioned (<figure>) and internally centering is done
 				// with widget's wrapper style/class, in the external data representation,
@@ -1138,22 +1138,22 @@
 	// @param {CKEDITOR.editor} editor
 	// @returns {Function}
 	function centerWrapperChecker(editor) {
-		let captionedClass = editor.config.ae_dragresize_ie11_captionedClass;
+		const captionedClass = editor.config.ae_dragresize_ie11_captionedClass;
 
-		let alignClasses = editor.config.ae_dragresize_ie11_alignClasses;
+		const alignClasses = editor.config.ae_dragresize_ie11_alignClasses;
 
-		let validChildren = {figure: 1, a: 1, img: 1};
+		const validChildren = {figure: 1, a: 1, img: 1};
 
 		return function(el) {
 			// Wrapper must be either <div> or <p>.
 			if (!(el.name in {div: 1, p: 1})) return false;
 
-			let children = el.children;
+			const children = el.children;
 
 			// Centering wrapper can have only one child.
 			if (children.length !== 1) return false;
 
-			let child = children[0];
+			const child = children[0];
 
 			// Only <figure> or <img /> can be first (only) child of centering wrapper,
 			// regardless of its type.
@@ -1214,13 +1214,13 @@
 	//
 	// @param {CKEDITOR.plugins.widget} widget
 	function setDimensions(widget) {
-		let data = widget.data;
+		const data = widget.data;
 
-		let dimensions = {width: data.width, height: data.height};
+		const dimensions = {width: data.width, height: data.height};
 
-		let image = widget.parts.image;
+		const image = widget.parts.image;
 
-		for (let d in dimensions) {
+		for (const d in dimensions) {
 			if (dimensions[d]) image.setAttribute(d, dimensions[d]);
 			else image.removeAttribute(d);
 		}
@@ -1230,25 +1230,25 @@
 	//
 	// @param {CKEDITOR.plugins.widget} widget
 	function setupResizer(widget) {
-		let editor = widget.editor;
+		const editor = widget.editor;
 
-		let editable = editor.editable();
+		const editable = editor.editable();
 
-		let doc = editor.document;
+		const doc = editor.document;
 
 		// Store the resizer in a widget for testing (#11004).
 
-		let resizer = (widget.resizer = doc.createElement('span'));
+		const resizer = (widget.resizer = doc.createElement('span'));
 
 		// Create resizer for each corner (NE, NW, SE, SW)
 
-		let resizerNE = doc.createElement('span');
+		const resizerNE = doc.createElement('span');
 
-		let resizerNW = doc.createElement('span');
+		const resizerNW = doc.createElement('span');
 
-		let resizerSE = doc.createElement('span');
+		const resizerSE = doc.createElement('span');
 
-		let resizerSW = doc.createElement('span');
+		const resizerSW = doc.createElement('span');
 
 		resizerNE.addClass('cke_image_resizer');
 		resizerNE.addClass('cke_image_resizer_ne');
@@ -1273,11 +1273,11 @@
 
 		// Inline widgets don't need a resizer wrapper as an image spans the entire widget.
 		if (!widget.inline) {
-			let imageOrLink = widget.parts.link || widget.parts.image;
+			const imageOrLink = widget.parts.link || widget.parts.image;
 
-			let oldResizeWrapper = imageOrLink.getParent();
+			const oldResizeWrapper = imageOrLink.getParent();
 
-			let resizeWrapper = doc.createElement('span');
+			const resizeWrapper = doc.createElement('span');
 
 			resizeWrapper.addClass('cke_image_resizer_wrapper');
 			resizeWrapper.append(imageOrLink);
@@ -1293,26 +1293,26 @@
 
 		// Calculate values of size variables and mouse offsets.
 		resizer.on('mousedown', function(evt) {
-			let image = widget.parts.image;
+			const image = widget.parts.image;
 
 			// The x-coordinate of the mouse relative to the screen
 			// when button gets pressed.
 
-			let startX = evt.data.$.screenX;
+			const startX = evt.data.$.screenX;
 
-			let startY = evt.data.$.screenY;
+			const startY = evt.data.$.screenY;
 
 			// The initial dimensions and aspect ratio of the image.
 
-			let startWidth = image.$.clientWidth;
+			const startWidth = image.$.clientWidth;
 
-			let startHeight = image.$.clientHeight;
+			const startHeight = image.$.clientHeight;
 
-			let ratio = startWidth / startHeight;
+			const ratio = startWidth / startHeight;
 
-			let listeners = [];
+			const listeners = [];
 
-			let target = evt.data.getTarget();
+			const target = evt.data.getTarget();
 
 			let factorX;
 
@@ -1348,7 +1348,7 @@
 			}
 
 			// A class applied to editable during resizing.
-			let cursorClass =
+			const cursorClass =
 				'cke_image_' +
 				(!~factorY ? 's' : 'n') +
 				(!~factorX ? 'w' : 'e');
@@ -1371,9 +1371,9 @@
 			// Attaches an event to a global document if inline editor.
 			// Additionally, if classic (`iframe`-based) editor, also attaches the same event to `iframe`'s document.
 			function attachToDocuments(name, callback, collection) {
-				let globalDoc = CKEDITOR.document;
+				const globalDoc = CKEDITOR.document;
 
-				let listeners = [];
+				const listeners = [];
 
 				if (!doc.equals(globalDoc))
 					listeners.push(globalDoc.on(name, callback));
@@ -1483,7 +1483,7 @@
 	 * @param {CKEDITOR.dom.element} image The image element
 	 * @param {String} imageAlignment The image alignment value to be removed
 	 */
-	let removeWidgetAlignment = function(widget, imageAlignment) {
+	const removeWidgetAlignment = function(widget, imageAlignment) {
 		if (imageAlignment === 'left' || imageAlignment === 'right') {
 			widget.wrapper.removeStyle('float');
 		} else if (imageAlignment === 'center') {
@@ -1497,12 +1497,12 @@
 	// @param {CKEDITOR.editor} editor
 	// @param {String} value 'left', 'right', 'center' or 'block'
 	function alignCommandIntegrator(editor) {
-		let execCallbacks = [];
+		const execCallbacks = [];
 
 		let enabled;
 
 		return function(value) {
-			let command = editor.getCommand('justify' + value);
+			const command = editor.getCommand('justify' + value);
 
 			// Most likely, the justify plugin isn't loaded.
 			if (!command) return;
@@ -1515,7 +1515,7 @@
 
 			if (value in {right: 1, left: 1, center: 1}) {
 				command.on('exec', function(evt) {
-					let widget = getFocusedWidget(editor);
+					const widget = getFocusedWidget(editor);
 
 					if (widget) {
 						if (widget.data.align === value) {
@@ -1537,9 +1537,9 @@
 			}
 
 			command.on('refresh', function(evt) {
-				let widget = getFocusedWidget(editor);
+				const widget = getFocusedWidget(editor);
 
-				let allowed = {right: 1, left: 1, center: 1};
+				const allowed = {right: 1, left: 1, center: 1};
 
 				if (!widget) return;
 
@@ -1574,7 +1574,7 @@
 	// @param {CKEDITOR.editor}
 	// @returns {CKEDITOR.plugins.widget}
 	function getFocusedWidget(editor) {
-		let widget = editor.widgets.focused;
+		const widget = editor.widgets.focused;
 
 		if (widget && widget.name == 'image') return widget;
 
@@ -1588,9 +1588,9 @@
 	// @param {CKEDITOR.editor}
 	// @returns {Object}
 	function getWidgetAllowedContent(editor) {
-		let alignClasses = editor.config.ae_dragresize_ie11_alignClasses;
+		const alignClasses = editor.config.ae_dragresize_ie11_alignClasses;
 
-		let rules = {
+		const rules = {
 			// Widget may need <div> or <p> centering wrapper.
 			div: {
 				match: centerWrapperChecker(editor),
@@ -1635,9 +1635,9 @@
 	// @param {CKEDITOR.editor}
 	// @returns {Object}
 	function getWidgetFeatures(editor) {
-		let alignClasses = editor.config.ae_dragresize_ie11_alignClasses;
+		const alignClasses = editor.config.ae_dragresize_ie11_alignClasses;
 
-		let features = {
+		const features = {
 			dimension: {
 				requiredContent: 'img[width,height]',
 			},

--- a/src/plugins/embed.js
+++ b/src/plugins/embed.js
@@ -2,9 +2,9 @@ import {HIGH_PRIORITY} from './priorities';
 
 /* istanbul ignore if */
 if (!CKEDITOR.plugins.get('ae_embed')) {
-	let REGEX_HTTP = /^https?/;
+	const REGEX_HTTP = /^https?/;
 
-	let REGEX_DEFAULT_LINK = /<a href=/;
+	const REGEX_DEFAULT_LINK = /<a href=/;
 
 	CKEDITOR.DEFAULT_AE_EMBED_URL_TPL =
 		'http://alloy.iframe.ly/api/oembed?url={url}&callback={callback}';
@@ -25,23 +25,23 @@ if (!CKEDITOR.plugins.get('ae_embed')) {
 	 */
 	CKEDITOR.plugins.add('ae_embed', {
 		requires: 'widget',
-		init: function(editor) {
-			let AE_EMBED_URL_TPL = new CKEDITOR.template(
+		init(editor) {
+			const AE_EMBED_URL_TPL = new CKEDITOR.template(
 				editor.config.embedUrlTemplate ||
 					CKEDITOR.DEFAULT_AE_EMBED_URL_TPL
 			);
-			let AE_EMBED_WIDGET_TPL = new CKEDITOR.template(
+			const AE_EMBED_WIDGET_TPL = new CKEDITOR.template(
 				editor.config.embedWidgetTpl ||
 					CKEDITOR.DEFAULT_AE_EMBED_WIDGET_TPL
 			);
-			let AE_EMBED_DEFAULT_LINK_TPL = new CKEDITOR.template(
+			const AE_EMBED_DEFAULT_LINK_TPL = new CKEDITOR.template(
 				editor.config.embedLinkDefaultTpl ||
 					CKEDITOR.DEFAULT_AE_EMBED_DEFAULT_LINK_TPL
 			);
 
 			// Default function to upcast DOM elements to embed widgets.
 			// It matches CKEDITOR.DEFAULT_AE_EMBED_WIDGET_TPL
-			let defaultEmbedWidgetUpcastFn = function(element, data) {
+			const defaultEmbedWidgetUpcastFn = function(element, data) {
 				if (
 					element.name === 'div' &&
 					element.attributes['data-ae-embed-url']
@@ -54,7 +54,7 @@ if (!CKEDITOR.plugins.get('ae_embed')) {
 
 			// Create a embedUrl command that can be invoked to easily embed media URLs
 			editor.addCommand('embedUrl', {
-				exec: function(editor, data) {
+				exec(editor, data) {
 					editor.insertHtml(
 						AE_EMBED_WIDGET_TPL.output({
 							url: data.url,
@@ -76,10 +76,10 @@ if (!CKEDITOR.plugins.get('ae_embed')) {
 				 * @method data
 				 * @param {event} event Data change event
 				 */
-				data: function(event) {
-					let widget = this;
+				data(event) {
+					const widget = this;
 
-					let url = event.data.url;
+					const url = event.data.url;
 
 					if (url) {
 						CKEDITOR.tools.jsonp(
@@ -107,11 +107,11 @@ if (!CKEDITOR.plugins.get('ae_embed')) {
 					}
 				},
 
-				createATag: function(url) {
+				createATag(url) {
 					this.editor.execCommand('undo');
 
-					let aTagHtml = AE_EMBED_DEFAULT_LINK_TPL.output({
-						url: url,
+					const aTagHtml = AE_EMBED_DEFAULT_LINK_TPL.output({
+						url,
 					});
 
 					this.editor.insertHtml(aTagHtml);
@@ -125,8 +125,8 @@ if (!CKEDITOR.plugins.get('ae_embed')) {
 				 * @param {CKEDITOR.htmlParser.element} element The element to be checked
 				 * @param {Object} data The object that will be passed to the widget
 				 */
-				upcast: function(element, data) {
-					let embedWidgetUpcastFn =
+				upcast(element, data) {
+					const embedWidgetUpcastFn =
 						editor.config.embedWidgetUpcastFn ||
 						defaultEmbedWidgetUpcastFn;
 
@@ -139,7 +139,7 @@ if (!CKEDITOR.plugins.get('ae_embed')) {
 				editor.on(
 					'paste',
 					function(event) {
-						let link = event.data.dataValue;
+						const link = event.data.dataValue;
 
 						if (REGEX_HTTP.test(link)) {
 							event.stop();
@@ -161,20 +161,20 @@ if (!CKEDITOR.plugins.get('ae_embed')) {
 			// Add a listener to handle selection change events and properly detect editor
 			// interactions on the widgets without messing with widget native selection
 			editor.on('selectionChange', function(_event) {
-				let selection = editor.getSelection();
+				const selection = editor.getSelection();
 
 				if (selection) {
-					let element = selection.getSelectedElement();
+					const element = selection.getSelectedElement();
 
 					if (element) {
-						let widgetElement = element.findOne(
+						const widgetElement = element.findOne(
 							'[data-widget="ae_embed"]'
 						);
 
 						if (widgetElement) {
-							let region = element.getClientRect();
+							const region = element.getClientRect();
 
-							let scrollPosition = new CKEDITOR.dom.window(
+							const scrollPosition = new CKEDITOR.dom.window(
 								window
 							).getScrollPosition();
 							region.left -= scrollPosition.x;
@@ -186,7 +186,7 @@ if (!CKEDITOR.plugins.get('ae_embed')) {
 								nativeEvent: {},
 								selectionData: {
 									element: widgetElement,
-									region: region,
+									region,
 								},
 							});
 						}

--- a/src/plugins/embedurl.js
+++ b/src/plugins/embedurl.js
@@ -187,7 +187,7 @@ if (!CKEDITOR.plugins.get('embedurl')) {
 			);
 
 			if (widgetElement) {
-				let styles =
+				const styles =
 					JSON.parse(widgetElement.getAttribute('data-styles')) || {};
 
 				styles.width = `${width}px`;
@@ -283,12 +283,12 @@ if (!CKEDITOR.plugins.get('embedurl')) {
 
 			const generateEmbedContent = (url, content) => {
 				return LFR_EMBED_WIDGET_TPL.output({
-					content: content,
+					content,
 					helpMessage: AlloyEditor.Strings.videoPlaybackDisabled,
 					helpMessageIcon: Liferay.Util.getLexiconIconTpl(
 						'info-circle'
 					),
-					url: url,
+					url,
 				});
 			};
 
@@ -365,7 +365,7 @@ if (!CKEDITOR.plugins.get('embedurl')) {
 									const embedId = scheme.exec(url)[1];
 
 									content = provider.tpl.output({
-										embedId: embedId,
+										embedId,
 									});
 								}
 
@@ -478,7 +478,7 @@ if (!CKEDITOR.plugins.get('embedurl')) {
 								window
 							).getScrollPosition();
 
-							let region = element.getClientRect();
+							const region = element.getClientRect();
 
 							region.direction = CKEDITOR.SELECTION_BOTTOM_TO_TOP;
 							region.left -= scrollPosition.x;
@@ -488,7 +488,7 @@ if (!CKEDITOR.plugins.get('embedurl')) {
 								nativeEvent: {},
 								selectionData: {
 									element: widgetElement,
-									region: region,
+									region,
 								},
 							});
 						}

--- a/src/plugins/imagealignment.js
+++ b/src/plugins/imagealignment.js
@@ -5,7 +5,7 @@ if (!CKEDITOR.plugins.get('ae_imagealignment')) {
 	 * Enum for supported image alignments
 	 * @type {Object}
 	 */
-	let IMAGE_ALIGNMENT = {
+	const IMAGE_ALIGNMENT = {
 		CENTER: 'center',
 		LEFT: 'left',
 		RIGHT: 'right',
@@ -15,7 +15,7 @@ if (!CKEDITOR.plugins.get('ae_imagealignment')) {
 	 * Enum values for supported image alignments
 	 * @type {Array}
 	 */
-	let ALIGN_VALUES = [
+	const ALIGN_VALUES = [
 		IMAGE_ALIGNMENT.LEFT,
 		IMAGE_ALIGNMENT.RIGHT,
 		IMAGE_ALIGNMENT.CENTER,
@@ -25,7 +25,7 @@ if (!CKEDITOR.plugins.get('ae_imagealignment')) {
 	 * Necessary styles for the center alignment
 	 * @type {Array.<Object>}
 	 */
-	let CENTERED_IMAGE_STYLE = [
+	const CENTERED_IMAGE_STYLE = [
 		{
 			name: 'display',
 			value: 'block',
@@ -46,7 +46,7 @@ if (!CKEDITOR.plugins.get('ae_imagealignment')) {
 	 * @param {CKEDITOR.dom.element} image The image element
 	 * @return {String} The alignment value
 	 */
-	let getImageAlignment = function(image) {
+	const getImageAlignment = function(image) {
 		let imageAlignment = image.getStyle('float');
 
 		if (
@@ -76,7 +76,7 @@ if (!CKEDITOR.plugins.get('ae_imagealignment')) {
 			});
 
 			if (!imageAlignment) {
-				let imageContainer = image.$.parentNode;
+				const imageContainer = image.$.parentNode;
 
 				if (imageContainer.style.textAlign == IMAGE_ALIGNMENT.CENTER) {
 					CENTERED_IMAGE_STYLE.forEach(function(style) {
@@ -110,7 +110,7 @@ if (!CKEDITOR.plugins.get('ae_imagealignment')) {
 	 * @param {CKEDITOR.dom.element} image The image element
 	 * @param {String} imageAlignment The image alignment value to be removed
 	 */
-	let removeImageAlignment = function(image, imageAlignment) {
+	const removeImageAlignment = function(image, imageAlignment) {
 		if (
 			imageAlignment === IMAGE_ALIGNMENT.LEFT ||
 			imageAlignment === IMAGE_ALIGNMENT.RIGHT
@@ -131,7 +131,7 @@ if (!CKEDITOR.plugins.get('ae_imagealignment')) {
 				}
 			});
 
-			let imageContainer = image.$.parentNode;
+			const imageContainer = image.$.parentNode;
 
 			if (imageContainer.style.textAlign == IMAGE_ALIGNMENT.CENTER) {
 				imageContainer.style.textAlign = '';
@@ -145,7 +145,7 @@ if (!CKEDITOR.plugins.get('ae_imagealignment')) {
 	 * @param {CKEDITOR.dom.element} image The image element
 	 * @param {String} imageAlignment The image alignment value to be set
 	 */
-	let setImageAlignment = function(image, imageAlignment) {
+	const setImageAlignment = function(image, imageAlignment) {
 		removeImageAlignment(image, getImageAlignment(image));
 
 		if (
@@ -181,25 +181,25 @@ if (!CKEDITOR.plugins.get('ae_imagealignment')) {
 		 * @method afterInit
 		 * @param {Object} editor The current editor instance
 		 */
-		afterInit: function(editor) {
-			let self = this;
+		afterInit(editor) {
+			const self = this;
 
 			ALIGN_VALUES.forEach(function(value) {
-				let command = editor.getCommand('justify' + value);
+				const command = editor.getCommand('justify' + value);
 
 				if (command) {
 					command.on('exec', function(event) {
-						let selectionData = editor.getSelectionData();
+						const selectionData = editor.getSelectionData();
 
 						if (
 							selectionData &&
 							SelectionTest.image({
-								data: {selectionData: selectionData},
+								data: {selectionData},
 							})
 						) {
-							let image = selectionData.element;
+							const image = selectionData.element;
 
-							let imageAlignment = getImageAlignment(image);
+							const imageAlignment = getImageAlignment(image);
 
 							if (imageAlignment === value) {
 								removeImageAlignment(image, value);
@@ -217,16 +217,16 @@ if (!CKEDITOR.plugins.get('ae_imagealignment')) {
 					});
 
 					command.on('refresh', function(event) {
-						let selectionData = {
+						const selectionData = {
 							element: event.data.path.lastElement,
 						};
 
 						if (
 							SelectionTest.image({
-								data: {selectionData: selectionData},
+								data: {selectionData},
 							})
 						) {
-							let imageAlignment = getImageAlignment(
+							const imageAlignment = getImageAlignment(
 								selectionData.element
 							);
 
@@ -251,9 +251,9 @@ if (!CKEDITOR.plugins.get('ae_imagealignment')) {
 		 * @param {CKEDITOR.editor} editor The editor instance
 		 * @param {CKEDITOR.dom.elementPath} elementPath The path of the selected image
 		 */
-		refreshCommands: function(editor, elementPath) {
+		refreshCommands(editor, elementPath) {
 			ALIGN_VALUES.forEach(function(value) {
-				let command = editor.getCommand('justify' + value);
+				const command = editor.getCommand('justify' + value);
 
 				if (command) {
 					command.refresh(editor, elementPath);

--- a/src/plugins/pasteimages.js
+++ b/src/plugins/pasteimages.js
@@ -30,11 +30,11 @@ if (!CKEDITOR.plugins.get('ae_pasteimages')) {
 		 * @method init
 		 * @param {Object} editor The current editor instance
 		 */
-		init: function(editor) {
+		init(editor) {
 			editor.once(
 				'contentDom',
 				function() {
-					let editable = editor.editable();
+					const editable = editor.editable();
 
 					editable.attachListener(
 						editable,
@@ -42,7 +42,7 @@ if (!CKEDITOR.plugins.get('ae_pasteimages')) {
 						this._onPaste,
 						this,
 						{
-							editor: editor,
+							editor,
 						}
 					);
 				}.bind(this)
@@ -60,29 +60,29 @@ if (!CKEDITOR.plugins.get('ae_pasteimages')) {
 		 * @protected
 		 * @param {CKEDITOR.dom.event} event A `paste` event, as received natively from CKEditor
 		 */
-		_onPaste: function(event) {
+		_onPaste(event) {
 			if (event.data.$.clipboardData) {
-				let pastedData = event.data.$.clipboardData.items[0];
-				let editor = event.listenerData.editor;
+				const pastedData = event.data.$.clipboardData.items[0];
+				const editor = event.listenerData.editor;
 
 				if (pastedData.type.indexOf('image') === 0) {
-					let reader = new FileReader();
-					let imageFile = pastedData.getAsFile();
+					const reader = new FileReader();
+					const imageFile = pastedData.getAsFile();
 
 					reader.onload = function(event) {
-						let result = editor.fire('beforeImageAdd', {
+						const result = editor.fire('beforeImageAdd', {
 							imageFiles: imageFile,
 						});
 
 						if (result) {
-							let el = CKEDITOR.dom.element.createFromHtml(
+							const el = CKEDITOR.dom.element.createFromHtml(
 								'<img src="' + event.target.result + '">'
 							);
 
 							editor.insertElement(el);
 
-							let imageData = {
-								el: el,
+							const imageData = {
+								el,
 								file: imageFile,
 							};
 

--- a/src/plugins/placeholder.js
+++ b/src/plugins/placeholder.js
@@ -6,9 +6,9 @@ if (!CKEDITOR.plugins.get('ae_placeholder')) {
 	 * @property
 	 * @type {string}
 	 */
-	let brFiller = CKEDITOR.env.needsBrFiller ? '<br>' : '';
+	const brFiller = CKEDITOR.env.needsBrFiller ? '<br>' : '';
 
-	let enterModeEmptyValue = {
+	const enterModeEmptyValue = {
 		1: ['<p>' + brFiller + '</p>'],
 		2: ['', ' ', brFiller],
 		3: ['<div>' + brFiller + '</div>'],
@@ -37,7 +37,7 @@ if (!CKEDITOR.plugins.get('ae_placeholder')) {
 		 * @method init
 		 * @param {Object} editor The current editor instance
 		 */
-		init: function(editor) {
+		init(editor) {
 			editor.on('blur', this._checkEmptyData, this);
 			editor.on('change', this._checkEmptyData, this);
 			editor.on('focus', this._removePlaceholderClass, this);
@@ -52,14 +52,14 @@ if (!CKEDITOR.plugins.get('ae_placeholder')) {
 		 * @method _checkEmptyData
 		 * @param {CKEDITOR.dom.event} editor event, fired from CKEditor
 		 */
-		_checkEmptyData: function(event) {
-			let editor = event.editor;
+		_checkEmptyData(event) {
+			const editor = event.editor;
 
-			let editableNode = editor.editable();
+			const editableNode = editor.editable();
 
-			let innerHtml = editableNode.$.innerHTML.trim();
+			const innerHtml = editableNode.$.innerHTML.trim();
 
-			let isEmpty = enterModeEmptyValue[editor.config.enterMode].some(
+			const isEmpty = enterModeEmptyValue[editor.config.enterMode].some(
 				function(element) {
 					return innerHtml === element;
 				}
@@ -79,10 +79,10 @@ if (!CKEDITOR.plugins.get('ae_placeholder')) {
              * @method _removePlaceholderClass
              + @param {CKEDITOR.dom.event} editor event, fired from CKEditor
              */
-		_removePlaceholderClass: function(event) {
-			let editor = event.editor;
+		_removePlaceholderClass(event) {
+			const editor = event.editor;
 
-			let editorNode = new CKEDITOR.dom.element(editor.element.$);
+			const editorNode = new CKEDITOR.dom.element(editor.element.$);
 
 			editorNode.removeClass(editor.config.placeholderClass);
 		},

--- a/src/plugins/selectionkeystrokes.js
+++ b/src/plugins/selectionkeystrokes.js
@@ -16,13 +16,13 @@ if (!CKEDITOR.plugins.get('ae_selectionkeystrokes')) {
 		 * @method init
 		 * @param {Object} editor The current editor instance
 		 */
-		init: function(editor) {
+		init(editor) {
 			if (editor.config.selectionKeystrokes) {
 				editor.config.selectionKeystrokes.forEach(function(
 					selectionKeystroke
 				) {
-					let command = new CKEDITOR.command(editor, {
-						exec: function(editor) {
+					const command = new CKEDITOR.command(editor, {
+						exec(editor) {
 							editor.fire('editorInteraction', {
 								manualSelection: selectionKeystroke.selection,
 								nativeEvent: {},
@@ -31,7 +31,7 @@ if (!CKEDITOR.plugins.get('ae_selectionkeystrokes')) {
 						},
 					});
 
-					let commandName =
+					const commandName =
 						'selectionKeystroke' + selectionKeystroke.selection;
 
 					editor.addCommand(commandName, command);

--- a/src/plugins/tabletools.js
+++ b/src/plugins/tabletools.js
@@ -4,12 +4,12 @@
  */
 
 if (!CKEDITOR.plugins.get('ae_tabletools')) {
-	let cellNodeRegex = /^(?:td|th)$/;
+	const cellNodeRegex = /^(?:td|th)$/;
 
 	function getSelectedCells(selection) {
-		let ranges = selection.getRanges();
-		let retval = [];
-		let database = {};
+		const ranges = selection.getRanges();
+		const retval = [];
+		const database = {};
 
 		function moveOutOfCellGuard(node) {
 			// Apply to the first cell only.
@@ -33,17 +33,17 @@ if (!CKEDITOR.plugins.get('ae_tabletools')) {
 		}
 
 		for (let i = 0; i < ranges.length; i++) {
-			let range = ranges[i];
+			const range = ranges[i];
 
 			if (range.collapsed) {
 				// Walker does not handle collapsed ranges yet - fall back to old API.
-				let startNode = range.getCommonAncestor();
-				let nearestCell =
+				const startNode = range.getCommonAncestor();
+				const nearestCell =
 					startNode.getAscendant('td', true) ||
 					startNode.getAscendant('th', true);
 				if (nearestCell) retval.push(nearestCell);
 			} else {
-				let walker = new CKEDITOR.dom.walker(range);
+				const walker = new CKEDITOR.dom.walker(range);
 				let node;
 				walker.guard = moveOutOfCellGuard;
 
@@ -59,7 +59,7 @@ if (!CKEDITOR.plugins.get('ae_tabletools')) {
 						node.type != CKEDITOR.NODE_ELEMENT ||
 						!node.is(CKEDITOR.dtd.table)
 					) {
-						let parent =
+						const parent =
 							node.getAscendant('td', true) ||
 							node.getAscendant('th', true);
 						if (parent && !parent.getCustomData('selected_cell')) {
@@ -84,9 +84,9 @@ if (!CKEDITOR.plugins.get('ae_tabletools')) {
 	function getFocusElementAfterDelCells(cellsToDelete) {
 		let i = 0;
 
-		let last = cellsToDelete.length - 1;
+		const last = cellsToDelete.length - 1;
 
-		let database = {};
+		const database = {};
 
 		let cell;
 
@@ -125,38 +125,38 @@ if (!CKEDITOR.plugins.get('ae_tabletools')) {
 	}
 
 	function insertRow(selection, insertBefore) {
-		let cells = getSelectedCells(selection);
+		const cells = getSelectedCells(selection);
 
-		let firstCell = cells[0];
+		const firstCell = cells[0];
 
-		let table = firstCell.getAscendant('table');
+		const table = firstCell.getAscendant('table');
 
-		let doc = firstCell.getDocument();
+		const doc = firstCell.getDocument();
 
-		let startRow = cells[0].getParent();
+		const startRow = cells[0].getParent();
 
-		let startRowIndex = startRow.$.rowIndex;
+		const startRowIndex = startRow.$.rowIndex;
 
-		let lastCell = cells[cells.length - 1];
+		const lastCell = cells[cells.length - 1];
 
-		let endRowIndex =
+		const endRowIndex =
 			lastCell.getParent().$.rowIndex + lastCell.$.rowSpan - 1;
 
-		let endRow = new CKEDITOR.dom.element(table.$.rows[endRowIndex]);
+		const endRow = new CKEDITOR.dom.element(table.$.rows[endRowIndex]);
 
-		let rowIndex = insertBefore ? startRowIndex : endRowIndex;
+		const rowIndex = insertBefore ? startRowIndex : endRowIndex;
 
-		let row = insertBefore ? startRow : endRow;
+		const row = insertBefore ? startRow : endRow;
 
-		let map = CKEDITOR.tools.buildTableMap(table);
+		const map = CKEDITOR.tools.buildTableMap(table);
 
-		let cloneRow = map[rowIndex];
+		const cloneRow = map[rowIndex];
 
-		let nextRow = insertBefore ? map[rowIndex - 1] : map[rowIndex + 1];
+		const nextRow = insertBefore ? map[rowIndex - 1] : map[rowIndex + 1];
 
-		let width = map[0].length;
+		const width = map[0].length;
 
-		let newRow = doc.createElement('tr');
+		const newRow = doc.createElement('tr');
 		for (let i = 0; cloneRow[i] && i < width; i++) {
 			let cell;
 			// Check whether there's a spanning row here, do not break it.
@@ -178,40 +178,44 @@ if (!CKEDITOR.plugins.get('ae_tabletools')) {
 			i += cell.colSpan - 1;
 		}
 
-		insertBefore ? newRow.insertBefore(row) : newRow.insertAfter(row);
+		if (insertBefore) {
+			newRow.insertBefore(row);
+		} else {
+			newRow.insertAfter(row);
+		}
 	}
 
 	function deleteRows(selectionOrRow) {
 		if (selectionOrRow instanceof CKEDITOR.dom.selection) {
-			let cells = getSelectedCells(selectionOrRow);
+			const cells = getSelectedCells(selectionOrRow);
 
-			let firstCell = cells[0];
+			const firstCell = cells[0];
 
 			const table = firstCell.getAscendant('table');
 
-			let map = CKEDITOR.tools.buildTableMap(table);
+			const map = CKEDITOR.tools.buildTableMap(table);
 
-			let startRow = cells[0].getParent();
+			const startRow = cells[0].getParent();
 
-			let startRowIndex = startRow.$.rowIndex;
+			const startRowIndex = startRow.$.rowIndex;
 
-			let lastCell = cells[cells.length - 1];
+			const lastCell = cells[cells.length - 1];
 
-			let endRowIndex =
+			const endRowIndex =
 				lastCell.getParent().$.rowIndex + lastCell.$.rowSpan - 1;
 
-			let rowsToDelete = [];
+			const rowsToDelete = [];
 
 			// Delete cell or reduce cell spans by checking through the table map.
 			for (let i = startRowIndex; i <= endRowIndex; i++) {
-				let mapRow = map[i];
+				const mapRow = map[i];
 
-				let row = new CKEDITOR.dom.element(table.$.rows[i]);
+				const row = new CKEDITOR.dom.element(table.$.rows[i]);
 
 				for (let j = 0; j < mapRow.length; j++) {
-					let cell = new CKEDITOR.dom.element(mapRow[j]);
+					const cell = new CKEDITOR.dom.element(mapRow[j]);
 
-					let cellRowIndex = cell.getParent().$.rowIndex;
+					const cellRowIndex = cell.getParent().$.rowIndex;
 
 					if (cell.$.rowSpan == 1) cell.remove();
 					// Row spanned cell.
@@ -220,16 +224,16 @@ if (!CKEDITOR.plugins.get('ae_tabletools')) {
 						cell.$.rowSpan -= 1;
 						// Root row of the cell, root cell to next row.
 						if (cellRowIndex == i) {
-							let nextMapRow = map[i + 1];
-							nextMapRow[j - 1]
-								? cell.insertAfter(
-										new CKEDITOR.dom.element(
-											nextMapRow[j - 1]
-										)
-								  )
-								: new CKEDITOR.dom.element(
-										table.$.rows[i + 1]
-								  ).append(cell, 1);
+							const nextMapRow = map[i + 1];
+							if (nextMapRow[j - 1]) {
+								cell.insertAfter(
+									new CKEDITOR.dom.element(nextMapRow[j - 1])
+								);
+							} else {
+								new CKEDITOR.dom.element(
+									table.$.rows[i + 1]
+								).append(cell, 1);
+							}
 						}
 					}
 
@@ -239,13 +243,13 @@ if (!CKEDITOR.plugins.get('ae_tabletools')) {
 				rowsToDelete.push(row);
 			}
 
-			let rows = table.$.rows;
+			const rows = table.$.rows;
 
 			// Where to put the cursor after rows been deleted?
 			// 1. Into next sibling row if any;
 			// 2. Into previous sibling row if any;
 			// 3. Into table's parent element if it's the very last row.
-			let cursorPosition = new CKEDITOR.dom.element(
+			const cursorPosition = new CKEDITOR.dom.element(
 				rows[endRowIndex + 1] ||
 					(startRowIndex > 0 ? rows[startRowIndex - 1] : null) ||
 					table.$.parentNode
@@ -266,13 +270,13 @@ if (!CKEDITOR.plugins.get('ae_tabletools')) {
 	}
 
 	function getCellColIndex(cell, isStart) {
-		let row = cell.getParent();
+		const row = cell.getParent();
 
-		let rowCells = row.$.cells;
+		const rowCells = row.$.cells;
 
 		let colIndex = 0;
 		for (let i = 0; i < rowCells.length; i++) {
-			let mapCell = rowCells[i];
+			const mapCell = rowCells[i];
 			colIndex += isStart ? 1 : mapCell.colSpan;
 			if (mapCell == cell.$) break;
 		}
@@ -283,7 +287,7 @@ if (!CKEDITOR.plugins.get('ae_tabletools')) {
 	function getColumnsIndices(cells, isStart) {
 		let retval = isStart ? Infinity : 0;
 		for (let i = 0; i < cells.length; i++) {
-			let colIndex = getCellColIndex(cells[i], isStart);
+			const colIndex = getCellColIndex(cells[i], isStart);
 			if (isStart ? colIndex < retval : colIndex > retval)
 				retval = colIndex;
 		}
@@ -291,29 +295,29 @@ if (!CKEDITOR.plugins.get('ae_tabletools')) {
 	}
 
 	function insertColumn(selection, insertBefore) {
-		let cells = getSelectedCells(selection);
+		const cells = getSelectedCells(selection);
 
-		let firstCell = cells[0];
+		const firstCell = cells[0];
 
-		let table = firstCell.getAscendant('table');
+		const table = firstCell.getAscendant('table');
 
-		let startCol = getColumnsIndices(cells, 1);
+		const startCol = getColumnsIndices(cells, 1);
 
-		let lastCol = getColumnsIndices(cells);
+		const lastCol = getColumnsIndices(cells);
 
-		let colIndex = insertBefore ? startCol : lastCol;
+		const colIndex = insertBefore ? startCol : lastCol;
 
-		let map = CKEDITOR.tools.buildTableMap(table);
+		const map = CKEDITOR.tools.buildTableMap(table);
 
-		let cloneCol = [];
+		const cloneCol = [];
 
-		let nextCol = [];
+		const nextCol = [];
 
-		let height = map.length;
+		const height = map.length;
 
 		for (let i = 0; i < height; i++) {
 			cloneCol.push(map[i][colIndex]);
-			let nextCell = insertBefore
+			const nextCell = insertBefore
 				? map[i][colIndex - 1]
 				: map[i][colIndex + 1];
 			nextCol.push(nextCell);
@@ -344,26 +348,27 @@ if (!CKEDITOR.plugins.get('ae_tabletools')) {
 	}
 
 	function deleteColumns(selectionOrCell) {
-		let cells = getSelectedCells(selectionOrCell);
+		const cells = getSelectedCells(selectionOrCell);
 
-		let firstCell = cells[0];
+		const firstCell = cells[0];
 
-		let lastCell = cells[cells.length - 1];
+		const lastCell = cells[cells.length - 1];
 
-		let table = firstCell.getAscendant('table');
+		const table = firstCell.getAscendant('table');
 
-		let map = CKEDITOR.tools.buildTableMap(table);
+		const map = CKEDITOR.tools.buildTableMap(table);
 
 		let startColIndex;
 
 		let endColIndex;
 
-		let rowsToDelete = [];
+		const rowsToDelete = [];
 
 		let rows;
 
 		// Figure out selected cells' column indices.
 		for (let i = 0, rows = map.length; i < rows; i++) {
+			// eslint-disable-next-line sort-vars
 			for (let j = 0, cols = map[i].length; j < cols; j++) {
 				if (map[i][j] == firstCell.$) startColIndex = j;
 				if (map[i][j] == lastCell.$) endColIndex = j;
@@ -373,11 +378,11 @@ if (!CKEDITOR.plugins.get('ae_tabletools')) {
 		// Delete cell or reduce cell spans by checking through the table map.
 		for (let i = startColIndex; i <= endColIndex; i++) {
 			for (let j = 0; j < map.length; j++) {
-				let mapRow = map[j];
+				const mapRow = map[j];
 
-				let row = new CKEDITOR.dom.element(table.$.rows[j]);
+				const row = new CKEDITOR.dom.element(table.$.rows[j]);
 
-				let cell = new CKEDITOR.dom.element(mapRow[i]);
+				const cell = new CKEDITOR.dom.element(mapRow[i]);
 
 				if (cell.$) {
 					if (cell.$.colSpan == 1) cell.remove();
@@ -391,13 +396,13 @@ if (!CKEDITOR.plugins.get('ae_tabletools')) {
 			}
 		}
 
-		let firstRowCells = table.$.rows[0] && table.$.rows[0].cells;
+		const firstRowCells = table.$.rows[0] && table.$.rows[0].cells;
 
 		// Where to put the cursor after columns been deleted?
 		// 1. Into next cell of the first row if any;
 		// 2. Into previous cell of the first row if any;
 		// 3. Into table's parent element;
-		let cursorPosition = new CKEDITOR.dom.element(
+		const cursorPosition = new CKEDITOR.dom.element(
 			firstRowCells[startColIndex] ||
 				(startColIndex
 					? firstRowCells[startColIndex - 1]
@@ -411,15 +416,15 @@ if (!CKEDITOR.plugins.get('ae_tabletools')) {
 	}
 
 	function insertCell(selection, insertBefore) {
-		let startElement = selection.getStartElement();
-		let cell =
+		const startElement = selection.getStartElement();
+		const cell =
 			startElement.getAscendant('td', 1) ||
 			startElement.getAscendant('th', 1);
 
 		if (!cell) return;
 
 		// Create the new cell element to be added.
-		let newCell = cell.clone();
+		const newCell = cell.clone();
 		newCell.appendBogus();
 
 		if (insertBefore) newCell.insertBefore(cell);
@@ -428,10 +433,10 @@ if (!CKEDITOR.plugins.get('ae_tabletools')) {
 
 	function deleteCells(selectionOrCell) {
 		if (selectionOrCell instanceof CKEDITOR.dom.selection) {
-			let cellsToDelete = getSelectedCells(selectionOrCell);
-			let table =
+			const cellsToDelete = getSelectedCells(selectionOrCell);
+			const table =
 				cellsToDelete[0] && cellsToDelete[0].getAscendant('table');
-			let cellToFocus = getFocusElementAfterDelCells(cellsToDelete);
+			const cellToFocus = getFocusElementAfterDelCells(cellsToDelete);
 
 			for (let i = cellsToDelete.length - 1; i >= 0; i--)
 				deleteCells(cellsToDelete[i]);
@@ -439,7 +444,7 @@ if (!CKEDITOR.plugins.get('ae_tabletools')) {
 			if (cellToFocus) placeCursorInCell(cellToFocus, true);
 			else if (table) table.remove();
 		} else if (selectionOrCell instanceof CKEDITOR.dom.element) {
-			let tr = selectionOrCell.getParent();
+			const tr = selectionOrCell.getParent();
 			if (tr.getChildCount() == 1) tr.remove();
 			else selectionOrCell.remove();
 		}
@@ -447,15 +452,17 @@ if (!CKEDITOR.plugins.get('ae_tabletools')) {
 
 	// Remove filler at end and empty spaces around the cell content.
 	function trimCell(cell) {
-		let bogus = cell.getBogus();
-		bogus && bogus.remove();
+		const bogus = cell.getBogus();
+		if (bogus) {
+			bogus.remove();
+		}
 		cell.trim();
 	}
 
 	function placeCursorInCell(cell, placeAtEnd) {
-		let docInner = cell.getDocument();
+		const docInner = cell.getDocument();
 
-		let docOuter = CKEDITOR.document;
+		const docOuter = CKEDITOR.document;
 
 		// Fixing "Unspecified error" thrown in IE10 by resetting
 		// selection the dirty and shameful way (#10308).
@@ -466,7 +473,7 @@ if (!CKEDITOR.plugins.get('ae_tabletools')) {
 			docInner.focus();
 		}
 
-		let range = new CKEDITOR.dom.range(docInner);
+		const range = new CKEDITOR.dom.range(docInner);
 		if (
 			!range['moveToElementEdit' + (placeAtEnd ? 'End' : 'Start')](cell)
 		) {
@@ -477,7 +484,7 @@ if (!CKEDITOR.plugins.get('ae_tabletools')) {
 	}
 
 	function cellInRow(tableMap, rowIndex, cell) {
-		let oRow = tableMap[rowIndex];
+		const oRow = tableMap[rowIndex];
 		if (typeof cell == 'undefined') return oRow;
 
 		for (let c = 0; oRow && c < oRow.length; c++) {
@@ -488,9 +495,9 @@ if (!CKEDITOR.plugins.get('ae_tabletools')) {
 	}
 
 	function cellInCol(tableMap, colIndex) {
-		let oCol = [];
+		const oCol = [];
 		for (let r = 0; r < tableMap.length; r++) {
-			let row = tableMap[r];
+			const row = tableMap[r];
 			oCol.push(row[colIndex]);
 
 			// Avoid adding duplicate cells.
@@ -500,7 +507,7 @@ if (!CKEDITOR.plugins.get('ae_tabletools')) {
 	}
 
 	function mergeCells(selection, mergeDirection, isDetect) {
-		let cells = getSelectedCells(selection);
+		const cells = getSelectedCells(selection);
 
 		// Invalid merge request if:
 		// 1. In batch mode despite that less than two selected.
@@ -517,26 +524,26 @@ if (!CKEDITOR.plugins.get('ae_tabletools')) {
 
 		let cell;
 
-		let firstCell = cells[0];
+		const firstCell = cells[0];
 
-		let table = firstCell.getAscendant('table');
+		const table = firstCell.getAscendant('table');
 
-		let map = CKEDITOR.tools.buildTableMap(table);
+		const map = CKEDITOR.tools.buildTableMap(table);
 
-		let mapHeight = map.length;
+		const mapHeight = map.length;
 
-		let mapWidth = map[0].length;
+		const mapWidth = map[0].length;
 
-		let startRow = firstCell.getParent().$.rowIndex;
+		const startRow = firstCell.getParent().$.rowIndex;
 
-		let startColumn = cellInRow(map, startRow, firstCell);
+		const startColumn = cellInRow(map, startRow, firstCell);
 
 		if (mergeDirection) {
 			let targetCell;
 			try {
-				let rowspan =
+				const rowspan =
 					parseInt(firstCell.getAttribute('rowspan'), 10) || 1;
-				let colspan =
+				const colspan =
 					parseInt(firstCell.getAttribute('colspan'), 10) || 1;
 
 				targetCell =
@@ -570,7 +577,7 @@ if (!CKEDITOR.plugins.get('ae_tabletools')) {
 		}
 
 		// Start from here are merging way ignorance (merge up/right, batch merge).
-		let doc = firstCell.getDocument();
+		const doc = firstCell.getDocument();
 
 		let lastRowIndex = startRow;
 
@@ -580,24 +587,24 @@ if (!CKEDITOR.plugins.get('ae_tabletools')) {
 
 		// Use a documentFragment as buffer when appending cell contents.
 
-		let frag = !isDetect && new CKEDITOR.dom.documentFragment(doc);
+		const frag = !isDetect && new CKEDITOR.dom.documentFragment(doc);
 
 		let dimension = 0;
 
 		for (let i = 0; i < cells.length; i++) {
 			cell = cells[i];
 
-			let tr = cell.getParent();
+			const tr = cell.getParent();
 
-			let cellFirstChild = cell.getFirst();
+			const cellFirstChild = cell.getFirst();
 
-			let colSpan = cell.$.colSpan;
+			const colSpan = cell.$.colSpan;
 
-			let rowSpan = cell.$.rowSpan;
+			const rowSpan = cell.$.rowSpan;
 
-			let rowIndex = tr.$.rowIndex;
+			const rowIndex = tr.$.rowIndex;
 
-			let colIndex = cellInRow(map, rowIndex, cell);
+			const colIndex = cellInRow(map, rowIndex, cell);
 
 			// Accumulated the actual places taken by all selected cells.
 			dimension += colSpan * rowSpan;
@@ -623,7 +630,7 @@ if (!CKEDITOR.plugins.get('ae_tabletools')) {
 							cellFirstChild.isBlockBoundary({br: 1})
 						)
 					) {
-						let last = frag.getLast(
+						const last = frag.getLast(
 							CKEDITOR.dom.walker.whitespaces(true)
 						);
 						if (last && !(last.is && last.is('br')))
@@ -632,7 +639,11 @@ if (!CKEDITOR.plugins.get('ae_tabletools')) {
 
 					cell.moveChildren(frag);
 				}
-				i ? cell.remove() : cell.setHtml('');
+				if (i) {
+					cell.remove();
+				} else {
+					cell.setHtml('');
+				}
 			}
 			lastRowIndex = rowIndex;
 		}
@@ -649,12 +660,12 @@ if (!CKEDITOR.plugins.get('ae_tabletools')) {
 			else firstCell.$.colSpan = totalColSpan;
 
 			// Swip empty <tr> left at the end of table due to the merging.
-			let trs = new CKEDITOR.dom.nodeList(table.$.rows);
+			const trs = new CKEDITOR.dom.nodeList(table.$.rows);
 
 			let count = trs.count();
 
 			for (let i = count - 1; i >= 0; i--) {
-				let tailTr = trs.getItem(i);
+				const tailTr = trs.getItem(i);
 				if (!tailTr.$.cells.length) {
 					tailTr.remove();
 					count++;
@@ -672,23 +683,23 @@ if (!CKEDITOR.plugins.get('ae_tabletools')) {
 	}
 
 	function verticalSplitCell(selection, isDetect) {
-		let cells = getSelectedCells(selection);
+		const cells = getSelectedCells(selection);
 		if (cells.length > 1) return false;
 		else if (isDetect) return true;
 
-		let cell = cells[0];
+		const cell = cells[0];
 
-		let tr = cell.getParent();
+		const tr = cell.getParent();
 
-		let table = tr.getAscendant('table');
+		const table = tr.getAscendant('table');
 
-		let map = CKEDITOR.tools.buildTableMap(table);
+		const map = CKEDITOR.tools.buildTableMap(table);
 
-		let rowIndex = tr.$.rowIndex;
+		const rowIndex = tr.$.rowIndex;
 
-		let colIndex = cellInRow(map, rowIndex, cell);
+		const colIndex = cellInRow(map, rowIndex, cell);
 
-		let rowSpan = cell.$.rowSpan;
+		const rowSpan = cell.$.rowSpan;
 
 		let newCell;
 
@@ -706,7 +717,7 @@ if (!CKEDITOR.plugins.get('ae_tabletools')) {
 				table.$.rows[newRowIndex]
 			);
 
-			let newCellRow = cellInRow(map, newRowIndex);
+			const newCellRow = cellInRow(map, newRowIndex);
 
 			let candidateCell;
 
@@ -735,7 +746,7 @@ if (!CKEDITOR.plugins.get('ae_tabletools')) {
 			newCellTr.insertAfter(tr);
 			newCellTr.append((newCell = cell.clone()));
 
-			let cellsInSameRow = cellInRow(map, rowIndex);
+			const cellsInSameRow = cellInRow(map, rowIndex);
 			for (let i = 0; i < cellsInSameRow.length; i++)
 				cellsInSameRow[i].rowSpan++;
 		}
@@ -751,25 +762,23 @@ if (!CKEDITOR.plugins.get('ae_tabletools')) {
 	}
 
 	function horizontalSplitCell(selection, isDetect) {
-		let cells = getSelectedCells(selection);
+		const cells = getSelectedCells(selection);
 		if (cells.length > 1) return false;
 		else if (isDetect) return true;
 
-		let cell = cells[0];
+		const cell = cells[0];
 
-		let tr = cell.getParent();
+		const tr = cell.getParent();
 
-		let table = tr.getAscendant('table');
+		const table = tr.getAscendant('table');
 
-		let map = CKEDITOR.tools.buildTableMap(table);
+		const map = CKEDITOR.tools.buildTableMap(table);
 
-		let rowIndex = tr.$.rowIndex;
+		const rowIndex = tr.$.rowIndex;
 
-		let colIndex = cellInRow(map, rowIndex, cell);
+		const colIndex = cellInRow(map, rowIndex, cell);
 
-		let colSpan = cell.$.colSpan;
-
-		let newCell;
+		const colSpan = cell.$.colSpan;
 
 		let newColSpan;
 
@@ -780,11 +789,11 @@ if (!CKEDITOR.plugins.get('ae_tabletools')) {
 			newCellColSpan = Math.floor(colSpan / 2);
 		} else {
 			newCellColSpan = newColSpan = 1;
-			let cellsInSameCol = cellInCol(map, colIndex);
+			const cellsInSameCol = cellInCol(map, colIndex);
 			for (let i = 0; i < cellsInSameCol.length; i++)
 				cellsInSameCol[i].colSpan++;
 		}
-		newCell = cell.clone();
+		const newCell = cell.clone();
 		newCell.insertAfter(cell);
 		newCell.appendBogus();
 
@@ -797,11 +806,11 @@ if (!CKEDITOR.plugins.get('ae_tabletools')) {
 	}
 
 	CKEDITOR.plugins.add('ae_tabletools', {
-		init: function(editor) {
+		init(editor) {
 			function createDef(def) {
 				return CKEDITOR.tools.extend(def || {}, {
 					contextSensitive: 1,
-					refresh: function(editor, path) {
+					refresh(editor, path) {
 						this.setState(
 							path.contains({td: 1, th: 1}, 1)
 								? CKEDITOR.TRISTATE_OFF
@@ -825,8 +834,8 @@ if (!CKEDITOR.plugins.get('ae_tabletools')) {
 				'rowDelete',
 				createDef({
 					requiredContent: 'table',
-					exec: function(editor) {
-						let selection = editor.getSelection();
+					exec(editor) {
+						const selection = editor.getSelection();
 						placeCursorInCell(deleteRows(selection));
 					},
 				})
@@ -836,8 +845,8 @@ if (!CKEDITOR.plugins.get('ae_tabletools')) {
 				'rowInsertBefore',
 				createDef({
 					requiredContent: 'table',
-					exec: function(editor) {
-						let selection = editor.getSelection();
+					exec(editor) {
+						const selection = editor.getSelection();
 						insertRow(selection, true);
 					},
 				})
@@ -847,8 +856,8 @@ if (!CKEDITOR.plugins.get('ae_tabletools')) {
 				'rowInsertAfter',
 				createDef({
 					requiredContent: 'table',
-					exec: function(editor) {
-						let selection = editor.getSelection();
+					exec(editor) {
+						const selection = editor.getSelection();
 						insertRow(selection);
 					},
 				})
@@ -858,10 +867,12 @@ if (!CKEDITOR.plugins.get('ae_tabletools')) {
 				'columnDelete',
 				createDef({
 					requiredContent: 'table',
-					exec: function(editor) {
-						let selection = editor.getSelection();
-						let element = deleteColumns(selection);
-						element && placeCursorInCell(element, true);
+					exec(editor) {
+						const selection = editor.getSelection();
+						const element = deleteColumns(selection);
+						if (element) {
+							placeCursorInCell(element, true);
+						}
 					},
 				})
 			);
@@ -870,8 +881,8 @@ if (!CKEDITOR.plugins.get('ae_tabletools')) {
 				'columnInsertBefore',
 				createDef({
 					requiredContent: 'table',
-					exec: function(editor) {
-						let selection = editor.getSelection();
+					exec(editor) {
+						const selection = editor.getSelection();
 						insertColumn(selection, true);
 					},
 				})
@@ -881,8 +892,8 @@ if (!CKEDITOR.plugins.get('ae_tabletools')) {
 				'columnInsertAfter',
 				createDef({
 					requiredContent: 'table',
-					exec: function(editor) {
-						let selection = editor.getSelection();
+					exec(editor) {
+						const selection = editor.getSelection();
 						insertColumn(selection);
 					},
 				})
@@ -892,8 +903,8 @@ if (!CKEDITOR.plugins.get('ae_tabletools')) {
 				'cellDelete',
 				createDef({
 					requiredContent: 'table',
-					exec: function(editor) {
-						let selection = editor.getSelection();
+					exec(editor) {
+						const selection = editor.getSelection();
 						deleteCells(selection);
 					},
 				})
@@ -904,7 +915,7 @@ if (!CKEDITOR.plugins.get('ae_tabletools')) {
 				createDef({
 					allowedContent: 'td[colspan,rowspan]',
 					requiredContent: 'td[colspan,rowspan]',
-					exec: function(editor) {
+					exec(editor) {
 						placeCursorInCell(
 							mergeCells(editor.getSelection()),
 							true
@@ -918,7 +929,7 @@ if (!CKEDITOR.plugins.get('ae_tabletools')) {
 				createDef({
 					allowedContent: 'td[colspan]',
 					requiredContent: 'td[colspan]',
-					exec: function(editor) {
+					exec(editor) {
 						placeCursorInCell(
 							mergeCells(editor.getSelection(), 'right'),
 							true
@@ -932,7 +943,7 @@ if (!CKEDITOR.plugins.get('ae_tabletools')) {
 				createDef({
 					allowedContent: 'td[rowspan]',
 					requiredContent: 'td[rowspan]',
-					exec: function(editor) {
+					exec(editor) {
 						placeCursorInCell(
 							mergeCells(editor.getSelection(), 'down'),
 							true
@@ -946,7 +957,7 @@ if (!CKEDITOR.plugins.get('ae_tabletools')) {
 				createDef({
 					allowedContent: 'td[rowspan]',
 					requiredContent: 'td[rowspan]',
-					exec: function(editor) {
+					exec(editor) {
 						placeCursorInCell(
 							verticalSplitCell(editor.getSelection())
 						);
@@ -959,7 +970,7 @@ if (!CKEDITOR.plugins.get('ae_tabletools')) {
 				createDef({
 					allowedContent: 'td[colspan]',
 					requiredContent: 'td[colspan]',
-					exec: function(editor) {
+					exec(editor) {
 						placeCursorInCell(
 							horizontalSplitCell(editor.getSelection())
 						);
@@ -971,8 +982,8 @@ if (!CKEDITOR.plugins.get('ae_tabletools')) {
 				'cellInsertBefore',
 				createDef({
 					requiredContent: 'table',
-					exec: function(editor) {
-						let selection = editor.getSelection();
+					exec(editor) {
+						const selection = editor.getSelection();
 						insertCell(selection, true);
 					},
 				})
@@ -982,15 +993,15 @@ if (!CKEDITOR.plugins.get('ae_tabletools')) {
 				'cellInsertAfter',
 				createDef({
 					requiredContent: 'table',
-					exec: function(editor) {
-						let selection = editor.getSelection();
+					exec(editor) {
+						const selection = editor.getSelection();
 						insertCell(selection);
 					},
 				})
 			);
 		},
 
-		getSelectedCells: getSelectedCells,
+		getSelectedCells,
 	});
 }
 
@@ -1002,27 +1013,29 @@ if (!CKEDITOR.plugins.get('ae_tabletools')) {
  * @member CKEDITOR.tools
  */
 CKEDITOR.tools.buildTableMap = function(table) {
-	let aRows = table.$.rows;
+	const aRows = table.$.rows;
 
 	// Row and Column counters.
 	let r = -1;
 
-	let aMap = [];
+	const aMap = [];
 
 	for (let i = 0; i < aRows.length; i++) {
 		r++;
-		!aMap[r] && (aMap[r] = []);
+		if (!aMap[r]) {
+			aMap[r] = [];
+		}
 
 		let c = -1;
 
 		for (let j = 0; j < aRows[i].cells.length; j++) {
-			let oCell = aRows[i].cells[j];
+			const oCell = aRows[i].cells[j];
 
 			c++;
 			while (aMap[r][c]) c++;
 
-			let iColSpan = isNaN(oCell.colSpan) ? 1 : oCell.colSpan;
-			let iRowSpan = isNaN(oCell.rowSpan) ? 1 : oCell.rowSpan;
+			const iColSpan = isNaN(oCell.colSpan) ? 1 : oCell.colSpan;
+			const iRowSpan = isNaN(oCell.rowSpan) ? 1 : oCell.rowSpan;
 
 			for (let rs = 0; rs < iRowSpan; rs++) {
 				if (!aMap[r + rs]) aMap[r + rs] = [];

--- a/src/selections/selection-arrowbox.js
+++ b/src/selections/selection-arrowbox.js
@@ -1,4 +1,4 @@
-let tableSelectionGetArrowBoxClasses = function() {
+const tableSelectionGetArrowBoxClasses = function() {
 	return 'ae-arrow-box ae-arrow-box-bottom';
 };
 

--- a/src/selections/selection-position.js
+++ b/src/selections/selection-position.js
@@ -1,7 +1,7 @@
 import ReactDOM from 'react-dom';
 
 // Default gutter value for toolbar positioning
-let DEFAULT_GUTTER = {
+const DEFAULT_GUTTER = {
 	left: 0,
 	top: 0,
 };
@@ -13,34 +13,35 @@ let DEFAULT_GUTTER = {
  * @param {Object} toolbar The toolbar to be centered
  * @param {Object} rect The rectangle according to which the Toolbar will be centered
  */
-let centerToolbar = function(toolbar, rect) {
-	let toolbarNode = ReactDOM.findDOMNode(toolbar);
+const centerToolbar = function(toolbar, rect) {
+	const toolbarNode = ReactDOM.findDOMNode(toolbar);
 
-	let nativeEditor = toolbar.context.editor.get('nativeEditor');
-	let uiNode = nativeEditor.config.uiNode || document.body;
-	let uiNodeStyle = getComputedStyle(uiNode);
-	let uiNodeMarginLeft = parseInt(
+	const nativeEditor = toolbar.context.editor.get('nativeEditor');
+	const uiNode = nativeEditor.config.uiNode || document.body;
+	const uiNodeStyle = getComputedStyle(uiNode);
+	const uiNodeMarginLeft = parseInt(
 		uiNodeStyle.getPropertyValue('margin-left'),
 		10
 	);
-	let uiNodeMarginRight = parseInt(
+	const uiNodeMarginRight = parseInt(
 		uiNodeStyle.getPropertyValue('margin-right'),
 		10
 	);
-	let totalWidth = uiNodeMarginLeft + uiNode.clientWidth + uiNodeMarginRight;
+	const totalWidth =
+		uiNodeMarginLeft + uiNode.clientWidth + uiNodeMarginRight;
 
-	let halfNodeWidth = toolbarNode.offsetWidth / 2;
-	let scrollPosition = new CKEDITOR.dom.window(window).getScrollPosition();
+	const halfNodeWidth = toolbarNode.offsetWidth / 2;
+	const scrollPosition = new CKEDITOR.dom.window(window).getScrollPosition();
 
-	let gutter = toolbar.props.gutter || DEFAULT_GUTTER;
+	const gutter = toolbar.props.gutter || DEFAULT_GUTTER;
 
-	let widgetXY = toolbar.getWidgetXYPoint(
+	const widgetXY = toolbar.getWidgetXYPoint(
 		rect.left + rect.width / 2 - scrollPosition.x,
 		rect.top + scrollPosition.y,
 		CKEDITOR.SELECTION_BOTTOM_TO_TOP
 	);
 
-	let endPosition = [
+	const endPosition = [
 		rect.left + rect.width / 2 - halfNodeWidth - scrollPosition.x,
 		rect.top - toolbarNode.offsetHeight + scrollPosition.y - gutter.top,
 	];
@@ -62,8 +63,8 @@ let centerToolbar = function(toolbar, rect) {
  * client rectangle of the selected image
  * @return {Boolean} True, in all cases
  */
-let imageSelectionSetPosition = function(payload) {
-	let selectionData = payload.selectionData
+const imageSelectionSetPosition = function(payload) {
+	const selectionData = payload.selectionData
 		? payload.selectionData
 		: payload.editorEvent
 		? payload.editorEvent.data.selectionData
@@ -84,14 +85,14 @@ let imageSelectionSetPosition = function(payload) {
  * client rectangle of the selected table
  * @return {Boolean} True, in all cases
  */
-let tableSelectionSetPosition = function(payload) {
-	let nativeEditor = payload.editor.get('nativeEditor');
-	let uiNode = nativeEditor.config.uiNode;
+const tableSelectionSetPosition = function(payload) {
+	const nativeEditor = payload.editor.get('nativeEditor');
+	const uiNode = nativeEditor.config.uiNode;
 
-	let scrollTop = uiNode ? uiNode.scrollTop : 0;
+	const scrollTop = uiNode ? uiNode.scrollTop : 0;
 
-	let table = new CKEDITOR.Table(nativeEditor).getFromSelection();
-	let rect = table.getClientRect();
+	const table = new CKEDITOR.Table(nativeEditor).getFromSelection();
+	const rect = table.getClientRect();
 	rect.top += scrollTop;
 
 	centerToolbar(this, rect);

--- a/src/selections/selection-test.js
+++ b/src/selections/selection-test.js
@@ -1,4 +1,4 @@
-let _isRangeAtElementEnd = function(range, element) {
+const _isRangeAtElementEnd = function(range, element) {
 	// Finding if a range is at the end of an element is somewhat tricky due to how CKEditor handles
 	// ranges. It might depend on wether a source node inside the element is selected or not. For now,
 	// we need to cover the following cases:
@@ -15,8 +15,8 @@ let _isRangeAtElementEnd = function(range, element) {
 	);
 };
 
-let embedSelectionTest = function(payload) {
-	let selectionData = payload.data.selectionData;
+const embedSelectionTest = function(payload) {
+	const selectionData = payload.data.selectionData;
 
 	return !!(
 		selectionData.element &&
@@ -51,14 +51,14 @@ const headingTextSelectionTest = function(payload) {
 	);
 };
 
-let linkSelectionTest = function(payload) {
-	let nativeEditor = payload.editor.get('nativeEditor');
-	let range = nativeEditor.getSelection().getRanges()[0];
-	let selectionData = payload.data.selectionData;
+const linkSelectionTest = function(payload) {
+	const nativeEditor = payload.editor.get('nativeEditor');
+	const range = nativeEditor.getSelection().getRanges()[0];
+	const selectionData = payload.data.selectionData;
 
-	let element = new CKEDITOR.Link(nativeEditor).getFromSelection();
-	let isSelectionEmpty = nativeEditor.isSelectionEmpty();
-	let elementIsNotImage = selectionData.element
+	const element = new CKEDITOR.Link(nativeEditor).getFromSelection();
+	const isSelectionEmpty = nativeEditor.isSelectionEmpty();
+	const elementIsNotImage = selectionData.element
 		? selectionData.element.getName() !== 'img'
 		: true;
 
@@ -82,12 +82,12 @@ const imageSelectionTest = function(payload) {
 	return !!(element && (hasImage || isImage));
 };
 
-let textSelectionTest = function(payload) {
-	let nativeEditor = payload.editor.get('nativeEditor');
+const textSelectionTest = function(payload) {
+	const nativeEditor = payload.editor.get('nativeEditor');
 
-	let selectionEmpty = nativeEditor.isSelectionEmpty();
+	const selectionEmpty = nativeEditor.isSelectionEmpty();
 
-	let selectionData = payload.data.selectionData;
+	const selectionData = payload.data.selectionData;
 
 	return !!(
 		!selectionData.element &&
@@ -100,11 +100,11 @@ let textSelectionTest = function(payload) {
 	);
 };
 
-let tableSelectionTest = function(payload) {
-	let nativeEditor = payload.editor.get('nativeEditor');
+const tableSelectionTest = function(payload) {
+	const nativeEditor = payload.editor.get('nativeEditor');
 
-	let table = new CKEDITOR.Table(nativeEditor);
-	let element = table.getFromSelection();
+	const table = new CKEDITOR.Table(nativeEditor);
+	const element = table.getFromSelection();
 
 	return !!(element && table.isEditable(element));
 };

--- a/test/ui/test/button-embed-edit.jsx
+++ b/test/ui/test/button-embed-edit.jsx
@@ -46,11 +46,9 @@ describe('ButtonEmbedEdit Component', function() {
 	it('focuses on the link input as soon as the component gets rendered in older browsers', function() {
 		// Make setTimeout synchronous to avoid unnecessary test delays
 		var requestAnimationFrame = window.requestAnimationFrame;
-		sinon
-			.stub(window, 'setTimeout')
-			.callsFake(function(callback) {
-				callback();
-			});
+		sinon.stub(window, 'setTimeout').callsFake(function(callback) {
+			callback();
+		});
 
 		window.requestAnimationFrame = null;
 


### PR DESCRIPTION
This upgrade trips a number of new lints, many of which were auto-fixable with `npm run lint:fix`. For the others:

- Turned off the "sort-keys" rule because it is very noisy in this project; maybe so noisy that I am not sure we want to keep it in the upstream default config; nevertheless, we don't need to make that decision right now.
- There was one "sort-vars" lint that would have been pretty awkward to fix, because it would cause us to change the "natural" ordering in the `for` statement initializer from `let j = 0, cols = ...` to `let cols = ..., j = 0`; for this one, I just added a suppression.

```
for (let j = 0, cols = map[i].length; j < cols; j++) {
```

- Assorted other lints, I just fixed them, specifically:

```
src/components/buttons/button-icon.jsx
  4:45  error  Expected object keys to be in sorted order. Expected className to be before symbol  sort-destructure-keys/sort-destructure-keys

src/components/buttons/button-link-autocomplete-list.jsx
  183:5  error  Expected an assignment or function call and instead saw an expression  no-unused-expressions

src/core/selection-region.js
  216:4  error  Return statement should not contain assignment             no-return-assign
  402:4  error  'hasOwnProperty' is never reassigned. Use 'const' instead  prefer-const

src/plugins/dragresize.js
  469:4  error  Expected an assignment or function call and instead saw an expression  no-unused-expressions
  488:4  error  Expected an assignment or function call and instead saw an expression  no-unused-expressions
  503:4  error  Expected an assignment or function call and instead saw an expression  no-unused-expressions
  515:4  error  Expected an assignment or function call and instead saw an expression  no-unused-expressions

src/plugins/tableresize.js
   99:4  error  Expected an assignment or function call and instead saw an expression  no-unused-expressions
  108:5  error  Expected an assignment or function call and instead saw an expression  no-unused-expressions
  119:5  error  Expected an assignment or function call and instead saw an expression  no-unused-expressions
  124:4  error  'pillarWidth' is never reassigned. Use 'const' instead                 prefer-const
  159:7  error  'document' is never reassigned. Use 'const' instead                    prefer-const
  160:7  error  'isResizing' is never reassigned. Use 'const' instead                  prefer-const
  161:7  error  'move' is never reassigned. Use 'const' instead                        prefer-const
  162:7  error  'resizer' is never reassigned. Use 'const' instead                     prefer-const
  210:6  error  Expected an assignment or function call and instead saw an expression  no-unused-expressions
  215:6  error  Expected an assignment or function call and instead saw an expression  no-unused-expressions
  250:4  error  Expected an assignment or function call and instead saw an expression  no-unused-expressions
  284:7  error  Expected an assignment or function call and instead saw an expression  no-unused-expressions
  289:7  error  Expected an assignment or function call and instead saw an expression  no-unused-expressions
  491:7  error  'table' is never reassigned. Use 'const' instead                       prefer-const

src/plugins/tabletools.js
   181:3   error  Expected an assignment or function call and instead saw an expression        no-unused-expressions
   224:8   error  Expected an assignment or function call and instead saw an expression        no-unused-expressions
   451:3   error  Expected an assignment or function call and instead saw an expression        no-unused-expressions
   635:5   error  Expected an assignment or function call and instead saw an expression        no-unused-expressions
   787:3   error  'newCell' is never reassigned. Use 'const' instead                           prefer-const
   864:7   error  Expected an assignment or function call and instead saw an expression        no-unused-expressions
  1014:3   error  Expected an assignment or function call and instead saw an expression        no-unused-expressions
```

Test plan: `npm run build && npm run test:debug` (see no failures in Firefox debug console), `npm run start` and check demo, especially the table-resizing functionality, which is where some of the most invasive code changes needed to be made in order to pacify the linter.

Related: https://github.com/liferay/eslint-config-liferay/issues/21