### PR TITLE
fix: preserve height style for IE (1.x)

### DIFF
--- a/src/plugins/dragresize_ie11.js
+++ b/src/plugins/dragresize_ie11.js
@@ -895,10 +895,19 @@
             var imageStyles = image.getAttribute('style');
 
             if (imageStyles) {
-                var widthStyles = /(width:.+?;)/g.exec(imageStyles);
-                var widthStyle = widthStyles[0];
+            	var styles = '';
 
-                image.setAttribute('style', widthStyle);
+            	var heightStyles = /(height:.+?;)/.exec(imageStyles);
+            	if (heightStyles) {
+                	styles += heightStyles[0];
+                }
+
+                var widthStyles = /(width:.+?;)/.exec(imageStyles);
+                if (widthStyles) {
+                	styles += widthStyles[0];
+                }
+
+                image.setAttribute('style', styles);
             }
         }
     }


### PR DESCRIPTION
Not certain if the 'backport' procedure is to do 1:1 commits but I've bundled the changes of this section of code into one commit here