### PR TITLE
Fixes #1061 Allow only required style for IE and other browsers

### DIFF
--- a/src/plugins/dragresize_ie11.js
+++ b/src/plugins/dragresize_ie11.js
@@ -528,11 +528,11 @@
                     var el = shift.element;
 
                     // Alignment changed.
-                    if ( shift.changed.align ) {
+                    if ( shift.changed.align || el.$.style.marginLeft === 'auto' && el.$.style.marginRight === 'auto') {
                         // No caption in the new state.
                         if ( !shift.newData.hasCaption ) {
                             // Changed to "center" (non-captioned).
-                            if ( newValue == 'center' ) {
+                            if ( newValue == 'center' || el.$.style.marginLeft === 'auto' && el.$.style.marginRight === 'auto') {
                                 shift.deflate();
                                 shift.element = wrapInCentering( editor, el );
                             }

--- a/src/plugins/imagealignment.js
+++ b/src/plugins/imagealignment.js
@@ -80,6 +80,7 @@
                         }
                     });
                     centeredImage = true;
+                    imageContainer.style.textAlign = '';
                 }
             }
 
@@ -142,11 +143,6 @@
                     });
                 }
             });
-
-            var imageContainer = image.$.parentNode;
-
-            imageContainer.style.textAlign = IMAGE_ALIGNMENT.CENTER;
-
         }
     };
 


### PR DESCRIPTION
PR to master: https://github.com/liferay/alloy-editor/pull/1104
Fixes: #1061
https://issues.liferay.com/browse/LPS-90092

My understanding is that 2.0.0-* will be intended for 7.1 and not be backported and 1.x will be for 7.0. Let me know if this is correct.

Thank you!