### PR TITLE
chore: make Travis use Node v11 (#1237)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ install:
 language: node_js
 
 node_js:
-- 'node'
+- "11"
 
 script:
   - yarn ci


### PR DESCRIPTION
Because node-sass is not compatible with the just-released v12, and is causing all CI runs to blow up; example:

https://travis-ci.org/liferay/alloy-editor/builds/523839150

Closes: https://github.com/liferay/alloy-editor/issues/1237