### PR TITLE
chore: Clean up redundant script names (#1187)

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,6 @@
   "scripts": {
     "build:assets": "gulp --gulpfile scripts/build/gulp/gulpfile.js build:assets",
     "build": "gulp --gulpfile scripts/build/gulp/gulpfile.js --release",
-    "checkFormat": "prettier --list-different -- '*.js' '{scripts,src,test}/**/*.{js,jsx}'",
     "dev": "gulp --gulpfile scripts/build/gulp/gulpfile.js",
     "format": "prettier --write -- '*.js' '{scripts,src,test}/**/*.{js,jsx}'",
     "format:changed": "git ls-files -mz *.js -- 'scripts/*.js' 'src/*.js' 'src/*.jsx' 'test/*.js' 'test/*.jsx' | xargs -0 prettier --write --",
@@ -65,8 +64,7 @@
     "lint:changed": "git ls-files -mz 'src/*.js' 'src/*.jsx' | xargs -0 eslint",
     "lint:fix": "eslint --fix 'src/**/*.{js,jsx}'",
     "lint:quiet": "eslint --quiet 'src/**/*.{js,jsx}'",
-    "prettier": "prettier --write -- '*.js' '{scripts,src,test}/**/*.{js,jsx}'",
-    "prepublishOnly": "npm run checkFormat && npm run test",
+    "prepublishOnly": "npm run format:check && npm run test",
     "start": "webpack-dev-server --config webpack.dev.js",
     "test": "karma start karma.js",
     "test:debug": "karma start karma.js --debug",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "dev": "gulp --gulpfile scripts/build/gulp/gulpfile.js",
     "format": "prettier --write -- '*.js' '{scripts,src,test}/**/*.{js,jsx}'",
     "format:changed": "git ls-files -mz *.js -- 'scripts/*.js' 'src/*.js' 'src/*.jsx' 'test/*.js' 'test/*.jsx' | xargs -0 prettier --write --",
+    "format:check": "prettier --list-different -- '*.js' '{scripts,src,test}/**/*.{js,jsx}'",
     "lint": "eslint 'src/**/*.{js,jsx}'",
     "lint:changed": "git ls-files -mz 'src/*.js' 'src/*.jsx' | xargs -0 eslint",
     "lint:fix": "eslint --fix 'src/**/*.{js,jsx}'",


### PR DESCRIPTION
Over in this comment I did a bit of a mini-audit of how we're using script names in a number of projects, and noticed that we have some redundant tasks in this project:

https://github.com/liferay/liferay-npm-tools/pull/41#discussion_r269474322

Specifically, we have "checkFormat" and "prettier", which both duplicate "format".

Closes: https://github.com/liferay/alloy-editor/issues/1187