### PR TITLE
feat: improve documentation on level of IE support (#1243)

### DIFF
--- a/content/docs/use/how_to_use_it.md
+++ b/content/docs/use/how_to_use_it.md
@@ -6,7 +6,7 @@ order: 2
 
 ###### The section below assumes that you are using the default UI built on React. If you're using your own custom UI, these steps will be different.
 
-<article id="article1">
+<article id="add-css">
 
 ## Add AlloyEditor's CSS to the page
 
@@ -16,7 +16,7 @@ order: 2
 
 </article>
 
-<article id="article2">
+<article id="add-js">
 
 ## Add AlloyEditor's JS to the page
 
@@ -42,15 +42,27 @@ There are a <strong>few ways</strong> to add the editor to the page:
   ```
 
   <span>If you use both React and CKEditor on your page, then just include AlloyEditor's core:</span>
+
   ```text/html
   <script src="alloy-editor/alloy-editor-core-min.js"></script>
   ```
-</section>
 
+</section>
 
 </article>
 
-<article id="article3">
+<article id="polyfilling">
+
+## Polyfilling older browsers
+
+To work properly on older browsers such as IE11 you will need to ensure that you have the appropriate polyfills in your environment. These are:
+
+- In order to correctly display icons, an SVG polyfill such as [svg4everybody](https://www.npmjs.com/package/svg4everybody).
+- To provide `Symbol`, which is needed by React, a polyfill like [react-app-polyfill](https://www.npmjs.com/package/react-app-polyfill).
+
+</article>
+
+<article id="making-editable">
 
 ## Invoke the static editable method of AlloyEditor
 
@@ -59,7 +71,7 @@ AlloyEditor.editable('myContentEditable');
 ```
 </article>
 
-<article id="article4">
+<article id="getting-content">
 
 ## Retrieve the content from the editor
 

--- a/content/docs/use/use.md
+++ b/content/docs/use/use.md
@@ -35,6 +35,8 @@ If you downloaded it via Bower:
 <script src="bower_components/alloyeditor/dist/alloy-editor/alloy-editor-all-min.js"></script>
 ```
 
+Note that if you intend to use AlloyEditor on older browsers such as IE you may need to make [some polyfills available in your environment](how_to_use_it.html#polyfilling).
+
 </article>
 
 <article id="article3">

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -3,6 +3,7 @@ const path = require('path');
 
 module.exports = {
 	plugins: [
+		'gatsby-plugin-catch-links',
 		'gatsby-plugin-meta-redirect',
 		{
 			resolve: 'gatsby-plugin-sass',

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "documentation": "9.0.0",
     "gatsby": "2.0.64",
     "gatsby-mdx": "0.1.4",
+    "gatsby-plugin-catch-links": "2.0.13",
     "gatsby-plugin-google-analytics": "2.0.8",
     "gatsby-plugin-manifest": "2.0.11",
     "gatsby-plugin-offline": "2.0.19",

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -72,7 +72,7 @@ class Index extends Component {
 									</p>
 
 									<p className="small font-weight-bold mt-5">
-										Supported browsers: IE9+, Edge, Chrome,
+										Supported browsers: IE11, Edge, Chrome,
 										Firefox, Safari
 									</p>
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6155,6 +6155,14 @@ gatsby-mdx@0.1.4:
     unist-util-remove "^1.0.1"
     unist-util-visit "^1.4.0"
 
+gatsby-plugin-catch-links@2.0.13:
+  version "2.0.13"
+  resolved "https://registry.yarnpkg.com/gatsby-plugin-catch-links/-/gatsby-plugin-catch-links-2.0.13.tgz#b49bb1e2383881cffca86a428348a7afdb6c3dd4"
+  integrity sha512-3JOwByiAKaiHo9k+QMiqe15H0T7wGh0NyulSFz7am1HC5/XHzcrX2ysW/zo1PV5eZq3P+n+X5V0t28cp+n1FBg==
+  dependencies:
+    "@babel/runtime" "^7.0.0"
+    escape-string-regexp "^1.0.5"
+
 gatsby-plugin-google-analytics@2.0.8:
   version "2.0.8"
   resolved "https://registry.yarnpkg.com/gatsby-plugin-google-analytics/-/gatsby-plugin-google-analytics-2.0.8.tgz#bef7913726e70f03533c4d14bfc73f8bd73550e0"


### PR DESCRIPTION
- Drops misleading reference to "IE9+"; we officially support "IE11" as described in #1161.
- Get rid of odious "article1", "article2" etc ids because I need to link to a specific section in "how_to_use_it.md"; we should do this everywhere but it is beyond the scope of this commit.
- Describe needed polyfills on "how_to_use_it.md".
- Provide a link to the polyfills section on "how_to_use_it.md" from "use.md".
- Add gatsby-plugin-catch-links plugin so that the aforementioned link doesn't force an unnecessary full page-reload.

Test plan: `yarn start` and check out the edited pages. Also, use the network pane to confirm that the full page-reload isn't happening.

<img width="1677" alt="AlloyEditor___Home" src="https://user-images.githubusercontent.com/7074/56651022-77065580-6688-11e9-9c8e-9b0208690572.png">
<img width="1676" alt="AlloyEditor___How_to_use_it_" src="https://user-images.githubusercontent.com/7074/56650861-2ee73300-6688-11e9-8359-818505e70215.png">
<img width="1676" alt="AlloyEditor___Basic_use" src="https://user-images.githubusercontent.com/7074/56650895-41616c80-6688-11e9-9cd7-70b167312a7e.png">

Closes: https://github.com/liferay/alloy-editor/issues/1243