### PR TITLE
fix: missing tooltip on remove-image button (#1286)

### DIFF
--- a/src/components/buttons/button-remove-image.jsx
+++ b/src/components/buttons/button-remove-image.jsx
@@ -27,7 +27,8 @@ class ButtonRemoveImage extends React.Component {
 				aria-label={AlloyEditor.Strings.removeImage}
 				aria-pressed={cssClass.indexOf('pressed') !== -1}
 				className={cssClass}
-				onClick={this.execCommand}>
+				onClick={this.execCommand}
+				title={AlloyEditor.Strings.removeImage}>
 				<ButtonIcon symbol="times-circle" />
 			</button>
 		);


### PR DESCRIPTION
Closes: https://github.com/liferay/alloy-editor/issues/1286

Test plan: `yarn build`, `yarn start`, see tooltip on remove-image button when hovering over an image toolbar.