### PR TITLE
fix(ie): add a check for 'imageStyles' before accessing (#1289)

### DIFF
--- a/src/plugins/dragresize_ie11.js
+++ b/src/plugins/dragresize_ie11.js
@@ -987,10 +987,13 @@
 			const image = wrapper.$.querySelector('img');
 
 			const imageStyles = image.getAttribute('style');
-			const widthStyles = /(width:.+?;)/g.exec(imageStyles);
-			const widthStyle = widthStyles[0];
 
-			image.setAttribute('style', widthStyle);
+			if (imageStyles) {
+				const widthStyles = /(width:.+?;)/g.exec(imageStyles);
+				const widthStyle = widthStyles[0];
+
+				image.setAttribute('style', widthStyle);
+			}
 		}
 	}
 


### PR DESCRIPTION
Fixes #1289
https://issues.liferay.com/browse/LPS-98250

`imageStyles` needs to be checked before getting any information from it.

Let me know if there are any questions or comments about this.
Thank you.