### PR TITLE
fix: move drag handler to ensure visible even when image on top line (#1316)

### DIFF
--- a/src/plugins/dragresize_ie11.js
+++ b/src/plugins/dragresize_ie11.js
@@ -494,6 +494,8 @@
 					'rgba(255, 255, 255, 1'
 				);
 				dragHandlerStyle.setAttribute('opacity', '1');
+                dragHandlerStyle.setAttribute('left', '5px');
+                dragHandlerStyle.setAttribute('top', '5px');
 
 				this.shiftState = helpers.stateShifter(this.editor);
 

--- a/src/plugins/dragresize_ie11.js
+++ b/src/plugins/dragresize_ie11.js
@@ -494,8 +494,8 @@
 					'rgba(255, 255, 255, 1'
 				);
 				dragHandlerStyle.setAttribute('opacity', '1');
-                dragHandlerStyle.setAttribute('left', '5px');
-                dragHandlerStyle.setAttribute('top', '5px');
+				dragHandlerStyle.setAttribute('left', '5px');
+				dragHandlerStyle.setAttribute('top', '5px');
 
 				this.shiftState = helpers.stateShifter(this.editor);
 


### PR DESCRIPTION
Closes: https://github.com/liferay/alloy-editor/issues/1316

Let me know if you think this is the correct approach or if we want to do something change the z-index of the drag handler.

