### PR TITLE
fix: broken website builds due to malformed Markdown (#1204)

### DIFF
--- a/content/docs/develop/create_skin.md
+++ b/content/docs/develop/create_skin.md
@@ -7,8 +7,6 @@ order: 5
 
 ###### AlloyEditor bundles a couple of gorgeous skins that you can use out of the box. However, if you would like to have a skin that reflects your app's look and feel, you can create your own skin.
 
-</article>
-
 <article id="article1">
 
 ## Create skin folders


### PR DESCRIPTION
`yarn build` was dying with:

```
error Plugin gatsby-mdx returned an error

  SyntaxError: unknown: Expected corresponding JSX closing tag for <MDXTag> (4:0)
```

Closes: https://github.com/liferay/alloy-editor/issues/1204