### PR TITLE
fix: make IE also preserve other browers' image height styling

### DIFF
--- a/src/plugins/dragresize_ie11.js
+++ b/src/plugins/dragresize_ie11.js
@@ -895,10 +895,16 @@
             var imageStyles = image.getAttribute('style');
 
             if (imageStyles) {
+                var heightStyles = /(height:.+?;)/g.exec(imageStyles);
+                var heightStyle = heightStyles[0];
+
                 var widthStyles = /(width:.+?;)/g.exec(imageStyles);
                 var widthStyle = widthStyles[0];
 
                 image.setAttribute('style', widthStyle);
+                var styles = heightStyle + widthStyle;
+
+                image.setAttribute('style', styles);
             }
         }
     }


### PR DESCRIPTION
Fixes #1297