### PR TITLE
fix: improve drag handler visibility on IE (#1255)

### DIFF
--- a/src/plugins/dragresize_ie11.js
+++ b/src/plugins/dragresize_ie11.js
@@ -443,6 +443,10 @@
                 if ( editor.filter.checkFeature( this.features.dimension ) && editor.config.ae_dragresize_ie11_disableResizer !== true )
                     setupResizer( this );
 
+                const dragHandlerStyle = this.dragHandlerContainer.$.style;
+                dragHandlerStyle.setAttribute('backgroundColor', 'rgba(255, 255, 255, 1');
+                dragHandlerStyle.setAttribute('opacity', '1');
+
                 this.shiftState = helpers.stateShifter( this.editor );
 
                 // Add widget editing option to its context menu.


### PR DESCRIPTION
Make the drag handler opaque, change the color to white to make it stand out more and move the handle so it is more visibly separate from the image

Sent in relation to https://github.com/liferay/alloy-editor/issues/1255