### PR TITLE
fix: alignment removal (#1315)

### DIFF
--- a/src/plugins/dragresize_ie11.js
+++ b/src/plugins/dragresize_ie11.js
@@ -349,6 +349,15 @@
 				)
 					this.data.align = 'none';
 
+				if (
+					(this.data.align === 'left' ||
+						this.data.align === 'right') &&
+					!this.wrapper.$.contains('float') &&
+					!this.oldData
+				) {
+					this.data.align = 'none';
+				}
+
 				// Convert the internal form of the widget from the old state to the new one.
 				this.shiftState({
 					widget: this,
@@ -1510,7 +1519,9 @@
 		if (imageAlignment === 'left' || imageAlignment === 'right') {
 			widget.wrapper.removeStyle('float');
 		} else if (imageAlignment === 'center') {
-			widget.editor.execCommand('justifyleft');
+			const imageCenter = widget.wrapper.$.querySelector('p');
+
+			imageCenter.style.textAlign = '';
 			widget.editor.execCommand('justifyleft');
 		}
 	};


### PR DESCRIPTION
#1315 

When the alignment of an image is removed, the alignment is set back to either left or right alignment. This fix looks at the data alignment and whether the wrapper contains any alignment styles and sets it to none if necessary.
Let me know if there are any questions or comments about this.
Thank you!