### PR TITLE
fix: console errors in Windows-based build (#1228)

### DIFF
--- a/webpack.common.js
+++ b/webpack.common.js
@@ -11,6 +11,16 @@ function toAbsolute(rootRelativePath) {
 	return path.join(__dirname, rootRelativePath);
 }
 
+/**
+ * For windows compatibility, we need to use windows path separators for webpack
+ * "test" properties.
+ */
+function toTestRegExp(file) {
+	return new RegExp(
+		file.split('/').join(path.sep).replace(/\\/g, '\\')
+	);
+}
+
 const base = {
 	/**
 	 * https://webpack.js.org/configuration/entry-context/
@@ -28,7 +38,7 @@ const base = {
 				loader: 'babel-loader',
 			},
 			{
-				test: /scripts\/build\/version\.js$/,
+				test: toTestRegExp('scripts/build/version.js'),
 				use: {
 					loader: 'val-loader',
 				},

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -17,7 +17,10 @@ function toAbsolute(rootRelativePath) {
  */
 function toTestRegExp(file) {
 	return new RegExp(
-		file.split('/').join(path.sep).replace(/\\/g, '\\')
+		file
+			.split('/')
+			.join(path.sep)
+			.replace(/\\/g, '\\')
 	);
 }
 

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -16,12 +16,7 @@ function toAbsolute(rootRelativePath) {
  * "test" properties.
  */
 function toTestRegExp(file) {
-	return new RegExp(
-		file
-			.split('/')
-			.join(path.sep)
-			.replace(/\\/g, '\\')
-	);
+	return new RegExp(path.normalize(file).replace(/\\/g, '\\'));
 }
 
 const base = {


### PR DESCRIPTION
It turns out that the "test" property in the Webpack build needs to be in a different format on Windows, otherwise it never matches, which means that our file at "scripts/build/version.js" doesn't pass through the val-loader, and in turn means that we produce untransformed output that IE 11 will choke on (an arrow function, and even if we fixed it, it would probably choke on the backticks).

You can make the build work on Windows by passing `path.resolve('scripts/build/version.js')` instead; this produces an absolute path with the appropriate Windows-style backslashes. But then the build doesn't work on macOS. If you try to make it a relative path (`path.relative('', path.resolve(...))`) then Webpack rejects it.

So, the solution is to make a RegExp with the backslashes (if present) escaped.

Test plan: build on macOS and Windows (with `yarn build`, `yarn start`) and confirm console errors are gone and version is correctly transpiled. Note that the demo misbehaves still on IE 11 (not console errors, but some misbehavior of the editor itself, but I think that's expected).

Closes: https://github.com/liferay/alloy-editor/issues/1228