### PR TITLE
#1224 cke_image_resizing class is added to containing parent span for…

### DIFF
--- a/src/plugins/dragresize_ie11.js
+++ b/src/plugins/dragresize_ie11.js
@@ -79,7 +79,7 @@
 					'right:auto;' +
 					'}' +
 					'.cke_widget_wrapper:hover .cke_image_resizer,' +
-					'.cke_image_resizer.cke_image_resizing{' +
+					'.cke_image_resizing>.cke_image_resizer{' +
 					'display:block' +
 					'}' +
 					// Expand widget wrapper when linked inline image.


### PR DESCRIPTION
…s image resizer, change selector so drag handles don't disappear while resizing

Fix for https://github.com/liferay/alloy-editor/issues/1224

Can't reproduce this issue in standalone AlloyEditor on IE11 because the only build steps I found for building AlloyEditor did not transpile ES6 into ES5 for some reason, making AlloyEditor in general not work correctly on IE11. I did, however, include steps in the case that you are able to get AlloyEditor to properly work on IE11.

Please let me know if there are any issues with the procedure here.

Related LPS: https://issues.liferay.com/browse/LPS-94092