### PR TITLE
fix: backslash escaping on Windows builds (#1251)

### DIFF
--- a/webpack.common.js
+++ b/webpack.common.js
@@ -16,7 +16,7 @@ function toAbsolute(rootRelativePath) {
  * "test" properties.
  */
 function toTestRegExp(file) {
-	return new RegExp(path.normalize(file).replace(/\\/g, '\\'));
+	return new RegExp(path.normalize(file).replace(/\\/g, '\\\\'));
 }
 
 const base = {


### PR DESCRIPTION
…ackslashes into the proper regular expression format that they need to be in

Sent in to fix https://github.com/liferay/alloy-editor/issues/1251 in relation to https://github.com/liferay/alloy-editor/pull/1236