### PR TITLE
fix: add svg4everybody polyfill to make demo work on IE11 (#1227)

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -1,6 +1,10 @@
 require('./src/styles/main.scss');
 require('react-app-polyfill/ie11');
 
+const svg4everybody = require('svg4everybody');
+
+svg4everybody();
+
 // A stub function is needed because gatsby won't load this file otherwise
 // (https://github.com/gatsbyjs/gatsby/issues/6759)
 exports.onClientEntry = () => {};

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "react-dom": "16.6.3",
     "react-helmet": "5.2.0",
     "react-live": "1.12.0",
+    "svg4everybody": "2.1.9",
     "wedeploy": "4.5.1",
     "wowjs": "1.1.3"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -12712,6 +12712,11 @@ supports-color@^5.1.0, supports-color@^5.3.0, supports-color@^5.4.0, supports-co
   dependencies:
     has-flag "^3.0.0"
 
+svg4everybody@2.1.9:
+  version "2.1.9"
+  resolved "https://registry.yarnpkg.com/svg4everybody/-/svg4everybody-2.1.9.tgz#5bd9f6defc133859a044646d4743fabc28db7e2d"
+  integrity sha1-W9n23vwTOFmgRGRtR0P6vCjbfi0=
+
 svgo@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/svgo/-/svgo-1.1.1.tgz#12384b03335bcecd85cfa5f4e3375fed671cb985"


### PR DESCRIPTION
This is the follow-up to #1230, and makes the demo fully functional in IE11 (well, as fully functional as IE ever is).

Test plan: `yarn build && yarn serve`, then hit demo from VirtualBox VM (http://localhost:9000).

![Screen Shot 2019-04-23 at 10 20 03](https://user-images.githubusercontent.com/7074/56565877-a72ef500-65b1-11e9-85a5-62722305b244.png)

Closes: https://github.com/liferay/alloy-editor/issues/1227