### PR TITLE
chore: Update to latest clay-css (#1220)

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
   },
   "homepage": "http://alloyeditor.com",
   "dependencies": {
-    "clay-css": "2.5.1",
+    "clay-css": "^2.11.1",
     "prop-types": "^15.6.2",
     "react": "^16.8.3",
     "react-dom": "^16.8.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1869,10 +1869,10 @@ class-utils@^0.3.5:
     isobject "^3.0.0"
     static-extend "^0.1.1"
 
-clay-css@2.5.1:
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/clay-css/-/clay-css-2.5.1.tgz#e47a2427d16766502b09487441ec31dc48873720"
-  integrity sha512-J9EEbLe7X9BA1mS4DZXqKM/J6ukt5Gw++67KTMuwooSUc2TH3tLkadueBibNhxTGSkAHWQwPk4VU3BtONC89fQ==
+clay-css@^2.11.1:
+  version "2.12.0"
+  resolved "https://registry.yarnpkg.com/clay-css/-/clay-css-2.12.0.tgz#984163b32848a17691a76b99cdeaa3aef5653c5c"
+  integrity sha512-Jwh7oiZ3VSvJPC0OMXwfJe1IBUkaD/w5IOtLkkv+4E8z8JXG7m4C+iACxJxunJsPxnC66SgWt9Lq2RbZUvv87w==
 
 cli-cursor@^2.1.0:
   version "2.1.0"


### PR DESCRIPTION
We're using clay-css for the spritesheet, but we had it pinned to an old version. In liferay-portal, we're using clay-css 2.11.1 right now, and there's no reason why we shouldn't just use the same here. So I'm specifying a looser range. Note that the latest is actually 2.12.0, but I only ask for "^2.11.1" because I want `yarn` in the portal to resolve clay-css to a single version.

Test plan: `yarn dev && yarn start`

![testing](https://user-images.githubusercontent.com/7074/55551504-42cbf480-56db-11e9-9aa6-42eb3d117166.png)

Closes: https://github.com/liferay/alloy-editor/issues/1220