### PR TITLE
chore: fix lint

### DIFF
--- a/src/components/buttons/button-color.jsx
+++ b/src/components/buttons/button-color.jsx
@@ -85,15 +85,11 @@ class ButtonColor extends React.Component {
 	render() {
 		let activeColor = AlloyEditor.Strings.normal;
 
-		let activeColorClass = 'text-body';
-
 		const colors = this._getColors();
 
 		colors.some(item => {
 			if (this._checkActive(item.style)) {
 				activeColor = item.name;
-
-				activeColorClass = item.style.attributes.class;
 			}
 		});
 


### PR DESCRIPTION
Fixes:

    src/components/buttons/button-color.jsx
      88:7  error  'activeColorClass' is assigned a value but never used  no-unused-vars

which became unused in 12e5c779b.