### PR TITLE
fix: check whether height and width style exist before using

### DIFF
--- a/src/plugins/dragresize_ie11.js
+++ b/src/plugins/dragresize_ie11.js
@@ -989,13 +989,13 @@
 			const imageStyles = image.getAttribute('style');
 
 			if (imageStyles) {
-				let styles = "";
+				let styles = '';
 
 				const heightStyles = /(height:.+?;)/g.exec(imageStyles);
 				if (heightStyles && heightStyles.length) {
 					styles += heightStyles[0];
 				}
-				
+
 				const widthStyles = /(width:.+?;)/g.exec(imageStyles);
 				if (widthStyles && widthStyles.length) {
 					styles += widthStyles[0];

--- a/src/plugins/dragresize_ie11.js
+++ b/src/plugins/dragresize_ie11.js
@@ -989,13 +989,17 @@
 			const imageStyles = image.getAttribute('style');
 
 			if (imageStyles) {
+				let styles = "";
+
 				const heightStyles = /(height:.+?;)/g.exec(imageStyles);
-				const heightStyle = heightStyles[0];
-
+				if (heightStyles && heightStyles.length) {
+					styles += heightStyles[0];
+				}
+				
 				const widthStyles = /(width:.+?;)/g.exec(imageStyles);
-				const widthStyle = widthStyles[0];
-
-				const styles = heightStyle + widthStyle;
+				if (widthStyles && widthStyles.length) {
+					styles += widthStyles[0];
+				}
 
 				image.setAttribute('style', styles);
 			}

--- a/src/plugins/dragresize_ie11.js
+++ b/src/plugins/dragresize_ie11.js
@@ -992,12 +992,12 @@
 				let styles = '';
 
 				const heightStyles = /(height:.+?;)/g.exec(imageStyles);
-				if (heightStyles && heightStyles.length) {
+				if (heightStyles) {
 					styles += heightStyles[0];
 				}
 
 				const widthStyles = /(width:.+?;)/g.exec(imageStyles);
-				if (widthStyles && widthStyles.length) {
+				if (widthStyles) {
 					styles += widthStyles[0];
 				}
 

--- a/src/plugins/dragresize_ie11.js
+++ b/src/plugins/dragresize_ie11.js
@@ -991,12 +991,12 @@
 			if (imageStyles) {
 				let styles = '';
 
-				const heightStyles = /(height:.+?;)/g.exec(imageStyles);
+				const heightStyles = /(height:.+?;)/.exec(imageStyles);
 				if (heightStyles) {
 					styles += heightStyles[0];
 				}
 
-				const widthStyles = /(width:.+?;)/g.exec(imageStyles);
+				const widthStyles = /(width:.+?;)/.exec(imageStyles);
 				if (widthStyles) {
 					styles += widthStyles[0];
 				}


### PR DESCRIPTION
This is to fix the issues described https://github.com/liferay/alloy-editor/pull/1298#discussion_r310046875.  We're guarding against null values for height and width styles