### PR TITLE
fix: make IE also preserve other browers' image height styling

### DIFF
--- a/src/plugins/dragresize_ie11.js
+++ b/src/plugins/dragresize_ie11.js
@@ -989,10 +989,15 @@
 			const imageStyles = image.getAttribute('style');
 
 			if (imageStyles) {
+				const heightStyles = /(height:.+?;)/g.exec(imageStyles);
+				const heightStyle = heightStyles[0];
+
 				const widthStyles = /(width:.+?;)/g.exec(imageStyles);
 				const widthStyle = widthStyles[0];
 
-				image.setAttribute('style', widthStyle);
+				const styles = heightStyle + widthStyle;
+
+				image.setAttribute('style', styles);
 			}
 		}
 	}


### PR DESCRIPTION
Fixes https://github.com/liferay/alloy-editor/issues/1297

Saving the image in IE sets/overrides the height value, so style height also needs to be preserved.