### PR TITLE
fix: make demo insert-image button work again (#1291)

### DIFF
--- a/src/adapter/core.js
+++ b/src/adapter/core.js
@@ -687,7 +687,13 @@ extend(
 				validator: '_validateToolbars',
 				value: {
 					add: {
-						buttons: ['image', 'embed', 'camera', 'hline', 'table'],
+						buttons: [
+							'imageFromFile',
+							'embed',
+							'camera',
+							'hline',
+							'table',
+						],
 						tabIndex: 2,
 					},
 					styles: {

--- a/src/components/buttons/button-image.jsx
+++ b/src/components/buttons/button-image.jsx
@@ -18,7 +18,7 @@ class ButtonImage extends React.Component {
 	 * @property {String} key
 	 * @static
 	 */
-	static key = 'image';
+	static key = 'imageFromFile';
 
 	constructor(props) {
 		super(props);
@@ -87,7 +87,7 @@ class ButtonImage extends React.Component {
 	 * @method _onInputChange
 	 * @protected
 	 */
-	_onInputChange() {
+	_onInputChange = () => {
 		const inputEl = this.fileInput.current;
 
 		// On IE11 the function might be called with an empty array of
@@ -127,7 +127,7 @@ class ButtonImage extends React.Component {
 		reader.readAsDataURL(file);
 
 		inputEl.value = '';
-	}
+	};
 }
 
 export default ButtonImage;


### PR DESCRIPTION
In 8a0aaf75ee8c223a776f4b0f08d3953 we added a button (button-item-selector-image.jsx) with a duplicate "image" key, clobbering the existing "image" button (in button-image.jsx). Because of the way object literals work in JS, when we list the buttons in "src/components/buttons/index.js", the old image button is mapped to "image", then the new button is mapped over the top, overwriting it.

The new button works in Liferay DXP because we have the necessary "imageselector" command, but in the demo, it does nothing.

Fix is to pick a non-colliding name ("imageFromFile"). That fixes the demo, and it doesn't break DXP because DXP doesn't actually use the src/adapter/core.js to define what goes in each toolbar, instead using the system described here:

https://portal.liferay.dev/docs/7-1/tutorials/-/knowledge_base/t/modifying-an-editors-configuration

Test plan: `yarn build` and `yarn start`; check the demo.

Closes: https://github.com/liferay/alloy-editor/issues/1291