### PR TITLE
fix(ie): add a check for 'imageStyles' before accessing (#1289)

### DIFF
--- a/src/plugins/dragresize_ie11.js
+++ b/src/plugins/dragresize_ie11.js
@@ -893,10 +893,13 @@
             var image = wrapper.$.querySelector('img');
 
             var imageStyles = image.getAttribute('style');
-            var widthStyles = /(width:.+?;)/g.exec(imageStyles);
-            var widthStyle = widthStyles[0];
 
-            image.setAttribute('style', widthStyle);
+            if (imageStyles) {
+                var widthStyles = /(width:.+?;)/g.exec(imageStyles);
+                var widthStyle = widthStyles[0];
+
+                image.setAttribute('style', widthStyle);
+            }
         }
     }
 


### PR DESCRIPTION
Fixes #1289 
https://issues.liferay.com/browse/LPS-98250

Fixes this issue in 1.x.
imageStyles needs to be checked before getting any information from it.

Let me know if there are any questions or comments about this.
Thank you.