### PR TITLE
fix(ie): make IE preserve other browsers' image width styling (#1275)

### DIFF
--- a/src/plugins/dragresize_ie11.js
+++ b/src/plugins/dragresize_ie11.js
@@ -986,7 +986,11 @@
 
 			const image = wrapper.$.querySelector('img');
 
-			image.removeAttribute('style');
+			const imageStyles = image.getAttribute('style');
+			const widthStyles = /(width:.+?;)/g.exec(imageStyles);
+			const widthStyle = widthStyles[0];
+
+			image.setAttribute('style', widthStyle);
 		}
 	}
 


### PR DESCRIPTION
…e styling

https://github.com/liferay/alloy-editor/issues/1275

Instead of removing all the styles, keep the width (controls sizing) style