### PR TITLE
feat: make it possible to build custom buttons that use "mixins"

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -14,7 +14,6 @@ module.exports = {
 	},
 	extends: ['liferay/react'],
 	rules: {
-		'require-jsdoc': 'warn',
 		'new-cap': [
 			'error',
 			{
@@ -65,7 +64,6 @@ module.exports = {
 		'react/no-string-refs': 'warn',
 		'react/prop-types': 'warn',
 		'sort-keys': 'warn',
-		'valid-jsdoc': 'warn',
 	},
 	settings: {
 		react: {

--- a/src/adapter/main.js
+++ b/src/adapter/main.js
@@ -1,4 +1,6 @@
+import * as Base from '../components/base';
 import Buttons from '../components/buttons';
+import * as Compat from '../components/compat';
 import Toolbars from '../components/toolbars';
 import Attribute from '../oop/attribute';
 import Lang from '../oop/lang';
@@ -317,7 +319,9 @@ const OOP = {
 
 export {
 	Attribute,
+	Base,
 	Buttons,
+	Compat,
 	Core,
 	Lang,
 	OOP,

--- a/src/components/base/index.js
+++ b/src/components/base/index.js
@@ -1,0 +1,11 @@
+export {default as ButtonActionStyle} from './button-action-style';
+export {default as ButtonCommandActive} from './button-command-active';
+export {default as ButtonCommand} from './button-command';
+export {default as ButtonKeystroke} from './button-keystroke';
+export {default as ButtonProps} from './button-props';
+export {default as ButtonStateClasses} from './button-state-classes';
+export {default as ButtonStyle} from './button-style';
+export {default as ToolbarButtons} from './toolbar-buttons';
+export {default as WidgetDropdown} from './widget-dropdown';
+export {default as WidgetExclusive} from './widget-exclusive';
+export {default as WidgetFocusManager} from './widget-focus-manager';

--- a/src/components/compat/button-action-style.js
+++ b/src/components/compat/button-action-style.js
@@ -1,0 +1,43 @@
+(function() {
+    'use strict';
+
+    /**
+     * ButtonActionStyle is a mixin that provides applying style implementation for a
+     * button based on the `applyStyle` and `removeStyle` API of CKEDITOR.
+     *
+     * To execute properly, the component has to expose the following methods which can be obtained
+     * out of the box using the {{#crossLink "ButtonStyle"}}{{/crossLink}} mixin:
+     * - `Function` {{#crossLink "ButtonStyle/isActive"}}{{/crossLink}} to check the active state
+     * - `Function` {{#crossLink "ButtonStyle/getStyle"}}{{/crossLink}} to return the style that should be applied
+     *
+     * @class ButtonActionStyle
+     */
+    var ButtonActionStyle = {
+        /**
+         * Removes or applies the component style to the current selection.
+         *
+         * @instance
+         * @memberof ButtonActionStyle
+         * @method applyStyle
+         */
+        applyStyle: function() {
+            if (AlloyEditor.Lang.isFunction(this.isActive) && AlloyEditor.Lang.isFunction(this.getStyle)) {
+                var editor = this.props.editor.get('nativeEditor');
+
+                editor.getSelection().lock();
+
+                if (this.isActive()) {
+                    editor.removeStyle(this.getStyle());
+                } else {
+                    editor.applyStyle(this.getStyle());
+                }
+
+                editor.getSelection().unlock();
+
+                editor.fire('actionPerformed', this);
+            }
+        }
+    };
+
+    AlloyEditor.ButtonActionStyle = ButtonActionStyle;
+}());

--- a/src/components/compat/button-action-style.js
+++ b/src/components/compat/button-action-style.js
@@ -1,43 +1,46 @@
 (function() {
-    'use strict';
+	'use strict';
 
-    /**
-     * ButtonActionStyle is a mixin that provides applying style implementation for a
-     * button based on the `applyStyle` and `removeStyle` API of CKEDITOR.
-     *
-     * To execute properly, the component has to expose the following methods which can be obtained
-     * out of the box using the {{#crossLink "ButtonStyle"}}{{/crossLink}} mixin:
-     * - `Function` {{#crossLink "ButtonStyle/isActive"}}{{/crossLink}} to check the active state
-     * - `Function` {{#crossLink "ButtonStyle/getStyle"}}{{/crossLink}} to return the style that should be applied
-     *
-     * @class ButtonActionStyle
-     */
-    var ButtonActionStyle = {
-        /**
-         * Removes or applies the component style to the current selection.
-         *
-         * @instance
-         * @memberof ButtonActionStyle
-         * @method applyStyle
-         */
-        applyStyle: function() {
-            if (AlloyEditor.Lang.isFunction(this.isActive) && AlloyEditor.Lang.isFunction(this.getStyle)) {
-                var editor = this.props.editor.get('nativeEditor');
+	/**
+	 * ButtonActionStyle is a mixin that provides applying style implementation for a
+	 * button based on the `applyStyle` and `removeStyle` API of CKEDITOR.
+	 *
+	 * To execute properly, the component has to expose the following methods which can be obtained
+	 * out of the box using the {{#crossLink "ButtonStyle"}}{{/crossLink}} mixin:
+	 * - `Function` {{#crossLink "ButtonStyle/isActive"}}{{/crossLink}} to check the active state
+	 * - `Function` {{#crossLink "ButtonStyle/getStyle"}}{{/crossLink}} to return the style that should be applied
+	 *
+	 * @class ButtonActionStyle
+	 */
+	var ButtonActionStyle = {
+		/**
+		 * Removes or applies the component style to the current selection.
+		 *
+		 * @instance
+		 * @memberof ButtonActionStyle
+		 * @method applyStyle
+		 */
+		applyStyle() {
+			if (
+				AlloyEditor.Lang.isFunction(this.isActive) &&
+				AlloyEditor.Lang.isFunction(this.getStyle)
+			) {
+				var editor = this.props.editor.get('nativeEditor');
 
-                editor.getSelection().lock();
+				editor.getSelection().lock();
 
-                if (this.isActive()) {
-                    editor.removeStyle(this.getStyle());
-                } else {
-                    editor.applyStyle(this.getStyle());
-                }
+				if (this.isActive()) {
+					editor.removeStyle(this.getStyle());
+				} else {
+					editor.applyStyle(this.getStyle());
+				}
 
-                editor.getSelection().unlock();
+				editor.getSelection().unlock();
 
-                editor.fire('actionPerformed', this);
-            }
-        }
-    };
+				editor.fire('actionPerformed', this);
+			}
+		},
+	};
 
-    AlloyEditor.ButtonActionStyle = ButtonActionStyle;
-}());
+	AlloyEditor.ButtonActionStyle = ButtonActionStyle;
+})();

--- a/src/components/compat/button-action-style.js
+++ b/src/components/compat/button-action-style.js
@@ -1,46 +1,45 @@
-(function() {
-	'use strict';
+import Lang from '../../oop/lang';
 
+/**
+ * ButtonActionStyle is a mixin that provides applying style
+ * implementation for a button based on the `applyStyle` and
+ * `removeStyle` API of CKEDITOR.
+ *
+ * To execute properly, the component has to expose the following
+ * methods which can be obtained out of the box using the {{#crossLink
+ * "ButtonStyle"}}{{/crossLink}} mixin:
+ * - `Function` {{#crossLink "ButtonStyle/isActive"}}{{/crossLink}} to
+ *    check the active state
+ * - `Function` {{#crossLink "ButtonStyle/getStyle"}}{{/crossLink}} to
+ *    return the style that should be applied
+ *
+ * @class ButtonActionStyle
+ */
+const ButtonActionStyle = {
 	/**
-	 * ButtonActionStyle is a mixin that provides applying style implementation for a
-	 * button based on the `applyStyle` and `removeStyle` API of CKEDITOR.
+	 * Removes or applies the component style to the current selection.
 	 *
-	 * To execute properly, the component has to expose the following methods which can be obtained
-	 * out of the box using the {{#crossLink "ButtonStyle"}}{{/crossLink}} mixin:
-	 * - `Function` {{#crossLink "ButtonStyle/isActive"}}{{/crossLink}} to check the active state
-	 * - `Function` {{#crossLink "ButtonStyle/getStyle"}}{{/crossLink}} to return the style that should be applied
-	 *
-	 * @class ButtonActionStyle
+	 * @instance
+	 * @memberof ButtonActionStyle
+	 * @method applyStyle
 	 */
-	var ButtonActionStyle = {
-		/**
-		 * Removes or applies the component style to the current selection.
-		 *
-		 * @instance
-		 * @memberof ButtonActionStyle
-		 * @method applyStyle
-		 */
-		applyStyle() {
-			if (
-				AlloyEditor.Lang.isFunction(this.isActive) &&
-				AlloyEditor.Lang.isFunction(this.getStyle)
-			) {
-				var editor = this.props.editor.get('nativeEditor');
+	applyStyle() {
+		if (Lang.isFunction(this.isActive) && Lang.isFunction(this.getStyle)) {
+			const editor = this.props.editor.get('nativeEditor');
 
-				editor.getSelection().lock();
+			editor.getSelection().lock();
 
-				if (this.isActive()) {
-					editor.removeStyle(this.getStyle());
-				} else {
-					editor.applyStyle(this.getStyle());
-				}
-
-				editor.getSelection().unlock();
-
-				editor.fire('actionPerformed', this);
+			if (this.isActive()) {
+				editor.removeStyle(this.getStyle());
+			} else {
+				editor.applyStyle(this.getStyle());
 			}
-		},
-	};
 
-	AlloyEditor.ButtonActionStyle = ButtonActionStyle;
-})();
+			editor.getSelection().unlock();
+
+			editor.fire('actionPerformed', this);
+		}
+	},
+};
+
+export default ButtonActionStyle;

--- a/src/components/compat/button-command-active.js
+++ b/src/components/compat/button-command-active.js
@@ -1,0 +1,29 @@
+(function() {
+    'use strict';
+
+    /**
+     * ButtonCommandActive is a mixin that provides an `isActive` method to determine if
+     * a context-aware command is currently in an active state.
+     *
+     * @class ButtonCommandActive
+     */
+    var ButtonCommandActive = {
+        /**
+         * Checks if the command is active in the current selection.
+         *
+         * @instance
+         * @memberof ButtonCommandActive
+         * @method isActive
+         * @return {Boolean} True if the command is active, false otherwise.
+         */
+        isActive: function() {
+            var editor = this.props.editor.get('nativeEditor');
+
+            var command = editor.getCommand(this.props.command);
+
+            return command ? command.state === CKEDITOR.TRISTATE_ON : false;
+        }
+    };
+
+    AlloyEditor.ButtonCommandActive = ButtonCommandActive;
+}());

--- a/src/components/compat/button-command-active.js
+++ b/src/components/compat/button-command-active.js
@@ -1,29 +1,29 @@
 (function() {
-    'use strict';
+	'use strict';
 
-    /**
-     * ButtonCommandActive is a mixin that provides an `isActive` method to determine if
-     * a context-aware command is currently in an active state.
-     *
-     * @class ButtonCommandActive
-     */
-    var ButtonCommandActive = {
-        /**
-         * Checks if the command is active in the current selection.
-         *
-         * @instance
-         * @memberof ButtonCommandActive
-         * @method isActive
-         * @return {Boolean} True if the command is active, false otherwise.
-         */
-        isActive: function() {
-            var editor = this.props.editor.get('nativeEditor');
+	/**
+	 * ButtonCommandActive is a mixin that provides an `isActive` method to determine if
+	 * a context-aware command is currently in an active state.
+	 *
+	 * @class ButtonCommandActive
+	 */
+	var ButtonCommandActive = {
+		/**
+		 * Checks if the command is active in the current selection.
+		 *
+		 * @instance
+		 * @memberof ButtonCommandActive
+		 * @method isActive
+		 * @return {Boolean} True if the command is active, false otherwise.
+		 */
+		isActive() {
+			var editor = this.props.editor.get('nativeEditor');
 
-            var command = editor.getCommand(this.props.command);
+			var command = editor.getCommand(this.props.command);
 
-            return command ? command.state === CKEDITOR.TRISTATE_ON : false;
-        }
-    };
+			return command ? command.state === CKEDITOR.TRISTATE_ON : false;
+		},
+	};
 
-    AlloyEditor.ButtonCommandActive = ButtonCommandActive;
-}());
+	AlloyEditor.ButtonCommandActive = ButtonCommandActive;
+})();

--- a/src/components/compat/button-command-active.js
+++ b/src/components/compat/button-command-active.js
@@ -1,29 +1,25 @@
-(function() {
-	'use strict';
-
+/**
+ * ButtonCommandActive is a mixin that provides an `isActive` method to
+ * determine if a context-aware command is currently in an active state.
+ *
+ * @class ButtonCommandActive
+ */
+const ButtonCommandActive = {
 	/**
-	 * ButtonCommandActive is a mixin that provides an `isActive` method to determine if
-	 * a context-aware command is currently in an active state.
+	 * Checks if the command is active in the current selection.
 	 *
-	 * @class ButtonCommandActive
+	 * @instance
+	 * @memberof ButtonCommandActive
+	 * @method isActive
+	 * @return {Boolean} True if the command is active, false otherwise.
 	 */
-	var ButtonCommandActive = {
-		/**
-		 * Checks if the command is active in the current selection.
-		 *
-		 * @instance
-		 * @memberof ButtonCommandActive
-		 * @method isActive
-		 * @return {Boolean} True if the command is active, false otherwise.
-		 */
-		isActive() {
-			var editor = this.props.editor.get('nativeEditor');
+	isActive() {
+		const editor = this.props.editor.get('nativeEditor');
 
-			var command = editor.getCommand(this.props.command);
+		const command = editor.getCommand(this.props.command);
 
-			return command ? command.state === CKEDITOR.TRISTATE_ON : false;
-		},
-	};
+		return command ? command.state === CKEDITOR.TRISTATE_ON : false;
+	},
+};
 
-	AlloyEditor.ButtonCommandActive = ButtonCommandActive;
-})();
+export default ButtonCommandActive;

--- a/src/components/compat/button-command.js
+++ b/src/components/compat/button-command.js
@@ -1,0 +1,53 @@
+(function() {
+    'use strict';
+
+    /**
+     * ButtonCommand is a mixin that executes a command via CKEDITOR's API.
+     *
+     * @class ButtonCommand
+     */
+    var ButtonCommand = {
+        // Allows validating props being passed to the component.
+        propTypes: {
+            /**
+             * The command that should be executed.
+             *
+             * @instance
+             * @memberof ButtonCommand
+             * @property {String} command
+             */
+            command: PropTypes.string.isRequired,
+
+            /**
+             * Indicates that the command may cause the editor to have a different.
+             *
+             * @instance
+             * @memberof ButtonCommand
+             * @property {boolean} modifiesSelection
+             */
+            modifiesSelection: PropTypes.bool
+        },
+
+        /**
+         * Executes a CKEditor command and fires `actionPerformed` event.
+         *
+         * @instance
+         * @memberof ButtonCommand
+         * @param {Object=} data Optional data to be passed to CKEDITOR's `execCommand` method.
+         * @method execCommand
+         */
+        execCommand: function(data) {
+            var editor = this.props.editor.get('nativeEditor');
+
+            editor.execCommand(this.props.command, data);
+
+            if (this.props.modifiesSelection) {
+                editor.selectionChange(true);
+            }
+
+            editor.fire('actionPerformed', this);
+        }
+    };
+
+    AlloyEditor.ButtonCommand = ButtonCommand;
+}());

--- a/src/components/compat/button-command.js
+++ b/src/components/compat/button-command.js
@@ -1,3 +1,5 @@
+import PropTypes from 'prop-types';
+
 (function() {
 	'use strict';
 

--- a/src/components/compat/button-command.js
+++ b/src/components/compat/button-command.js
@@ -1,55 +1,51 @@
 import PropTypes from 'prop-types';
 
-(function() {
-	'use strict';
-
-	/**
-	 * ButtonCommand is a mixin that executes a command via CKEDITOR's API.
-	 *
-	 * @class ButtonCommand
-	 */
-	var ButtonCommand = {
-		// Allows validating props being passed to the component.
-		propTypes: {
-			/**
-			 * The command that should be executed.
-			 *
-			 * @instance
-			 * @memberof ButtonCommand
-			 * @property {String} command
-			 */
-			command: PropTypes.string.isRequired,
-
-			/**
-			 * Indicates that the command may cause the editor to have a different.
-			 *
-			 * @instance
-			 * @memberof ButtonCommand
-			 * @property {boolean} modifiesSelection
-			 */
-			modifiesSelection: PropTypes.bool,
-		},
-
+/**
+ * ButtonCommand is a mixin that executes a command via CKEDITOR's API.
+ *
+ * @class ButtonCommand
+ */
+const ButtonCommand = {
+	// Allows validating props being passed to the component.
+	propTypes: {
 		/**
-		 * Executes a CKEditor command and fires `actionPerformed` event.
+		 * The command that should be executed.
 		 *
 		 * @instance
 		 * @memberof ButtonCommand
-		 * @param {Object=} data Optional data to be passed to CKEDITOR's `execCommand` method.
-		 * @method execCommand
+		 * @property {String} command
 		 */
-		execCommand(data) {
-			var editor = this.props.editor.get('nativeEditor');
+		command: PropTypes.string.isRequired,
 
-			editor.execCommand(this.props.command, data);
+		/**
+		 * Indicates that the command may cause the editor to have a different.
+		 *
+		 * @instance
+		 * @memberof ButtonCommand
+		 * @property {boolean} modifiesSelection
+		 */
+		modifiesSelection: PropTypes.bool,
+	},
 
-			if (this.props.modifiesSelection) {
-				editor.selectionChange(true);
-			}
+	/**
+	 * Executes a CKEditor command and fires `actionPerformed` event.
+	 *
+	 * @instance
+	 * @memberof ButtonCommand
+	 * @param {Object=} data Optional data to be passed to CKEDITOR's `execCommand` method.
+	 * @method execCommand
+	 */
+	execCommand(data) {
+		const editor = this.props.editor.get('nativeEditor');
 
-			editor.fire('actionPerformed', this);
-		},
-	};
+		editor.execCommand(this.props.command, data);
 
-	AlloyEditor.ButtonCommand = ButtonCommand;
-})();
+		if (this.props.modifiesSelection) {
+			editor.selectionChange(true);
+		}
+
+		editor.fire('actionPerformed', this);
+	},
+};
+
+export default ButtonCommand;

--- a/src/components/compat/button-command.js
+++ b/src/components/compat/button-command.js
@@ -1,53 +1,53 @@
 (function() {
-    'use strict';
+	'use strict';
 
-    /**
-     * ButtonCommand is a mixin that executes a command via CKEDITOR's API.
-     *
-     * @class ButtonCommand
-     */
-    var ButtonCommand = {
-        // Allows validating props being passed to the component.
-        propTypes: {
-            /**
-             * The command that should be executed.
-             *
-             * @instance
-             * @memberof ButtonCommand
-             * @property {String} command
-             */
-            command: PropTypes.string.isRequired,
+	/**
+	 * ButtonCommand is a mixin that executes a command via CKEDITOR's API.
+	 *
+	 * @class ButtonCommand
+	 */
+	var ButtonCommand = {
+		// Allows validating props being passed to the component.
+		propTypes: {
+			/**
+			 * The command that should be executed.
+			 *
+			 * @instance
+			 * @memberof ButtonCommand
+			 * @property {String} command
+			 */
+			command: PropTypes.string.isRequired,
 
-            /**
-             * Indicates that the command may cause the editor to have a different.
-             *
-             * @instance
-             * @memberof ButtonCommand
-             * @property {boolean} modifiesSelection
-             */
-            modifiesSelection: PropTypes.bool
-        },
+			/**
+			 * Indicates that the command may cause the editor to have a different.
+			 *
+			 * @instance
+			 * @memberof ButtonCommand
+			 * @property {boolean} modifiesSelection
+			 */
+			modifiesSelection: PropTypes.bool,
+		},
 
-        /**
-         * Executes a CKEditor command and fires `actionPerformed` event.
-         *
-         * @instance
-         * @memberof ButtonCommand
-         * @param {Object=} data Optional data to be passed to CKEDITOR's `execCommand` method.
-         * @method execCommand
-         */
-        execCommand: function(data) {
-            var editor = this.props.editor.get('nativeEditor');
+		/**
+		 * Executes a CKEditor command and fires `actionPerformed` event.
+		 *
+		 * @instance
+		 * @memberof ButtonCommand
+		 * @param {Object=} data Optional data to be passed to CKEDITOR's `execCommand` method.
+		 * @method execCommand
+		 */
+		execCommand(data) {
+			var editor = this.props.editor.get('nativeEditor');
 
-            editor.execCommand(this.props.command, data);
+			editor.execCommand(this.props.command, data);
 
-            if (this.props.modifiesSelection) {
-                editor.selectionChange(true);
-            }
+			if (this.props.modifiesSelection) {
+				editor.selectionChange(true);
+			}
 
-            editor.fire('actionPerformed', this);
-        }
-    };
+			editor.fire('actionPerformed', this);
+		},
+	};
 
-    AlloyEditor.ButtonCommand = ButtonCommand;
-}());
+	AlloyEditor.ButtonCommand = ButtonCommand;
+})();

--- a/src/components/compat/button-keystroke.js
+++ b/src/components/compat/button-keystroke.js
@@ -1,0 +1,77 @@
+(function() {
+    'use strict';
+
+    /**
+     * ButtonKeystroke is a mixin that provides a `keystroke` prop that allows configuring
+     * a function of the instance to be invoked upon the keystroke activation.
+     *
+     * @class ButtonKeystroke
+     */
+    var ButtonKeystroke = {
+        // Allows validating props being passed to the component.
+        propTypes: {
+            /**
+             * The keystroke definition. An object with the following properties:
+             * - fn: The function to be executed
+             * - keys: The keystroke definition, as expected by http://docs.ckeditor.com/#!/api/CKEDITOR.editor-method-setKeystroke
+             * - name: The name for the CKEditor command that will be created. If empty,
+             * a random name will be created on the fly
+             *
+             * @instance
+             * @memberof ButtonKeystroke
+             * @property {Object} keystroke
+             */
+            keystroke: PropTypes.object.isRequired
+        },
+
+        /**
+         * Lifecycle. Invoked once, both on the client and server, immediately before the initial rendering occurs.
+         *
+         * @instance
+         * @memberof ButtonKeystroke
+         * @method componentWillMount
+         */
+        componentWillMount: function() {
+            var nativeEditor = this.props.editor.get('nativeEditor');
+            var keystroke = this.props.keystroke;
+
+            var commandName = keystroke.name || ((Math.random() * 1e9) >>> 0).toString();
+
+            var command = nativeEditor.getCommand(commandName);
+
+            if (!command) {
+                command = new CKEDITOR.command(nativeEditor, {
+                    exec: function(editor) {
+                            var keystrokeFn = keystroke.fn;
+
+                            if (AlloyEditor.Lang.isString(keystrokeFn)) {
+                                this[keystrokeFn].call(this, editor);
+                            } else if (AlloyEditor.Lang.isFunction(keystrokeFn)) {
+                                keystrokeFn.call(this, editor);
+                            }
+                        }.bind(this)
+                    }
+                );
+
+                nativeEditor.addCommand(commandName, command);
+            }
+
+            this._defaultKeystrokeCommand = nativeEditor.keystrokeHandler.keystrokes[keystroke.keys];
+
+            nativeEditor.setKeystroke(keystroke.keys, commandName);
+        },
+
+        /**
+         * Lifecycle. Invoked immediately before a component is unmounted from the DOM.
+         *
+         * @instance
+         * @memberof ButtonKeystroke
+         * @method componentWillUnmount
+         */
+        componentWillUnmount: function() {
+            this.props.editor.get('nativeEditor').setKeystroke(this.props.keystroke.keys, this._defaultKeystrokeCommand);
+        }
+    };
+
+    AlloyEditor.ButtonKeystroke = ButtonKeystroke;
+}());

--- a/src/components/compat/button-keystroke.js
+++ b/src/components/compat/button-keystroke.js
@@ -1,77 +1,83 @@
 (function() {
-    'use strict';
+	'use strict';
 
-    /**
-     * ButtonKeystroke is a mixin that provides a `keystroke` prop that allows configuring
-     * a function of the instance to be invoked upon the keystroke activation.
-     *
-     * @class ButtonKeystroke
-     */
-    var ButtonKeystroke = {
-        // Allows validating props being passed to the component.
-        propTypes: {
-            /**
-             * The keystroke definition. An object with the following properties:
-             * - fn: The function to be executed
-             * - keys: The keystroke definition, as expected by http://docs.ckeditor.com/#!/api/CKEDITOR.editor-method-setKeystroke
-             * - name: The name for the CKEditor command that will be created. If empty,
-             * a random name will be created on the fly
-             *
-             * @instance
-             * @memberof ButtonKeystroke
-             * @property {Object} keystroke
-             */
-            keystroke: PropTypes.object.isRequired
-        },
+	/**
+	 * ButtonKeystroke is a mixin that provides a `keystroke` prop that allows configuring
+	 * a function of the instance to be invoked upon the keystroke activation.
+	 *
+	 * @class ButtonKeystroke
+	 */
+	var ButtonKeystroke = {
+		// Allows validating props being passed to the component.
+		propTypes: {
+			/**
+			 * The keystroke definition. An object with the following properties:
+			 * - fn: The function to be executed
+			 * - keys: The keystroke definition, as expected by http://docs.ckeditor.com/#!/api/CKEDITOR.editor-method-setKeystroke
+			 * - name: The name for the CKEditor command that will be created. If empty,
+			 * a random name will be created on the fly
+			 *
+			 * @instance
+			 * @memberof ButtonKeystroke
+			 * @property {Object} keystroke
+			 */
+			keystroke: PropTypes.object.isRequired,
+		},
 
-        /**
-         * Lifecycle. Invoked once, both on the client and server, immediately before the initial rendering occurs.
-         *
-         * @instance
-         * @memberof ButtonKeystroke
-         * @method componentWillMount
-         */
-        componentWillMount: function() {
-            var nativeEditor = this.props.editor.get('nativeEditor');
-            var keystroke = this.props.keystroke;
+		/**
+		 * Lifecycle. Invoked once, both on the client and server, immediately before the initial rendering occurs.
+		 *
+		 * @instance
+		 * @memberof ButtonKeystroke
+		 * @method componentWillMount
+		 */
+		componentWillMount() {
+			var nativeEditor = this.props.editor.get('nativeEditor');
+			var keystroke = this.props.keystroke;
 
-            var commandName = keystroke.name || ((Math.random() * 1e9) >>> 0).toString();
+			var commandName =
+				keystroke.name || ((Math.random() * 1e9) >>> 0).toString();
 
-            var command = nativeEditor.getCommand(commandName);
+			var command = nativeEditor.getCommand(commandName);
 
-            if (!command) {
-                command = new CKEDITOR.command(nativeEditor, {
-                    exec: function(editor) {
-                            var keystrokeFn = keystroke.fn;
+			if (!command) {
+				command = new CKEDITOR.command(nativeEditor, {
+					exec: function(editor) {
+						var keystrokeFn = keystroke.fn;
 
-                            if (AlloyEditor.Lang.isString(keystrokeFn)) {
-                                this[keystrokeFn].call(this, editor);
-                            } else if (AlloyEditor.Lang.isFunction(keystrokeFn)) {
-                                keystrokeFn.call(this, editor);
-                            }
-                        }.bind(this)
-                    }
-                );
+						if (AlloyEditor.Lang.isString(keystrokeFn)) {
+							this[keystrokeFn].call(this, editor);
+						} else if (AlloyEditor.Lang.isFunction(keystrokeFn)) {
+							keystrokeFn.call(this, editor);
+						}
+					}.bind(this),
+				});
 
-                nativeEditor.addCommand(commandName, command);
-            }
+				nativeEditor.addCommand(commandName, command);
+			}
 
-            this._defaultKeystrokeCommand = nativeEditor.keystrokeHandler.keystrokes[keystroke.keys];
+			this._defaultKeystrokeCommand =
+				nativeEditor.keystrokeHandler.keystrokes[keystroke.keys];
 
-            nativeEditor.setKeystroke(keystroke.keys, commandName);
-        },
+			nativeEditor.setKeystroke(keystroke.keys, commandName);
+		},
 
-        /**
-         * Lifecycle. Invoked immediately before a component is unmounted from the DOM.
-         *
-         * @instance
-         * @memberof ButtonKeystroke
-         * @method componentWillUnmount
-         */
-        componentWillUnmount: function() {
-            this.props.editor.get('nativeEditor').setKeystroke(this.props.keystroke.keys, this._defaultKeystrokeCommand);
-        }
-    };
+		/**
+		 * Lifecycle. Invoked immediately before a component is unmounted from the DOM.
+		 *
+		 * @instance
+		 * @memberof ButtonKeystroke
+		 * @method componentWillUnmount
+		 */
+		componentWillUnmount() {
+			this.props.editor
+				.get('nativeEditor')
+				.setKeystroke(
+					this.props.keystroke.keys,
+					this._defaultKeystrokeCommand
+				);
+		},
+	};
 
-    AlloyEditor.ButtonKeystroke = ButtonKeystroke;
-}());
+	AlloyEditor.ButtonKeystroke = ButtonKeystroke;
+})();

--- a/src/components/compat/button-keystroke.js
+++ b/src/components/compat/button-keystroke.js
@@ -1,3 +1,5 @@
+import PropTypes from 'prop-types';
+
 (function() {
 	'use strict';
 

--- a/src/components/compat/button-keystroke.js
+++ b/src/components/compat/button-keystroke.js
@@ -1,85 +1,83 @@
 import PropTypes from 'prop-types';
 
-(function() {
-	'use strict';
+import Lang from '../../oop/lang';
+
+/**
+ * ButtonKeystroke is a mixin that provides a `keystroke` prop that allows configuring
+ * a function of the instance to be invoked upon the keystroke activation.
+ *
+ * @class ButtonKeystroke
+ */
+const ButtonKeystroke = {
+	// Allows validating props being passed to the component.
+	propTypes: {
+		/**
+		 * The keystroke definition. An object with the following properties:
+		 * - fn: The function to be executed
+		 * - keys: The keystroke definition, as expected by http://docs.ckeditor.com/#!/api/CKEDITOR.editor-method-setKeystroke
+		 * - name: The name for the CKEditor command that will be created. If empty,
+		 * a random name will be created on the fly
+		 *
+		 * @instance
+		 * @memberof ButtonKeystroke
+		 * @property {Object} keystroke
+		 */
+		keystroke: PropTypes.object.isRequired,
+	},
 
 	/**
-	 * ButtonKeystroke is a mixin that provides a `keystroke` prop that allows configuring
-	 * a function of the instance to be invoked upon the keystroke activation.
+	 * Lifecycle. Invoked once, both on the client and server, immediately before the initial rendering occurs.
 	 *
-	 * @class ButtonKeystroke
+	 * @instance
+	 * @memberof ButtonKeystroke
+	 * @method componentWillMount
 	 */
-	var ButtonKeystroke = {
-		// Allows validating props being passed to the component.
-		propTypes: {
-			/**
-			 * The keystroke definition. An object with the following properties:
-			 * - fn: The function to be executed
-			 * - keys: The keystroke definition, as expected by http://docs.ckeditor.com/#!/api/CKEDITOR.editor-method-setKeystroke
-			 * - name: The name for the CKEditor command that will be created. If empty,
-			 * a random name will be created on the fly
-			 *
-			 * @instance
-			 * @memberof ButtonKeystroke
-			 * @property {Object} keystroke
-			 */
-			keystroke: PropTypes.object.isRequired,
-		},
+	componentWillMount() {
+		const nativeEditor = this.props.editor.get('nativeEditor');
+		const keystroke = this.props.keystroke;
 
-		/**
-		 * Lifecycle. Invoked once, both on the client and server, immediately before the initial rendering occurs.
-		 *
-		 * @instance
-		 * @memberof ButtonKeystroke
-		 * @method componentWillMount
-		 */
-		componentWillMount() {
-			var nativeEditor = this.props.editor.get('nativeEditor');
-			var keystroke = this.props.keystroke;
+		const commandName =
+			keystroke.name || ((Math.random() * 1e9) >>> 0).toString();
 
-			var commandName =
-				keystroke.name || ((Math.random() * 1e9) >>> 0).toString();
+		let command = nativeEditor.getCommand(commandName);
 
-			var command = nativeEditor.getCommand(commandName);
+		if (!command) {
+			command = new CKEDITOR.command(nativeEditor, {
+				exec: function(editor) {
+					const keystrokeFn = keystroke.fn;
 
-			if (!command) {
-				command = new CKEDITOR.command(nativeEditor, {
-					exec: function(editor) {
-						var keystrokeFn = keystroke.fn;
+					if (Lang.isString(keystrokeFn)) {
+						this[keystrokeFn].call(this, editor);
+					} else if (Lang.isFunction(keystrokeFn)) {
+						keystrokeFn.call(this, editor);
+					}
+				}.bind(this),
+			});
 
-						if (AlloyEditor.Lang.isString(keystrokeFn)) {
-							this[keystrokeFn].call(this, editor);
-						} else if (AlloyEditor.Lang.isFunction(keystrokeFn)) {
-							keystrokeFn.call(this, editor);
-						}
-					}.bind(this),
-				});
+			nativeEditor.addCommand(commandName, command);
+		}
 
-				nativeEditor.addCommand(commandName, command);
-			}
+		this._defaultKeystrokeCommand =
+			nativeEditor.keystrokeHandler.keystrokes[keystroke.keys];
 
-			this._defaultKeystrokeCommand =
-				nativeEditor.keystrokeHandler.keystrokes[keystroke.keys];
+		nativeEditor.setKeystroke(keystroke.keys, commandName);
+	},
 
-			nativeEditor.setKeystroke(keystroke.keys, commandName);
-		},
+	/**
+	 * Lifecycle. Invoked immediately before a component is unmounted from the DOM.
+	 *
+	 * @instance
+	 * @memberof ButtonKeystroke
+	 * @method componentWillUnmount
+	 */
+	componentWillUnmount() {
+		this.props.editor
+			.get('nativeEditor')
+			.setKeystroke(
+				this.props.keystroke.keys,
+				this._defaultKeystrokeCommand
+			);
+	},
+};
 
-		/**
-		 * Lifecycle. Invoked immediately before a component is unmounted from the DOM.
-		 *
-		 * @instance
-		 * @memberof ButtonKeystroke
-		 * @method componentWillUnmount
-		 */
-		componentWillUnmount() {
-			this.props.editor
-				.get('nativeEditor')
-				.setKeystroke(
-					this.props.keystroke.keys,
-					this._defaultKeystrokeCommand
-				);
-		},
-	};
-
-	AlloyEditor.ButtonKeystroke = ButtonKeystroke;
-})();
+export default ButtonKeystroke;

--- a/src/components/compat/button-props.js
+++ b/src/components/compat/button-props.js
@@ -1,0 +1,46 @@
+(function() {
+    'use strict';
+
+    /**
+     * ButtonCfgProps is a mixin that provides a style prop and some methods to apply the resulting
+     * style and checking if it is present in a given path or selection.
+     *
+     * @class ButtonCfgProps
+     */
+    var ButtonCfgProps = {
+        // Allows validating props being passed to the component.
+        propTypes: {
+            /**
+             * The editor instance where the component is being used.
+             *
+             * @instance
+             * @memberof ButtonCfgProps
+             * @property {Object} editor
+             */
+            editor: PropTypes.object.isRequired
+        },
+
+        /**
+         * Merges the properties, passed to the current component with user's configuration
+         * via `buttonCfg` property.
+         *
+         * @instance
+         * @memberof ButtonCfgProps
+         * @method mergeButtonCfgProps
+         * @param {Object} props The properties to be merged with the provided configuration for this
+         * button. If not passed, the user configuration will be merged with `this.props`
+         * @return {Object} The merged properties
+         */
+        mergeButtonCfgProps: function(props) {
+            props = props || this.props;
+
+            var nativeEditor = this.props.editor.get('nativeEditor');
+            var buttonCfg = nativeEditor.config.buttonCfg || {};
+            var result = CKEDITOR.tools.merge(props, buttonCfg[AlloyEditor.ButtonLinkEdit.key]);
+
+            return result;
+        }
+    };
+
+    AlloyEditor.ButtonCfgProps = ButtonCfgProps;
+}());

--- a/src/components/compat/button-props.js
+++ b/src/components/compat/button-props.js
@@ -1,3 +1,5 @@
+import PropTypes from 'prop-types';
+
 (function() {
 	'use strict';
 

--- a/src/components/compat/button-props.js
+++ b/src/components/compat/button-props.js
@@ -1,46 +1,49 @@
 (function() {
-    'use strict';
+	'use strict';
 
-    /**
-     * ButtonCfgProps is a mixin that provides a style prop and some methods to apply the resulting
-     * style and checking if it is present in a given path or selection.
-     *
-     * @class ButtonCfgProps
-     */
-    var ButtonCfgProps = {
-        // Allows validating props being passed to the component.
-        propTypes: {
-            /**
-             * The editor instance where the component is being used.
-             *
-             * @instance
-             * @memberof ButtonCfgProps
-             * @property {Object} editor
-             */
-            editor: PropTypes.object.isRequired
-        },
+	/**
+	 * ButtonCfgProps is a mixin that provides a style prop and some methods to apply the resulting
+	 * style and checking if it is present in a given path or selection.
+	 *
+	 * @class ButtonCfgProps
+	 */
+	var ButtonCfgProps = {
+		// Allows validating props being passed to the component.
+		propTypes: {
+			/**
+			 * The editor instance where the component is being used.
+			 *
+			 * @instance
+			 * @memberof ButtonCfgProps
+			 * @property {Object} editor
+			 */
+			editor: PropTypes.object.isRequired,
+		},
 
-        /**
-         * Merges the properties, passed to the current component with user's configuration
-         * via `buttonCfg` property.
-         *
-         * @instance
-         * @memberof ButtonCfgProps
-         * @method mergeButtonCfgProps
-         * @param {Object} props The properties to be merged with the provided configuration for this
-         * button. If not passed, the user configuration will be merged with `this.props`
-         * @return {Object} The merged properties
-         */
-        mergeButtonCfgProps: function(props) {
-            props = props || this.props;
+		/**
+		 * Merges the properties, passed to the current component with user's configuration
+		 * via `buttonCfg` property.
+		 *
+		 * @instance
+		 * @memberof ButtonCfgProps
+		 * @method mergeButtonCfgProps
+		 * @param {Object} props The properties to be merged with the provided configuration for this
+		 * button. If not passed, the user configuration will be merged with `this.props`
+		 * @return {Object} The merged properties
+		 */
+		mergeButtonCfgProps(props) {
+			props = props || this.props;
 
-            var nativeEditor = this.props.editor.get('nativeEditor');
-            var buttonCfg = nativeEditor.config.buttonCfg || {};
-            var result = CKEDITOR.tools.merge(props, buttonCfg[AlloyEditor.ButtonLinkEdit.key]);
+			var nativeEditor = this.props.editor.get('nativeEditor');
+			var buttonCfg = nativeEditor.config.buttonCfg || {};
+			var result = CKEDITOR.tools.merge(
+				props,
+				buttonCfg[AlloyEditor.ButtonLinkEdit.key]
+			);
 
-            return result;
-        }
-    };
+			return result;
+		},
+	};
 
-    AlloyEditor.ButtonCfgProps = ButtonCfgProps;
-}());
+	AlloyEditor.ButtonCfgProps = ButtonCfgProps;
+})();

--- a/src/components/compat/button-props.js
+++ b/src/components/compat/button-props.js
@@ -1,51 +1,49 @@
 import PropTypes from 'prop-types';
 
-(function() {
-	'use strict';
+import ButtonLinkEdit from '../buttons/button-link-edit.jsx';
 
-	/**
-	 * ButtonCfgProps is a mixin that provides a style prop and some methods to apply the resulting
-	 * style and checking if it is present in a given path or selection.
-	 *
-	 * @class ButtonCfgProps
-	 */
-	var ButtonCfgProps = {
-		// Allows validating props being passed to the component.
-		propTypes: {
-			/**
-			 * The editor instance where the component is being used.
-			 *
-			 * @instance
-			 * @memberof ButtonCfgProps
-			 * @property {Object} editor
-			 */
-			editor: PropTypes.object.isRequired,
-		},
-
+/**
+ * ButtonProps is a mixin that provides a style prop and some methods to apply the resulting
+ * style and checking if it is present in a given path or selection.
+ *
+ * @class ButtonProps
+ */
+const ButtonProps = {
+	// Allows validating props being passed to the component.
+	propTypes: {
 		/**
-		 * Merges the properties, passed to the current component with user's configuration
-		 * via `buttonCfg` property.
+		 * The editor instance where the component is being used.
 		 *
 		 * @instance
-		 * @memberof ButtonCfgProps
-		 * @method mergeButtonCfgProps
-		 * @param {Object} props The properties to be merged with the provided configuration for this
-		 * button. If not passed, the user configuration will be merged with `this.props`
-		 * @return {Object} The merged properties
+		 * @memberof ButtonProps
+		 * @property {Object} editor
 		 */
-		mergeButtonCfgProps(props) {
-			props = props || this.props;
+		editor: PropTypes.object.isRequired,
+	},
 
-			var nativeEditor = this.props.editor.get('nativeEditor');
-			var buttonCfg = nativeEditor.config.buttonCfg || {};
-			var result = CKEDITOR.tools.merge(
-				props,
-				buttonCfg[AlloyEditor.ButtonLinkEdit.key]
-			);
+	/**
+	 * Merges the properties, passed to the current component with user's configuration
+	 * via `buttonCfg` property.
+	 *
+	 * @instance
+	 * @memberof ButtonProps
+	 * @method mergeButtonCfgProps
+	 * @param {Object} props The properties to be merged with the provided configuration for this
+	 * button. If not passed, the user configuration will be merged with `this.props`
+	 * @return {Object} The merged properties
+	 */
+	mergeButtonCfgProps(props) {
+		props = props || this.props;
 
-			return result;
-		},
-	};
+		const nativeEditor = this.props.editor.get('nativeEditor');
+		const buttonCfg = nativeEditor.config.buttonCfg || {};
+		const result = CKEDITOR.tools.merge(
+			props,
+			buttonCfg[ButtonLinkEdit.key]
+		);
 
-	AlloyEditor.ButtonCfgProps = ButtonCfgProps;
-})();
+		return result;
+	},
+};
+
+export default ButtonProps;

--- a/src/components/compat/button-state-classes.js
+++ b/src/components/compat/button-state-classes.js
@@ -1,0 +1,42 @@
+(function() {
+    'use strict';
+
+    /**
+     * ButtonStateClasses is a mixin that decorates the domElement of a component
+     * with different CSS classes based on the current state of the element.
+     *
+     * To check for state, the component can expose the following methods:
+     * - `Function` **isActive** to check the active state
+     * - `Function` **isDisabled** to check the disabled state
+     *
+     * @class ButtonStateClasses
+     */
+    var ButtonStateClasses = {
+        /**
+         * Returns the list of state classes associated to the current element's state, according
+         * to the results of the isActive and isDisabled methods.
+         *
+         * @instance
+         * @memberof ButtonStateClasses
+         * @method getStateClasses
+         * @return {String} A string with the state CSS classes.
+         */
+        getStateClasses: function() {
+            var stateClasses = '';
+
+            // Check for active state
+            if (AlloyEditor.Lang.isFunction(this.isActive) && this.isActive()) {
+                stateClasses += 'ae-button-pressed';
+            }
+
+            // Check for disabled state
+            if (AlloyEditor.Lang.isFunction(this.isDisabled) && this.isDisabled()) {
+                stateClasses += ' ae-button-disabled';
+            }
+
+            return stateClasses;
+        }
+    };
+
+    AlloyEditor.ButtonStateClasses = ButtonStateClasses;
+}());

--- a/src/components/compat/button-state-classes.js
+++ b/src/components/compat/button-state-classes.js
@@ -1,42 +1,45 @@
 (function() {
-    'use strict';
+	'use strict';
 
-    /**
-     * ButtonStateClasses is a mixin that decorates the domElement of a component
-     * with different CSS classes based on the current state of the element.
-     *
-     * To check for state, the component can expose the following methods:
-     * - `Function` **isActive** to check the active state
-     * - `Function` **isDisabled** to check the disabled state
-     *
-     * @class ButtonStateClasses
-     */
-    var ButtonStateClasses = {
-        /**
-         * Returns the list of state classes associated to the current element's state, according
-         * to the results of the isActive and isDisabled methods.
-         *
-         * @instance
-         * @memberof ButtonStateClasses
-         * @method getStateClasses
-         * @return {String} A string with the state CSS classes.
-         */
-        getStateClasses: function() {
-            var stateClasses = '';
+	/**
+	 * ButtonStateClasses is a mixin that decorates the domElement of a component
+	 * with different CSS classes based on the current state of the element.
+	 *
+	 * To check for state, the component can expose the following methods:
+	 * - `Function` **isActive** to check the active state
+	 * - `Function` **isDisabled** to check the disabled state
+	 *
+	 * @class ButtonStateClasses
+	 */
+	var ButtonStateClasses = {
+		/**
+		 * Returns the list of state classes associated to the current element's state, according
+		 * to the results of the isActive and isDisabled methods.
+		 *
+		 * @instance
+		 * @memberof ButtonStateClasses
+		 * @method getStateClasses
+		 * @return {String} A string with the state CSS classes.
+		 */
+		getStateClasses() {
+			var stateClasses = '';
 
-            // Check for active state
-            if (AlloyEditor.Lang.isFunction(this.isActive) && this.isActive()) {
-                stateClasses += 'ae-button-pressed';
-            }
+			// Check for active state
+			if (AlloyEditor.Lang.isFunction(this.isActive) && this.isActive()) {
+				stateClasses += 'ae-button-pressed';
+			}
 
-            // Check for disabled state
-            if (AlloyEditor.Lang.isFunction(this.isDisabled) && this.isDisabled()) {
-                stateClasses += ' ae-button-disabled';
-            }
+			// Check for disabled state
+			if (
+				AlloyEditor.Lang.isFunction(this.isDisabled) &&
+				this.isDisabled()
+			) {
+				stateClasses += ' ae-button-disabled';
+			}
 
-            return stateClasses;
-        }
-    };
+			return stateClasses;
+		},
+	};
 
-    AlloyEditor.ButtonStateClasses = ButtonStateClasses;
-}());
+	AlloyEditor.ButtonStateClasses = ButtonStateClasses;
+})();

--- a/src/components/compat/button-state-classes.js
+++ b/src/components/compat/button-state-classes.js
@@ -1,45 +1,40 @@
-(function() {
-	'use strict';
+import Lang from '../../oop/lang';
 
+/**
+ * ButtonStateClasses is a mixin that decorates the domElement of a component
+ * with different CSS classes based on the current state of the element.
+ *
+ * To check for state, the component can expose the following methods:
+ * - `Function` **isActive** to check the active state
+ * - `Function` **isDisabled** to check the disabled state
+ *
+ * @class ButtonStateClasses
+ */
+const ButtonStateClasses = {
 	/**
-	 * ButtonStateClasses is a mixin that decorates the domElement of a component
-	 * with different CSS classes based on the current state of the element.
+	 * Returns the list of state classes associated to the current element's state, according
+	 * to the results of the isActive and isDisabled methods.
 	 *
-	 * To check for state, the component can expose the following methods:
-	 * - `Function` **isActive** to check the active state
-	 * - `Function` **isDisabled** to check the disabled state
-	 *
-	 * @class ButtonStateClasses
+	 * @instance
+	 * @memberof ButtonStateClasses
+	 * @method getStateClasses
+	 * @return {String} A string with the state CSS classes.
 	 */
-	var ButtonStateClasses = {
-		/**
-		 * Returns the list of state classes associated to the current element's state, according
-		 * to the results of the isActive and isDisabled methods.
-		 *
-		 * @instance
-		 * @memberof ButtonStateClasses
-		 * @method getStateClasses
-		 * @return {String} A string with the state CSS classes.
-		 */
-		getStateClasses() {
-			var stateClasses = '';
+	getStateClasses() {
+		let stateClasses = '';
 
-			// Check for active state
-			if (AlloyEditor.Lang.isFunction(this.isActive) && this.isActive()) {
-				stateClasses += 'ae-button-pressed';
-			}
+		// Check for active state
+		if (Lang.isFunction(this.isActive) && this.isActive()) {
+			stateClasses += 'ae-button-pressed';
+		}
 
-			// Check for disabled state
-			if (
-				AlloyEditor.Lang.isFunction(this.isDisabled) &&
-				this.isDisabled()
-			) {
-				stateClasses += ' ae-button-disabled';
-			}
+		// Check for disabled state
+		if (Lang.isFunction(this.isDisabled) && this.isDisabled()) {
+			stateClasses += ' ae-button-disabled';
+		}
 
-			return stateClasses;
-		},
-	};
+		return stateClasses;
+	},
+};
 
-	AlloyEditor.ButtonStateClasses = ButtonStateClasses;
-})();
+export default ButtonStateClasses;

--- a/src/components/compat/button-style.js
+++ b/src/components/compat/button-style.js
@@ -1,0 +1,114 @@
+(function() {
+    'use strict';
+
+    /**
+     * ButtonStyle is a mixin that provides a style prop and some methods to apply the resulting
+     * style and checking if it is present in a given path or selection.
+     *
+     * @class ButtonStyle
+     */
+    var ButtonStyle = {
+        // Allows validating props being passed to the component.
+        propTypes: {
+            /**
+             * The style the button should handle. Allowed values are:
+             * - Object as described by http://docs.ckeditor.com/#!/api/CKEDITOR.style.
+             * - String pointing to an object inside the editor instance configuration. For example, `style = 'coreStyles_bold'` will try to
+             * retrieve the style object from `editor.config.coreStyles_bold`. Nested properties such as `style = 'myplugin.myConfig.myStyle'`
+             * are also supported and will try to retrieve the style object from the editor configuration as well.
+             *
+             * @instance
+             * @memberof ButtonStyle
+             * @property {Object|String} style
+             */
+            style: PropTypes.oneOfType([
+                PropTypes.object,
+                PropTypes.string
+            ]),
+
+			/**
+			 * The style function the button should handle.
+             * If specified, style function has higher priority than style property.
+			 *
+			 * @instance
+			 * @memberof ButtonStyle
+			 * @property {function} styleFn
+			 */
+            styleFn: PropTypes.func
+        },
+
+        /**
+         * Lifecycle. Invoked once, both on the client and server, immediately before the initial rendering occurs.
+         *
+         * @instance
+         * @memberof ButtonStyle
+         * @method componentWillMount
+         */
+        componentWillMount: function() {
+            var Lang = AlloyEditor.Lang;
+            var style = this.props.style;
+
+            if (Lang.isString(style)) {
+                var parts = style.split('.');
+                var currentMember = this.props.editor.get('nativeEditor').config;
+                var property = parts.shift();
+
+                while (property && Lang.isObject(currentMember) && Lang.isObject(currentMember[property])) {
+                    currentMember = currentMember[property];
+                    property = parts.shift();
+                }
+
+                if (Lang.isObject(currentMember)) {
+                    style = currentMember;
+                }
+            }
+
+            this._style = new CKEDITOR.style(style);
+        },
+
+        /**
+         * Lifecycle. Invoked immediately before a component is unmounted from the DOM.
+         *
+         * @instance
+         * @memberof ButtonStyle
+         * @method componentWillUnmount
+         */
+        componentWillUnmount: function() {
+            this._style = null;
+        },
+
+        /**
+         * Returns instance of CKEDITOR.style which represents the current button style.
+         *
+         * @instance
+         * @memberof ButtonStyle
+         * @method getStyle
+         * @return {CKEDITOR.style} The current style representation.
+         */
+        getStyle: function() {
+            return this._style;
+        },
+
+        /**
+         * Checks if style is active in the current selection.
+         *
+         * @instance
+         * @memberof ButtonStyle
+         * @method isActive
+         * @return {Boolean} True if style is active, false otherwise.
+         */
+        isActive: function() {
+            var result;
+
+            var editor = this.props.editor.get('nativeEditor');
+
+            var elementPath = editor.elementPath();
+
+            result = this.getStyle().checkActive(elementPath, editor);
+
+            return result;
+        }
+    };
+
+    AlloyEditor.ButtonStyle = ButtonStyle;
+}());

--- a/src/components/compat/button-style.js
+++ b/src/components/compat/button-style.js
@@ -1,114 +1,116 @@
 (function() {
-    'use strict';
+	'use strict';
 
-    /**
-     * ButtonStyle is a mixin that provides a style prop and some methods to apply the resulting
-     * style and checking if it is present in a given path or selection.
-     *
-     * @class ButtonStyle
-     */
-    var ButtonStyle = {
-        // Allows validating props being passed to the component.
-        propTypes: {
-            /**
-             * The style the button should handle. Allowed values are:
-             * - Object as described by http://docs.ckeditor.com/#!/api/CKEDITOR.style.
-             * - String pointing to an object inside the editor instance configuration. For example, `style = 'coreStyles_bold'` will try to
-             * retrieve the style object from `editor.config.coreStyles_bold`. Nested properties such as `style = 'myplugin.myConfig.myStyle'`
-             * are also supported and will try to retrieve the style object from the editor configuration as well.
-             *
-             * @instance
-             * @memberof ButtonStyle
-             * @property {Object|String} style
-             */
-            style: PropTypes.oneOfType([
-                PropTypes.object,
-                PropTypes.string
-            ]),
+	/**
+	 * ButtonStyle is a mixin that provides a style prop and some methods to apply the resulting
+	 * style and checking if it is present in a given path or selection.
+	 *
+	 * @class ButtonStyle
+	 */
+	var ButtonStyle = {
+		// Allows validating props being passed to the component.
+		propTypes: {
+			/**
+			 * The style the button should handle. Allowed values are:
+			 * - Object as described by http://docs.ckeditor.com/#!/api/CKEDITOR.style.
+			 * - String pointing to an object inside the editor instance configuration. For example, `style = 'coreStyles_bold'` will try to
+			 * retrieve the style object from `editor.config.coreStyles_bold`. Nested properties such as `style = 'myplugin.myConfig.myStyle'`
+			 * are also supported and will try to retrieve the style object from the editor configuration as well.
+			 *
+			 * @instance
+			 * @memberof ButtonStyle
+			 * @property {Object|String} style
+			 */
+			style: PropTypes.oneOfType([PropTypes.object, PropTypes.string]),
 
 			/**
 			 * The style function the button should handle.
-             * If specified, style function has higher priority than style property.
+			 * If specified, style function has higher priority than style property.
 			 *
 			 * @instance
 			 * @memberof ButtonStyle
 			 * @property {function} styleFn
 			 */
-            styleFn: PropTypes.func
-        },
+			styleFn: PropTypes.func,
+		},
 
-        /**
-         * Lifecycle. Invoked once, both on the client and server, immediately before the initial rendering occurs.
-         *
-         * @instance
-         * @memberof ButtonStyle
-         * @method componentWillMount
-         */
-        componentWillMount: function() {
-            var Lang = AlloyEditor.Lang;
-            var style = this.props.style;
+		/**
+		 * Lifecycle. Invoked once, both on the client and server, immediately before the initial rendering occurs.
+		 *
+		 * @instance
+		 * @memberof ButtonStyle
+		 * @method componentWillMount
+		 */
+		componentWillMount() {
+			var Lang = AlloyEditor.Lang;
+			var style = this.props.style;
 
-            if (Lang.isString(style)) {
-                var parts = style.split('.');
-                var currentMember = this.props.editor.get('nativeEditor').config;
-                var property = parts.shift();
+			if (Lang.isString(style)) {
+				var parts = style.split('.');
+				var currentMember = this.props.editor.get('nativeEditor')
+					.config;
+				var property = parts.shift();
 
-                while (property && Lang.isObject(currentMember) && Lang.isObject(currentMember[property])) {
-                    currentMember = currentMember[property];
-                    property = parts.shift();
-                }
+				while (
+					property &&
+					Lang.isObject(currentMember) &&
+					Lang.isObject(currentMember[property])
+				) {
+					currentMember = currentMember[property];
+					property = parts.shift();
+				}
 
-                if (Lang.isObject(currentMember)) {
-                    style = currentMember;
-                }
-            }
+				if (Lang.isObject(currentMember)) {
+					style = currentMember;
+				}
+			}
 
-            this._style = new CKEDITOR.style(style);
-        },
+			this._style = new CKEDITOR.style(style);
+		},
 
-        /**
-         * Lifecycle. Invoked immediately before a component is unmounted from the DOM.
-         *
-         * @instance
-         * @memberof ButtonStyle
-         * @method componentWillUnmount
-         */
-        componentWillUnmount: function() {
-            this._style = null;
-        },
+		/**
+		 * Lifecycle. Invoked immediately before a component is unmounted from the DOM.
+		 *
+		 * @instance
+		 * @memberof ButtonStyle
+		 * @method componentWillUnmount
+		 */
+		componentWillUnmount() {
+			this._style = null;
+		},
 
-        /**
-         * Returns instance of CKEDITOR.style which represents the current button style.
-         *
-         * @instance
-         * @memberof ButtonStyle
-         * @method getStyle
-         * @return {CKEDITOR.style} The current style representation.
-         */
-        getStyle: function() {
-            return this._style;
-        },
+		/**
+		 * Returns instance of CKEDITOR.style which represents the current button style.
+		 *
+		 * @instance
+		 * @memberof ButtonStyle
+		 * @method getStyle
+		 * @return {CKEDITOR.style} The current style representation.
+		 */
+		getStyle() {
+			return this._style;
+		},
 
-        /**
-         * Checks if style is active in the current selection.
-         *
-         * @instance
-         * @memberof ButtonStyle
-         * @method isActive
-         * @return {Boolean} True if style is active, false otherwise.
-         */
-        isActive: function() {
-            var result;
+		/**
+		 * Checks if style is active in the current selection.
+		 *
+		 * @instance
+		 * @memberof ButtonStyle
+		 * @method isActive
+		 * @return {Boolean} True if style is active, false otherwise.
+		 */
+		isActive() {
+			var result;
 
-            var editor = this.props.editor.get('nativeEditor');
+			var editor = this.props.editor.get('nativeEditor');
 
-            var elementPath = editor.elementPath();
+			var elementPath = editor.elementPath();
 
-            result = this.getStyle().checkActive(elementPath, editor);
+			result = this.getStyle().checkActive(elementPath, editor);
 
-            return result;
-        }
-    };
+			return result;
+		},
+	};
 
-    AlloyEditor.ButtonStyle = ButtonStyle;
-}());
+	AlloyEditor.ButtonStyle = ButtonStyle;
+})();

--- a/src/components/compat/button-style.js
+++ b/src/components/compat/button-style.js
@@ -1,3 +1,5 @@
+import PropTypes from 'prop-types';
+
 (function() {
 	'use strict';
 

--- a/src/components/compat/button-style.js
+++ b/src/components/compat/button-style.js
@@ -1,118 +1,119 @@
 import PropTypes from 'prop-types';
 
-(function() {
-	'use strict';
+import Lang from '../../oop/lang';
+
+/**
+ * ButtonStyle is a mixin that provides a style prop and some methods to
+ * apply the resulting style and checking if it is present in a given
+ * path or selection.
+ *
+ * @class ButtonStyle
+ */
+const ButtonStyle = {
+	// Allows validating props being passed to the component.
+	propTypes: {
+		/**
+		 * The style the button should handle. Allowed values are:
+		 * - Object as described by
+		 *   http://docs.ckeditor.com/#!/api/CKEDITOR.style.
+		 * - String pointing to an object inside the editor instance
+		 *   configuration. For example, `style = 'coreStyles_bold'` will
+		 *   try to retrieve the style object from
+		 *   `editor.config.coreStyles_bold`. Nested properties such as
+		 *   `style = 'myplugin.myConfig.myStyle'` are also supported
+		 *   and will try to retrieve the style object from the editor
+		 *   configuration as well.
+		 *
+		 * @instance
+		 * @memberof ButtonStyle
+		 * @property {Object|String} style
+		 */
+		style: PropTypes.oneOfType([PropTypes.object, PropTypes.string]),
+
+		/**
+		 * The style function the button should handle.
+		 * If specified, style function has higher priority than style property.
+		 *
+		 * @instance
+		 * @memberof ButtonStyle
+		 * @property {function} styleFn
+		 */
+		styleFn: PropTypes.func,
+	},
 
 	/**
-	 * ButtonStyle is a mixin that provides a style prop and some methods to apply the resulting
-	 * style and checking if it is present in a given path or selection.
+	 * Lifecycle. Invoked once, both on the client and server,
+	 * immediately before the initial rendering occurs.
 	 *
-	 * @class ButtonStyle
+	 * @instance
+	 * @memberof ButtonStyle
+	 * @method componentWillMount
 	 */
-	var ButtonStyle = {
-		// Allows validating props being passed to the component.
-		propTypes: {
-			/**
-			 * The style the button should handle. Allowed values are:
-			 * - Object as described by http://docs.ckeditor.com/#!/api/CKEDITOR.style.
-			 * - String pointing to an object inside the editor instance configuration. For example, `style = 'coreStyles_bold'` will try to
-			 * retrieve the style object from `editor.config.coreStyles_bold`. Nested properties such as `style = 'myplugin.myConfig.myStyle'`
-			 * are also supported and will try to retrieve the style object from the editor configuration as well.
-			 *
-			 * @instance
-			 * @memberof ButtonStyle
-			 * @property {Object|String} style
-			 */
-			style: PropTypes.oneOfType([PropTypes.object, PropTypes.string]),
+	componentWillMount() {
+		let style = this.props.style;
 
-			/**
-			 * The style function the button should handle.
-			 * If specified, style function has higher priority than style property.
-			 *
-			 * @instance
-			 * @memberof ButtonStyle
-			 * @property {function} styleFn
-			 */
-			styleFn: PropTypes.func,
-		},
+		if (Lang.isString(style)) {
+			const parts = style.split('.');
+			let currentMember = this.props.editor.get('nativeEditor').config;
+			let property = parts.shift();
 
-		/**
-		 * Lifecycle. Invoked once, both on the client and server, immediately before the initial rendering occurs.
-		 *
-		 * @instance
-		 * @memberof ButtonStyle
-		 * @method componentWillMount
-		 */
-		componentWillMount() {
-			var Lang = AlloyEditor.Lang;
-			var style = this.props.style;
-
-			if (Lang.isString(style)) {
-				var parts = style.split('.');
-				var currentMember = this.props.editor.get('nativeEditor')
-					.config;
-				var property = parts.shift();
-
-				while (
-					property &&
-					Lang.isObject(currentMember) &&
-					Lang.isObject(currentMember[property])
-				) {
-					currentMember = currentMember[property];
-					property = parts.shift();
-				}
-
-				if (Lang.isObject(currentMember)) {
-					style = currentMember;
-				}
+			while (
+				property &&
+				Lang.isObject(currentMember) &&
+				Lang.isObject(currentMember[property])
+			) {
+				currentMember = currentMember[property];
+				property = parts.shift();
 			}
 
-			this._style = new CKEDITOR.style(style);
-		},
+			if (Lang.isObject(currentMember)) {
+				style = currentMember;
+			}
+		}
 
-		/**
-		 * Lifecycle. Invoked immediately before a component is unmounted from the DOM.
-		 *
-		 * @instance
-		 * @memberof ButtonStyle
-		 * @method componentWillUnmount
-		 */
-		componentWillUnmount() {
-			this._style = null;
-		},
+		this._style = new CKEDITOR.style(style);
+	},
 
-		/**
-		 * Returns instance of CKEDITOR.style which represents the current button style.
-		 *
-		 * @instance
-		 * @memberof ButtonStyle
-		 * @method getStyle
-		 * @return {CKEDITOR.style} The current style representation.
-		 */
-		getStyle() {
-			return this._style;
-		},
+	/**
+	 * Lifecycle. Invoked immediately before a component is unmounted
+	 * from the DOM.
+	 *
+	 * @instance
+	 * @memberof ButtonStyle
+	 * @method componentWillUnmount
+	 */
+	componentWillUnmount() {
+		this._style = null;
+	},
 
-		/**
-		 * Checks if style is active in the current selection.
-		 *
-		 * @instance
-		 * @memberof ButtonStyle
-		 * @method isActive
-		 * @return {Boolean} True if style is active, false otherwise.
-		 */
-		isActive() {
-			var result;
+	/**
+	 * Returns instance of CKEDITOR.style which represents the current
+	 * button style.
+	 *
+	 * @instance
+	 * @memberof ButtonStyle
+	 * @method getStyle
+	 * @return {CKEDITOR.style} The current style representation.
+	 */
+	getStyle() {
+		return this._style;
+	},
 
-			var editor = this.props.editor.get('nativeEditor');
+	/**
+	 * Checks if style is active in the current selection.
+	 *
+	 * @instance
+	 * @memberof ButtonStyle
+	 * @method isActive
+	 * @return {Boolean} True if style is active, false otherwise.
+	 */
+	isActive() {
+		const editor = this.props.editor.get('nativeEditor');
 
-			var elementPath = editor.elementPath();
+		const elementPath = editor.elementPath();
 
-			result = this.getStyle().checkActive(elementPath, editor);
+		return this.getStyle().checkActive(elementPath, editor);
+	},
+};
 
-			return result;
-		},
-	};
-
-	AlloyEditor.ButtonStyle = ButtonStyle;
-})();
+export default ButtonStyle;

--- a/src/components/compat/index.js
+++ b/src/components/compat/index.js
@@ -1,0 +1,14 @@
+export {default as ButtonActionStyle} from './button-action-style';
+export {default as ButtonCommandActive} from './button-command-active';
+export {default as ButtonCommand} from './button-command';
+export {default as ButtonKeystroke} from './button-keystroke';
+export {default as ButtonProps} from './button-props';
+export {default as ButtonStateClasses} from './button-state-classes';
+export {default as ButtonStyle} from './button-style';
+export {default as ToolbarButtons} from './toolbar-buttons';
+export {default as WidgetArrowBox} from './widget-arrow-box';
+export {default as WidgetDropdown} from './widget-dropdown';
+export {default as WidgetExclusive} from './widget-exclusive';
+export {default as WidgetFocusManager} from './widget-focus-manager';
+export {default as WidgetInteractionPoint} from './widget-interaction-point';
+export {default as WidgetPosition} from './widget-position';

--- a/src/components/compat/toolbar-buttons.js
+++ b/src/components/compat/toolbar-buttons.js
@@ -1,0 +1,100 @@
+(function() {
+    'use strict';
+
+    /**
+     * ToolbarButtons is a mixin which provides a list of buttons which have to be
+     * displayed on the current toolbar depending on user preferences and given state.
+     *
+     * @class ToolbarButtons
+     */
+    var ToolbarButtons = {
+        /**
+         * Analayses the current selection and returns the buttons or button groups to be rendered.
+         *
+         * @instance
+         * @method getToolbarButtonGroups
+         * @param {Array} buttons The buttons could be shown, prior to the state filtering.
+         * @param {Object} additionalProps Additional props that should be passed down to the buttons.
+         * @return {Array} An Array which contains the buttons or button groups that should be rendered.
+         */
+        getToolbarButtonGroups: function(buttons, additionalProps) {
+            var instance = this;
+
+            if (AlloyEditor.Lang.isFunction(buttons)) {
+                buttons = buttons.call(this) || [];
+            }
+
+
+            return buttons.reduce(function(list, button) {
+                if (Array.isArray(button)) {
+                    list.push(instance.getToolbarButtons(button, additionalProps));
+                    return list;
+                } else {
+                    return instance.getToolbarButtons(buttons, additionalProps);
+                }
+            }, []);
+        },
+
+        /**
+         * Analyzes the current selection and the buttons exclusive mode value to figure out which
+         * buttons should be present in a given state.
+         *
+         * @instance
+         * @memberof ToolbarButtons
+         * @method getToolbarButtons
+         * @param {Array} buttons The buttons could be shown, prior to the state filtering.
+         * @param {Object} additionalProps Additional props that should be passed down to the buttons.
+         * @return {Array} An Array which contains the buttons that should be rendered.
+         */
+        getToolbarButtons: function(buttons, additionalProps) {
+            var buttonProps = {};
+
+            var nativeEditor = this.props.editor.get('nativeEditor');
+            var buttonCfg = nativeEditor.config.buttonCfg || {};
+
+            if (AlloyEditor.Lang.isFunction(buttons)) {
+                buttons = buttons.call(this) || [];
+            }
+
+            var toolbarButtons = this.filterExclusive(
+                    buttons.filter(function(button) {
+                        return button && (AlloyEditor.Buttons[button] || AlloyEditor.Buttons[button.name]);
+                    })
+                    .map(function(button) {
+                        if (AlloyEditor.Lang.isString(button)) {
+                            buttonProps[button]= buttonCfg[button];
+                            button = AlloyEditor.Buttons[button];
+                        } else if (AlloyEditor.Lang.isString(button.name)) {
+                            buttonProps[AlloyEditor.Buttons[button.name].key] = CKEDITOR.tools.merge(buttonCfg[button], button.cfg);
+                            button = AlloyEditor.Buttons[button.name];
+                        }
+
+                        return button;
+                    })
+                )
+                .map(function(button, index) {
+                    var props = this.mergeExclusiveProps({
+                        editor: this.props.editor,
+                        key: button.key !== 'separator' ? button.key : `${button.key}-${index}`,
+                        tabKey: button.key,
+                        tabIndex: (this.props.trigger && this.props.trigger.props.tabKey === button.key) ? 0 : -1,
+                        trigger: this.props.trigger
+                    }, button.key);
+
+                    props = this.mergeDropdownProps(props, button.key);
+
+                    if (additionalProps) {
+                        props = CKEDITOR.tools.merge(props, additionalProps);
+                    }
+
+                    props = CKEDITOR.tools.merge(props, buttonProps[button.key]);
+
+                    return React.createElement(button, props);
+                }, this);
+
+            return toolbarButtons;
+        }
+    };
+
+    AlloyEditor.ToolbarButtons = ToolbarButtons;
+}());

--- a/src/components/compat/toolbar-buttons.js
+++ b/src/components/compat/toolbar-buttons.js
@@ -1,122 +1,117 @@
 import React from 'react';
 
-(function() {
-	'use strict';
+import Lang from '../../oop/lang';
+
+/**
+ * ToolbarButtons is a mixin which provides a list of buttons which have
+ * to be displayed on the current toolbar depending on user preferences
+ * and given state.
+ *
+ * @class ToolbarButtons
+ */
+const ToolbarButtons = {
+	/**
+	 * Analyses the current selection and returns the buttons or button
+	 * groups to be rendered.
+	 *
+	 * @instance
+	 * @method getToolbarButtonGroups
+	 * @param {Array} buttons The buttons could be shown, prior to the state filtering.
+	 * @param {Object} additionalProps Additional props that should be passed down to the buttons.
+	 * @return {Array} An Array which contains the buttons or button groups that should be rendered.
+	 */
+	getToolbarButtonGroups(buttons, additionalProps) {
+		const instance = this;
+
+		if (Lang.isFunction(buttons)) {
+			buttons = buttons.call(this) || [];
+		}
+
+		return buttons.reduce((list, button) => {
+			if (Array.isArray(button)) {
+				list.push(instance.getToolbarButtons(button, additionalProps));
+				return list;
+			} else {
+				return instance.getToolbarButtons(buttons, additionalProps);
+			}
+		}, []);
+	},
 
 	/**
-	 * ToolbarButtons is a mixin which provides a list of buttons which have to be
-	 * displayed on the current toolbar depending on user preferences and given state.
+	 * Analyzes the current selection and the buttons exclusive mode value to figure out which
+	 * buttons should be present in a given state.
 	 *
-	 * @class ToolbarButtons
+	 * @instance
+	 * @memberof ToolbarButtons
+	 * @method getToolbarButtons
+	 * @param {Array} buttons The buttons could be shown, prior to the state filtering.
+	 * @param {Object} additionalProps Additional props that should be passed down to the buttons.
+	 * @return {Array} An Array which contains the buttons that should be rendered.
 	 */
-	var ToolbarButtons = {
-		/**
-		 * Analayses the current selection and returns the buttons or button groups to be rendered.
-		 *
-		 * @instance
-		 * @method getToolbarButtonGroups
-		 * @param {Array} buttons The buttons could be shown, prior to the state filtering.
-		 * @param {Object} additionalProps Additional props that should be passed down to the buttons.
-		 * @return {Array} An Array which contains the buttons or button groups that should be rendered.
-		 */
-		getToolbarButtonGroups(buttons, additionalProps) {
-			var instance = this;
+	getToolbarButtons(buttons, additionalProps) {
+		const buttonProps = {};
 
-			if (AlloyEditor.Lang.isFunction(buttons)) {
-				buttons = buttons.call(this) || [];
-			}
+		const nativeEditor = this.props.editor.get('nativeEditor');
+		const buttonCfg = nativeEditor.config.buttonCfg || {};
 
-			return buttons.reduce((list, button) => {
-				if (Array.isArray(button)) {
-					list.push(
-						instance.getToolbarButtons(button, additionalProps)
+		if (Lang.isFunction(buttons)) {
+			buttons = buttons.call(this) || [];
+		}
+
+		const toolbarButtons = this.filterExclusive(
+			buttons
+				.filter(button => {
+					return (
+						button &&
+						(AlloyEditor.Buttons[button] ||
+							AlloyEditor.Buttons[button.name])
 					);
-					return list;
-				} else {
-					return instance.getToolbarButtons(buttons, additionalProps);
-				}
-			}, []);
-		},
+				})
+				.map(button => {
+					if (Lang.isString(button)) {
+						buttonProps[button] = buttonCfg[button];
+						button = AlloyEditor.Buttons[button];
+					} else if (Lang.isString(button.name)) {
+						buttonProps[
+							AlloyEditor.Buttons[button.name].key
+						] = CKEDITOR.tools.merge(buttonCfg[button], button.cfg);
+						button = AlloyEditor.Buttons[button.name];
+					}
 
-		/**
-		 * Analyzes the current selection and the buttons exclusive mode value to figure out which
-		 * buttons should be present in a given state.
-		 *
-		 * @instance
-		 * @memberof ToolbarButtons
-		 * @method getToolbarButtons
-		 * @param {Array} buttons The buttons could be shown, prior to the state filtering.
-		 * @param {Object} additionalProps Additional props that should be passed down to the buttons.
-		 * @return {Array} An Array which contains the buttons that should be rendered.
-		 */
-		getToolbarButtons(buttons, additionalProps) {
-			var buttonProps = {};
+					return button;
+				})
+		).map(function(button, index) {
+			let props = this.mergeExclusiveProps(
+				{
+					editor: this.props.editor,
+					key:
+						button.key !== 'separator'
+							? button.key
+							: `${button.key}-${index}`,
+					tabKey: button.key,
+					tabIndex:
+						this.props.trigger &&
+						this.props.trigger.props.tabKey === button.key
+							? 0
+							: -1,
+					trigger: this.props.trigger,
+				},
+				button.key
+			);
 
-			var nativeEditor = this.props.editor.get('nativeEditor');
-			var buttonCfg = nativeEditor.config.buttonCfg || {};
+			props = this.mergeDropdownProps(props, button.key);
 
-			if (AlloyEditor.Lang.isFunction(buttons)) {
-				buttons = buttons.call(this) || [];
+			if (additionalProps) {
+				props = CKEDITOR.tools.merge(props, additionalProps);
 			}
 
-			var toolbarButtons = this.filterExclusive(
-				buttons
-					.filter(button => {
-						return (
-							button &&
-							(AlloyEditor.Buttons[button] ||
-								AlloyEditor.Buttons[button.name])
-						);
-					})
-					.map(button => {
-						if (AlloyEditor.Lang.isString(button)) {
-							buttonProps[button] = buttonCfg[button];
-							button = AlloyEditor.Buttons[button];
-						} else if (AlloyEditor.Lang.isString(button.name)) {
-							buttonProps[
-								AlloyEditor.Buttons[button.name].key
-							] = CKEDITOR.tools.merge(
-								buttonCfg[button],
-								button.cfg
-							);
-							button = AlloyEditor.Buttons[button.name];
-						}
+			props = CKEDITOR.tools.merge(props, buttonProps[button.key]);
 
-						return button;
-					})
-			).map(function(button, index) {
-				var props = this.mergeExclusiveProps(
-					{
-						editor: this.props.editor,
-						key:
-							button.key !== 'separator'
-								? button.key
-								: `${button.key}-${index}`,
-						tabKey: button.key,
-						tabIndex:
-							this.props.trigger &&
-							this.props.trigger.props.tabKey === button.key
-								? 0
-								: -1,
-						trigger: this.props.trigger,
-					},
-					button.key
-				);
+			return React.createElement(button, props);
+		}, this);
 
-				props = this.mergeDropdownProps(props, button.key);
+		return toolbarButtons;
+	},
+};
 
-				if (additionalProps) {
-					props = CKEDITOR.tools.merge(props, additionalProps);
-				}
-
-				props = CKEDITOR.tools.merge(props, buttonProps[button.key]);
-
-				return React.createElement(button, props);
-			}, this);
-
-			return toolbarButtons;
-		},
-	};
-
-	AlloyEditor.ToolbarButtons = ToolbarButtons;
-})();
+export default ToolbarButtons;

--- a/src/components/compat/toolbar-buttons.js
+++ b/src/components/compat/toolbar-buttons.js
@@ -1,100 +1,120 @@
 (function() {
-    'use strict';
+	'use strict';
 
-    /**
-     * ToolbarButtons is a mixin which provides a list of buttons which have to be
-     * displayed on the current toolbar depending on user preferences and given state.
-     *
-     * @class ToolbarButtons
-     */
-    var ToolbarButtons = {
-        /**
-         * Analayses the current selection and returns the buttons or button groups to be rendered.
-         *
-         * @instance
-         * @method getToolbarButtonGroups
-         * @param {Array} buttons The buttons could be shown, prior to the state filtering.
-         * @param {Object} additionalProps Additional props that should be passed down to the buttons.
-         * @return {Array} An Array which contains the buttons or button groups that should be rendered.
-         */
-        getToolbarButtonGroups: function(buttons, additionalProps) {
-            var instance = this;
+	/**
+	 * ToolbarButtons is a mixin which provides a list of buttons which have to be
+	 * displayed on the current toolbar depending on user preferences and given state.
+	 *
+	 * @class ToolbarButtons
+	 */
+	var ToolbarButtons = {
+		/**
+		 * Analayses the current selection and returns the buttons or button groups to be rendered.
+		 *
+		 * @instance
+		 * @method getToolbarButtonGroups
+		 * @param {Array} buttons The buttons could be shown, prior to the state filtering.
+		 * @param {Object} additionalProps Additional props that should be passed down to the buttons.
+		 * @return {Array} An Array which contains the buttons or button groups that should be rendered.
+		 */
+		getToolbarButtonGroups(buttons, additionalProps) {
+			var instance = this;
 
-            if (AlloyEditor.Lang.isFunction(buttons)) {
-                buttons = buttons.call(this) || [];
-            }
+			if (AlloyEditor.Lang.isFunction(buttons)) {
+				buttons = buttons.call(this) || [];
+			}
 
+			return buttons.reduce((list, button) => {
+				if (Array.isArray(button)) {
+					list.push(
+						instance.getToolbarButtons(button, additionalProps)
+					);
+					return list;
+				} else {
+					return instance.getToolbarButtons(buttons, additionalProps);
+				}
+			}, []);
+		},
 
-            return buttons.reduce(function(list, button) {
-                if (Array.isArray(button)) {
-                    list.push(instance.getToolbarButtons(button, additionalProps));
-                    return list;
-                } else {
-                    return instance.getToolbarButtons(buttons, additionalProps);
-                }
-            }, []);
-        },
+		/**
+		 * Analyzes the current selection and the buttons exclusive mode value to figure out which
+		 * buttons should be present in a given state.
+		 *
+		 * @instance
+		 * @memberof ToolbarButtons
+		 * @method getToolbarButtons
+		 * @param {Array} buttons The buttons could be shown, prior to the state filtering.
+		 * @param {Object} additionalProps Additional props that should be passed down to the buttons.
+		 * @return {Array} An Array which contains the buttons that should be rendered.
+		 */
+		getToolbarButtons(buttons, additionalProps) {
+			var buttonProps = {};
 
-        /**
-         * Analyzes the current selection and the buttons exclusive mode value to figure out which
-         * buttons should be present in a given state.
-         *
-         * @instance
-         * @memberof ToolbarButtons
-         * @method getToolbarButtons
-         * @param {Array} buttons The buttons could be shown, prior to the state filtering.
-         * @param {Object} additionalProps Additional props that should be passed down to the buttons.
-         * @return {Array} An Array which contains the buttons that should be rendered.
-         */
-        getToolbarButtons: function(buttons, additionalProps) {
-            var buttonProps = {};
+			var nativeEditor = this.props.editor.get('nativeEditor');
+			var buttonCfg = nativeEditor.config.buttonCfg || {};
 
-            var nativeEditor = this.props.editor.get('nativeEditor');
-            var buttonCfg = nativeEditor.config.buttonCfg || {};
+			if (AlloyEditor.Lang.isFunction(buttons)) {
+				buttons = buttons.call(this) || [];
+			}
 
-            if (AlloyEditor.Lang.isFunction(buttons)) {
-                buttons = buttons.call(this) || [];
-            }
+			var toolbarButtons = this.filterExclusive(
+				buttons
+					.filter(button => {
+						return (
+							button &&
+							(AlloyEditor.Buttons[button] ||
+								AlloyEditor.Buttons[button.name])
+						);
+					})
+					.map(button => {
+						if (AlloyEditor.Lang.isString(button)) {
+							buttonProps[button] = buttonCfg[button];
+							button = AlloyEditor.Buttons[button];
+						} else if (AlloyEditor.Lang.isString(button.name)) {
+							buttonProps[
+								AlloyEditor.Buttons[button.name].key
+							] = CKEDITOR.tools.merge(
+								buttonCfg[button],
+								button.cfg
+							);
+							button = AlloyEditor.Buttons[button.name];
+						}
 
-            var toolbarButtons = this.filterExclusive(
-                    buttons.filter(function(button) {
-                        return button && (AlloyEditor.Buttons[button] || AlloyEditor.Buttons[button.name]);
-                    })
-                    .map(function(button) {
-                        if (AlloyEditor.Lang.isString(button)) {
-                            buttonProps[button]= buttonCfg[button];
-                            button = AlloyEditor.Buttons[button];
-                        } else if (AlloyEditor.Lang.isString(button.name)) {
-                            buttonProps[AlloyEditor.Buttons[button.name].key] = CKEDITOR.tools.merge(buttonCfg[button], button.cfg);
-                            button = AlloyEditor.Buttons[button.name];
-                        }
+						return button;
+					})
+			).map(function(button, index) {
+				var props = this.mergeExclusiveProps(
+					{
+						editor: this.props.editor,
+						key:
+							button.key !== 'separator'
+								? button.key
+								: `${button.key}-${index}`,
+						tabKey: button.key,
+						tabIndex:
+							this.props.trigger &&
+							this.props.trigger.props.tabKey === button.key
+								? 0
+								: -1,
+						trigger: this.props.trigger,
+					},
+					button.key
+				);
 
-                        return button;
-                    })
-                )
-                .map(function(button, index) {
-                    var props = this.mergeExclusiveProps({
-                        editor: this.props.editor,
-                        key: button.key !== 'separator' ? button.key : `${button.key}-${index}`,
-                        tabKey: button.key,
-                        tabIndex: (this.props.trigger && this.props.trigger.props.tabKey === button.key) ? 0 : -1,
-                        trigger: this.props.trigger
-                    }, button.key);
+				props = this.mergeDropdownProps(props, button.key);
 
-                    props = this.mergeDropdownProps(props, button.key);
+				if (additionalProps) {
+					props = CKEDITOR.tools.merge(props, additionalProps);
+				}
 
-                    if (additionalProps) {
-                        props = CKEDITOR.tools.merge(props, additionalProps);
-                    }
+				props = CKEDITOR.tools.merge(props, buttonProps[button.key]);
 
-                    props = CKEDITOR.tools.merge(props, buttonProps[button.key]);
+				return React.createElement(button, props);
+			}, this);
 
-                    return React.createElement(button, props);
-                }, this);
+			return toolbarButtons;
+		},
+	};
 
-            return toolbarButtons;
-        }
-    };
-
-    AlloyEditor.ToolbarButtons = ToolbarButtons;
-}());
+	AlloyEditor.ToolbarButtons = ToolbarButtons;
+})();

--- a/src/components/compat/toolbar-buttons.js
+++ b/src/components/compat/toolbar-buttons.js
@@ -1,3 +1,5 @@
+import React from 'react';
+
 (function() {
 	'use strict';
 

--- a/src/components/compat/widget-arrow-box.js
+++ b/src/components/compat/widget-arrow-box.js
@@ -1,0 +1,36 @@
+(function() {
+    'use strict';
+
+    /**
+     * Provides functionality for displaying Widget Arrow box on top or on bottom of the widget
+     * depending on the point of user interaction with the editor.
+     *
+     * @class WidgetArrowBox
+     */
+    var WidgetArrowBox = {
+        /**
+         * Returns the list of arrow box classes associated to the current element's state. It relies
+         * on the getInteractionPoint method to calculate the selection direction.
+         *
+         * @instance
+         * @memberof WidgetArrowBox
+         * @method getArrowBoxClasses
+         * @return {String} A string with the arrow box CSS classes.
+         */
+        getArrowBoxClasses: function() {
+            var arrowBoxClasses = 'ae-arrow-box';
+
+            if (AlloyEditor.Lang.isFunction(this.getInteractionPoint) && this.getInteractionPoint()) {
+                if (this.getInteractionPoint().direction === CKEDITOR.SELECTION_TOP_TO_BOTTOM) {
+                    arrowBoxClasses += ' ae-arrow-box-top';
+                } else {
+                    arrowBoxClasses += ' ae-arrow-box-bottom';
+                }
+            }
+
+            return arrowBoxClasses;
+        }
+    };
+
+    AlloyEditor.WidgetArrowBox = WidgetArrowBox;
+}());

--- a/src/components/compat/widget-arrow-box.js
+++ b/src/components/compat/widget-arrow-box.js
@@ -1,36 +1,42 @@
 (function() {
-    'use strict';
+	'use strict';
 
-    /**
-     * Provides functionality for displaying Widget Arrow box on top or on bottom of the widget
-     * depending on the point of user interaction with the editor.
-     *
-     * @class WidgetArrowBox
-     */
-    var WidgetArrowBox = {
-        /**
-         * Returns the list of arrow box classes associated to the current element's state. It relies
-         * on the getInteractionPoint method to calculate the selection direction.
-         *
-         * @instance
-         * @memberof WidgetArrowBox
-         * @method getArrowBoxClasses
-         * @return {String} A string with the arrow box CSS classes.
-         */
-        getArrowBoxClasses: function() {
-            var arrowBoxClasses = 'ae-arrow-box';
+	/**
+	 * Provides functionality for displaying Widget Arrow box on top or on bottom of the widget
+	 * depending on the point of user interaction with the editor.
+	 *
+	 * @class WidgetArrowBox
+	 */
+	var WidgetArrowBox = {
+		/**
+		 * Returns the list of arrow box classes associated to the current element's state. It relies
+		 * on the getInteractionPoint method to calculate the selection direction.
+		 *
+		 * @instance
+		 * @memberof WidgetArrowBox
+		 * @method getArrowBoxClasses
+		 * @return {String} A string with the arrow box CSS classes.
+		 */
+		getArrowBoxClasses() {
+			var arrowBoxClasses = 'ae-arrow-box';
 
-            if (AlloyEditor.Lang.isFunction(this.getInteractionPoint) && this.getInteractionPoint()) {
-                if (this.getInteractionPoint().direction === CKEDITOR.SELECTION_TOP_TO_BOTTOM) {
-                    arrowBoxClasses += ' ae-arrow-box-top';
-                } else {
-                    arrowBoxClasses += ' ae-arrow-box-bottom';
-                }
-            }
+			if (
+				AlloyEditor.Lang.isFunction(this.getInteractionPoint) &&
+				this.getInteractionPoint()
+			) {
+				if (
+					this.getInteractionPoint().direction ===
+					CKEDITOR.SELECTION_TOP_TO_BOTTOM
+				) {
+					arrowBoxClasses += ' ae-arrow-box-top';
+				} else {
+					arrowBoxClasses += ' ae-arrow-box-bottom';
+				}
+			}
 
-            return arrowBoxClasses;
-        }
-    };
+			return arrowBoxClasses;
+		},
+	};
 
-    AlloyEditor.WidgetArrowBox = WidgetArrowBox;
-}());
+	AlloyEditor.WidgetArrowBox = WidgetArrowBox;
+})();

--- a/src/components/compat/widget-arrow-box.js
+++ b/src/components/compat/widget-arrow-box.js
@@ -1,42 +1,40 @@
-(function() {
-	'use strict';
+import Lang from '../../oop/lang';
 
+/**
+ * Provides functionality for displaying Widget Arrow box on top or on bottom of the widget
+ * depending on the point of user interaction with the editor.
+ *
+ * @class WidgetArrowBox
+ */
+const WidgetArrowBox = {
 	/**
-	 * Provides functionality for displaying Widget Arrow box on top or on bottom of the widget
-	 * depending on the point of user interaction with the editor.
+	 * Returns the list of arrow box classes associated to the current element's state. It relies
+	 * on the getInteractionPoint method to calculate the selection direction.
 	 *
-	 * @class WidgetArrowBox
+	 * @instance
+	 * @memberof WidgetArrowBox
+	 * @method getArrowBoxClasses
+	 * @return {String} A string with the arrow box CSS classes.
 	 */
-	var WidgetArrowBox = {
-		/**
-		 * Returns the list of arrow box classes associated to the current element's state. It relies
-		 * on the getInteractionPoint method to calculate the selection direction.
-		 *
-		 * @instance
-		 * @memberof WidgetArrowBox
-		 * @method getArrowBoxClasses
-		 * @return {String} A string with the arrow box CSS classes.
-		 */
-		getArrowBoxClasses() {
-			var arrowBoxClasses = 'ae-arrow-box';
+	getArrowBoxClasses() {
+		let arrowBoxClasses = 'ae-arrow-box';
 
+		if (
+			Lang.isFunction(this.getInteractionPoint) &&
+			this.getInteractionPoint()
+		) {
 			if (
-				AlloyEditor.Lang.isFunction(this.getInteractionPoint) &&
-				this.getInteractionPoint()
+				this.getInteractionPoint().direction ===
+				CKEDITOR.SELECTION_TOP_TO_BOTTOM
 			) {
-				if (
-					this.getInteractionPoint().direction ===
-					CKEDITOR.SELECTION_TOP_TO_BOTTOM
-				) {
-					arrowBoxClasses += ' ae-arrow-box-top';
-				} else {
-					arrowBoxClasses += ' ae-arrow-box-bottom';
-				}
+				arrowBoxClasses += ' ae-arrow-box-top';
+			} else {
+				arrowBoxClasses += ' ae-arrow-box-bottom';
 			}
+		}
 
-			return arrowBoxClasses;
-		},
-	};
+		return arrowBoxClasses;
+	},
+};
 
-	AlloyEditor.WidgetArrowBox = WidgetArrowBox;
-})();
+export default WidgetArrowBox;

--- a/src/components/compat/widget-dropdown.js
+++ b/src/components/compat/widget-dropdown.js
@@ -1,0 +1,86 @@
+(function() {
+    'use strict';
+
+    /**
+     * Provides functionality for managing different dropdowns inside a widget.
+     *
+     * @class WidgetDropdown
+     */
+    var WidgetDropdown = {
+        /**
+         * Lifecycle. Invoked when a component is receiving new props.
+         * This method is not called for the initial render.
+         *
+         * @instance
+         * @memberof WidgetDropdown
+         * @method componentWillReceiveProps
+         */
+        componentWillReceiveProps: function(nextProps) {
+            this.setState({
+                dropdownTrigger: null,
+                itemDropdown: null
+            });
+        },
+
+        /**
+         * Lifecycle. Invoked once before the component is mounted.
+         *
+         * @instance
+         * @memberof WidgetDropdown
+         * @method getInitialState
+         */
+        getInitialState: function() {
+            return {
+                dropdownTrigger: null,
+                itemDropdown: null
+            };
+        },
+
+        /**
+         * Merges the provided object with two more properties:
+         * - expanded - boolean flag which indicates if an widget should be rendered exclusively.
+         * - toggleDropdown - function, which can be used by an widget in order to obtain exclusive state.
+         *
+         * @instance
+         * @memberof WidgetDropdown
+         * @method mergeDropdownProps
+         * @param {Object} obj The properties container which should be merged with the properties, related
+         *    to dropdown state.
+         * @param {Object} itemKey They key of an React Widget which contains the dropdown.
+         * @return {Object} The merged object.
+         */
+        mergeDropdownProps: function(obj, itemKey) {
+            return CKEDITOR.tools.merge(obj, {
+                expanded: this.state.itemDropdown === itemKey ? true : false,
+                tabIndex: this.state.dropdownTrigger === itemKey ? 0 : -1,
+                toggleDropdown: this.toggleDropdown.bind(this, itemKey)
+            });
+        },
+
+        /**
+         * Sets the active dropdown of the widget or discards the toggled item from the state.
+         *
+         * @instance
+         * @memberof WidgetDropdown
+         * @method toggleDropdown
+         * @param {Object} itemDropdown The widget which requests to toggle its dropdown.
+         * @param {Number} toggleDirection User movement direction when toggled via keyboard.
+         */
+        toggleDropdown: function(itemDropdown, toggleDirection) {
+            this.setState({
+                dropdownTrigger: itemDropdown,
+                itemDropdown: itemDropdown !== this.state.itemDropdown ? itemDropdown : null
+            }, function() {
+                if (!this.state.itemDropdown) {
+                    if (this.moveFocus) {
+                        this.moveFocus(toggleDirection);
+                    } else {
+                        ReactDOM.findDOMNode(this).focus();
+                    }
+                }
+            });
+        }
+    };
+
+    AlloyEditor.WidgetDropdown = WidgetDropdown;
+}());

--- a/src/components/compat/widget-dropdown.js
+++ b/src/components/compat/widget-dropdown.js
@@ -1,3 +1,5 @@
+import ReactDOM from 'react-dom';
+
 (function() {
 	'use strict';
 
@@ -15,7 +17,7 @@
 		 * @memberof WidgetDropdown
 		 * @method componentWillReceiveProps
 		 */
-		componentWillReceiveProps: function(nextProps) {
+		componentWillReceiveProps(_nextProps) {
 			this.setState({
 				dropdownTrigger: null,
 				itemDropdown: null,

--- a/src/components/compat/widget-dropdown.js
+++ b/src/components/compat/widget-dropdown.js
@@ -1,94 +1,93 @@
 import ReactDOM from 'react-dom';
 
-(function() {
-	'use strict';
+/**
+ * Provides functionality for managing different dropdowns inside a widget.
+ *
+ * @class WidgetDropdown
+ */
+const WidgetDropdown = {
+	/**
+	 * Lifecycle. Invoked when a component is receiving new props.
+	 * This method is not called for the initial render.
+	 *
+	 * @instance
+	 * @memberof WidgetDropdown
+	 * @method componentWillReceiveProps
+	 */
+	componentWillReceiveProps(_nextProps) {
+		this.setState({
+			dropdownTrigger: null,
+			itemDropdown: null,
+		});
+	},
 
 	/**
-	 * Provides functionality for managing different dropdowns inside a widget.
+	 * Lifecycle. Invoked once before the component is mounted.
 	 *
-	 * @class WidgetDropdown
+	 * @instance
+	 * @memberof WidgetDropdown
+	 * @method getInitialState
 	 */
-	var WidgetDropdown = {
-		/**
-		 * Lifecycle. Invoked when a component is receiving new props.
-		 * This method is not called for the initial render.
-		 *
-		 * @instance
-		 * @memberof WidgetDropdown
-		 * @method componentWillReceiveProps
-		 */
-		componentWillReceiveProps(_nextProps) {
-			this.setState({
-				dropdownTrigger: null,
-				itemDropdown: null,
-			});
-		},
+	getInitialState() {
+		return {
+			dropdownTrigger: null,
+			itemDropdown: null,
+		};
+	},
 
-		/**
-		 * Lifecycle. Invoked once before the component is mounted.
-		 *
-		 * @instance
-		 * @memberof WidgetDropdown
-		 * @method getInitialState
-		 */
-		getInitialState() {
-			return {
-				dropdownTrigger: null,
-				itemDropdown: null,
-			};
-		},
+	/**
+	 * Merges the provided object with two more properties:
+	 * - expanded - boolean flag which indicates if an widget should be
+	 *   rendered exclusively.
+	 * - toggleDropdown - function, which can be used by an widget in
+	 *   order to obtain exclusive state.
+	 *
+	 * @instance
+	 * @memberof WidgetDropdown
+	 * @method mergeDropdownProps
+	 * @param {Object} obj The properties container which should be merged with the properties, related
+	 *    to dropdown state.
+	 * @param {Object} itemKey They key of an React Widget which contains the dropdown.
+	 * @return {Object} The merged object.
+	 */
+	mergeDropdownProps(obj, itemKey) {
+		return CKEDITOR.tools.merge(obj, {
+			expanded: this.state.itemDropdown === itemKey ? true : false,
+			tabIndex: this.state.dropdownTrigger === itemKey ? 0 : -1,
+			toggleDropdown: this.toggleDropdown.bind(this, itemKey),
+		});
+	},
 
-		/**
-		 * Merges the provided object with two more properties:
-		 * - expanded - boolean flag which indicates if an widget should be rendered exclusively.
-		 * - toggleDropdown - function, which can be used by an widget in order to obtain exclusive state.
-		 *
-		 * @instance
-		 * @memberof WidgetDropdown
-		 * @method mergeDropdownProps
-		 * @param {Object} obj The properties container which should be merged with the properties, related
-		 *    to dropdown state.
-		 * @param {Object} itemKey They key of an React Widget which contains the dropdown.
-		 * @return {Object} The merged object.
-		 */
-		mergeDropdownProps(obj, itemKey) {
-			return CKEDITOR.tools.merge(obj, {
-				expanded: this.state.itemDropdown === itemKey ? true : false,
-				tabIndex: this.state.dropdownTrigger === itemKey ? 0 : -1,
-				toggleDropdown: this.toggleDropdown.bind(this, itemKey),
-			});
-		},
-
-		/**
-		 * Sets the active dropdown of the widget or discards the toggled item from the state.
-		 *
-		 * @instance
-		 * @memberof WidgetDropdown
-		 * @method toggleDropdown
-		 * @param {Object} itemDropdown The widget which requests to toggle its dropdown.
-		 * @param {Number} toggleDirection User movement direction when toggled via keyboard.
-		 */
-		toggleDropdown(itemDropdown, toggleDirection) {
-			this.setState(
-				{
-					dropdownTrigger: itemDropdown,
-					itemDropdown:
-						itemDropdown !== this.state.itemDropdown
-							? itemDropdown
-							: null,
-				},
-				function() {
-					if (!this.state.itemDropdown) {
-						if (this.moveFocus) {
-							this.moveFocus(toggleDirection);
-						} else {
-							ReactDOM.findDOMNode(this).focus();
-						}
+	/**
+	 * Sets the active dropdown of the widget or discards the toggled
+	 * item from the state.
+	 *
+	 * @instance
+	 * @memberof WidgetDropdown
+	 * @method toggleDropdown
+	 * @param {Object} itemDropdown The widget which requests to toggle its dropdown.
+	 * @param {Number} toggleDirection User movement direction when toggled via keyboard.
+	 */
+	toggleDropdown(itemDropdown, toggleDirection) {
+		this.setState(
+			{
+				dropdownTrigger: itemDropdown,
+				itemDropdown:
+					itemDropdown !== this.state.itemDropdown
+						? itemDropdown
+						: null,
+			},
+			function() {
+				if (!this.state.itemDropdown) {
+					if (this.moveFocus) {
+						this.moveFocus(toggleDirection);
+					} else {
+						ReactDOM.findDOMNode(this).focus();
 					}
 				}
-			);
-		},
-	};
+			}
+		);
+	},
+};
 
-	AlloyEditor.WidgetDropdown = WidgetDropdown;
-})();
+export default WidgetDropdown;

--- a/src/components/compat/widget-dropdown.js
+++ b/src/components/compat/widget-dropdown.js
@@ -1,86 +1,92 @@
 (function() {
-    'use strict';
+	'use strict';
 
-    /**
-     * Provides functionality for managing different dropdowns inside a widget.
-     *
-     * @class WidgetDropdown
-     */
-    var WidgetDropdown = {
-        /**
-         * Lifecycle. Invoked when a component is receiving new props.
-         * This method is not called for the initial render.
-         *
-         * @instance
-         * @memberof WidgetDropdown
-         * @method componentWillReceiveProps
-         */
-        componentWillReceiveProps: function(nextProps) {
-            this.setState({
-                dropdownTrigger: null,
-                itemDropdown: null
-            });
-        },
+	/**
+	 * Provides functionality for managing different dropdowns inside a widget.
+	 *
+	 * @class WidgetDropdown
+	 */
+	var WidgetDropdown = {
+		/**
+		 * Lifecycle. Invoked when a component is receiving new props.
+		 * This method is not called for the initial render.
+		 *
+		 * @instance
+		 * @memberof WidgetDropdown
+		 * @method componentWillReceiveProps
+		 */
+		componentWillReceiveProps: function(nextProps) {
+			this.setState({
+				dropdownTrigger: null,
+				itemDropdown: null,
+			});
+		},
 
-        /**
-         * Lifecycle. Invoked once before the component is mounted.
-         *
-         * @instance
-         * @memberof WidgetDropdown
-         * @method getInitialState
-         */
-        getInitialState: function() {
-            return {
-                dropdownTrigger: null,
-                itemDropdown: null
-            };
-        },
+		/**
+		 * Lifecycle. Invoked once before the component is mounted.
+		 *
+		 * @instance
+		 * @memberof WidgetDropdown
+		 * @method getInitialState
+		 */
+		getInitialState() {
+			return {
+				dropdownTrigger: null,
+				itemDropdown: null,
+			};
+		},
 
-        /**
-         * Merges the provided object with two more properties:
-         * - expanded - boolean flag which indicates if an widget should be rendered exclusively.
-         * - toggleDropdown - function, which can be used by an widget in order to obtain exclusive state.
-         *
-         * @instance
-         * @memberof WidgetDropdown
-         * @method mergeDropdownProps
-         * @param {Object} obj The properties container which should be merged with the properties, related
-         *    to dropdown state.
-         * @param {Object} itemKey They key of an React Widget which contains the dropdown.
-         * @return {Object} The merged object.
-         */
-        mergeDropdownProps: function(obj, itemKey) {
-            return CKEDITOR.tools.merge(obj, {
-                expanded: this.state.itemDropdown === itemKey ? true : false,
-                tabIndex: this.state.dropdownTrigger === itemKey ? 0 : -1,
-                toggleDropdown: this.toggleDropdown.bind(this, itemKey)
-            });
-        },
+		/**
+		 * Merges the provided object with two more properties:
+		 * - expanded - boolean flag which indicates if an widget should be rendered exclusively.
+		 * - toggleDropdown - function, which can be used by an widget in order to obtain exclusive state.
+		 *
+		 * @instance
+		 * @memberof WidgetDropdown
+		 * @method mergeDropdownProps
+		 * @param {Object} obj The properties container which should be merged with the properties, related
+		 *    to dropdown state.
+		 * @param {Object} itemKey They key of an React Widget which contains the dropdown.
+		 * @return {Object} The merged object.
+		 */
+		mergeDropdownProps(obj, itemKey) {
+			return CKEDITOR.tools.merge(obj, {
+				expanded: this.state.itemDropdown === itemKey ? true : false,
+				tabIndex: this.state.dropdownTrigger === itemKey ? 0 : -1,
+				toggleDropdown: this.toggleDropdown.bind(this, itemKey),
+			});
+		},
 
-        /**
-         * Sets the active dropdown of the widget or discards the toggled item from the state.
-         *
-         * @instance
-         * @memberof WidgetDropdown
-         * @method toggleDropdown
-         * @param {Object} itemDropdown The widget which requests to toggle its dropdown.
-         * @param {Number} toggleDirection User movement direction when toggled via keyboard.
-         */
-        toggleDropdown: function(itemDropdown, toggleDirection) {
-            this.setState({
-                dropdownTrigger: itemDropdown,
-                itemDropdown: itemDropdown !== this.state.itemDropdown ? itemDropdown : null
-            }, function() {
-                if (!this.state.itemDropdown) {
-                    if (this.moveFocus) {
-                        this.moveFocus(toggleDirection);
-                    } else {
-                        ReactDOM.findDOMNode(this).focus();
-                    }
-                }
-            });
-        }
-    };
+		/**
+		 * Sets the active dropdown of the widget or discards the toggled item from the state.
+		 *
+		 * @instance
+		 * @memberof WidgetDropdown
+		 * @method toggleDropdown
+		 * @param {Object} itemDropdown The widget which requests to toggle its dropdown.
+		 * @param {Number} toggleDirection User movement direction when toggled via keyboard.
+		 */
+		toggleDropdown(itemDropdown, toggleDirection) {
+			this.setState(
+				{
+					dropdownTrigger: itemDropdown,
+					itemDropdown:
+						itemDropdown !== this.state.itemDropdown
+							? itemDropdown
+							: null,
+				},
+				function() {
+					if (!this.state.itemDropdown) {
+						if (this.moveFocus) {
+							this.moveFocus(toggleDirection);
+						} else {
+							ReactDOM.findDOMNode(this).focus();
+						}
+					}
+				}
+			);
+		},
+	};
 
-    AlloyEditor.WidgetDropdown = WidgetDropdown;
-}());
+	AlloyEditor.WidgetDropdown = WidgetDropdown;
+})();

--- a/src/components/compat/widget-exclusive.js
+++ b/src/components/compat/widget-exclusive.js
@@ -1,0 +1,107 @@
+(function() {
+    'use strict';
+
+    /**
+     * Provides functionality for managing exclusive state of an widget.
+     * The exclusive state means that a button may request to be the only rendered
+     * widget in its parent container. WidgetExclusive will manage this state by
+     * filtering and suppressing the other sibling widgets from displaying.
+     *
+     * @class WidgetExclusive
+     */
+    var WidgetExclusive = {
+        /**
+         * Cancels the exclusive state of an widget.
+         *
+         * @instance
+         * @memberof WidgetExclusive
+         * @method cancelExclusive
+         * @param {Object} itemExclusive The widget which exclusive state should be canceled.
+         */
+        cancelExclusive: function(itemExclusive) {
+            if (this.state.itemExclusive === itemExclusive) {
+                this.setState({
+                    itemExclusive: null
+                });
+            }
+        },
+
+        /**
+         * Lifecycle. Invoked when a component is receiving new props.
+         * This method is not called for the initial render.
+         * Calling this.setState() within this function will not trigger an additional render.
+         *
+         * @instance
+         * @memberof WidgetExclusive
+         * @method componentWillReceiveProps
+         * @param {Object} nextProps Object containing the current set of properties.
+         */
+        componentWillReceiveProps: function(nextProps) {
+            // Receiving properties means that the component is being re-rendered.
+            // Re-rendering is triggered by editorInteraction, so we have to
+            // reset the exclusive state and render the UI according to the new selection.
+            this.setState({
+                itemExclusive: null
+            });
+        },
+
+        /**
+         * Filters the items and returns only those with exclusive state.
+         *
+         * @instance
+         * @memberof WidgetExclusive
+         * @method filterExclusive
+         * @param {Array} items The widgets to be filtered.
+         * @return {Array|Object} The item with executive state.
+         */
+        filterExclusive: function(items) {
+            return items.filter(function(item) {
+                if (this.state.itemExclusive) {
+                    if (this.state.itemExclusive === item.key) {
+                        return item;
+                    }
+                } else {
+                    return item;
+                }
+            }.bind(this));
+        },
+
+        /**
+         * Merges the provided object with three more properties:
+         * - cancelExclusive - function, which can be used by a widget in order to cancel executive state.
+         * - renderExclusive - boolean flag which indicates if an widget should be rendered exclusively.
+         * - requestExclusive - function, which can be used by a widget in order to obtain exclusive state.
+         *
+         * @instance
+         * @memberof WidgetExclusive
+         * @method mergeExclusiveProps
+         * @param {Object} obj The properties container which should be merged with the properties, related
+         *    to exclusive state.
+         * @param {Object} itemKey They key of an React Widget which should be rendered exclusively.
+         * @return {Object} The merged object.
+         */
+        mergeExclusiveProps: function(obj, itemKey) {
+            return CKEDITOR.tools.merge(obj, {
+                cancelExclusive: this.cancelExclusive.bind(this, itemKey),
+                renderExclusive: (this.state.itemExclusive === itemKey),
+                requestExclusive: this.requestExclusive.bind(this, itemKey)
+            });
+        },
+
+        /**
+         * Requests and sets exclusive state of an widget.
+         *
+         * @instance
+         * @memberof WidgetExclusive
+         * @method requestExclusive
+         * @param {Object} itemExclusive The widget which requests exclusive state.
+         */
+        requestExclusive: function(itemExclusive) {
+            this.setState({
+                itemExclusive: itemExclusive
+            });
+        }
+    };
+
+    AlloyEditor.WidgetExclusive = WidgetExclusive;
+}());

--- a/src/components/compat/widget-exclusive.js
+++ b/src/components/compat/widget-exclusive.js
@@ -1,107 +1,107 @@
 (function() {
-    'use strict';
+	'use strict';
 
-    /**
-     * Provides functionality for managing exclusive state of an widget.
-     * The exclusive state means that a button may request to be the only rendered
-     * widget in its parent container. WidgetExclusive will manage this state by
-     * filtering and suppressing the other sibling widgets from displaying.
-     *
-     * @class WidgetExclusive
-     */
-    var WidgetExclusive = {
-        /**
-         * Cancels the exclusive state of an widget.
-         *
-         * @instance
-         * @memberof WidgetExclusive
-         * @method cancelExclusive
-         * @param {Object} itemExclusive The widget which exclusive state should be canceled.
-         */
-        cancelExclusive: function(itemExclusive) {
-            if (this.state.itemExclusive === itemExclusive) {
-                this.setState({
-                    itemExclusive: null
-                });
-            }
-        },
+	/**
+	 * Provides functionality for managing exclusive state of an widget.
+	 * The exclusive state means that a button may request to be the only rendered
+	 * widget in its parent container. WidgetExclusive will manage this state by
+	 * filtering and suppressing the other sibling widgets from displaying.
+	 *
+	 * @class WidgetExclusive
+	 */
+	var WidgetExclusive = {
+		/**
+		 * Cancels the exclusive state of an widget.
+		 *
+		 * @instance
+		 * @memberof WidgetExclusive
+		 * @method cancelExclusive
+		 * @param {Object} itemExclusive The widget which exclusive state should be canceled.
+		 */
+		cancelExclusive(itemExclusive) {
+			if (this.state.itemExclusive === itemExclusive) {
+				this.setState({
+					itemExclusive: null,
+				});
+			}
+		},
 
-        /**
-         * Lifecycle. Invoked when a component is receiving new props.
-         * This method is not called for the initial render.
-         * Calling this.setState() within this function will not trigger an additional render.
-         *
-         * @instance
-         * @memberof WidgetExclusive
-         * @method componentWillReceiveProps
-         * @param {Object} nextProps Object containing the current set of properties.
-         */
-        componentWillReceiveProps: function(nextProps) {
-            // Receiving properties means that the component is being re-rendered.
-            // Re-rendering is triggered by editorInteraction, so we have to
-            // reset the exclusive state and render the UI according to the new selection.
-            this.setState({
-                itemExclusive: null
-            });
-        },
+		/**
+		 * Lifecycle. Invoked when a component is receiving new props.
+		 * This method is not called for the initial render.
+		 * Calling this.setState() within this function will not trigger an additional render.
+		 *
+		 * @instance
+		 * @memberof WidgetExclusive
+		 * @method componentWillReceiveProps
+		 * @param {Object} nextProps Object containing the current set of properties.
+		 */
+		componentWillReceiveProps(_nextProps) {
+			// Receiving properties means that the component is being re-rendered.
+			// Re-rendering is triggered by editorInteraction, so we have to
+			// reset the exclusive state and render the UI according to the new selection.
+			this.setState({
+				itemExclusive: null,
+			});
+		},
 
-        /**
-         * Filters the items and returns only those with exclusive state.
-         *
-         * @instance
-         * @memberof WidgetExclusive
-         * @method filterExclusive
-         * @param {Array} items The widgets to be filtered.
-         * @return {Array|Object} The item with executive state.
-         */
-        filterExclusive: function(items) {
-            return items.filter(function(item) {
-                if (this.state.itemExclusive) {
-                    if (this.state.itemExclusive === item.key) {
-                        return item;
-                    }
-                } else {
-                    return item;
-                }
-            }.bind(this));
-        },
+		/**
+		 * Filters the items and returns only those with exclusive state.
+		 *
+		 * @instance
+		 * @memberof WidgetExclusive
+		 * @method filterExclusive
+		 * @param {Array} items The widgets to be filtered.
+		 * @return {Array|Object} The item with executive state.
+		 */
+		filterExclusive(items) {
+			return items.filter(item => {
+				if (this.state.itemExclusive) {
+					if (this.state.itemExclusive === item.key) {
+						return item;
+					}
+				} else {
+					return item;
+				}
+			});
+		},
 
-        /**
-         * Merges the provided object with three more properties:
-         * - cancelExclusive - function, which can be used by a widget in order to cancel executive state.
-         * - renderExclusive - boolean flag which indicates if an widget should be rendered exclusively.
-         * - requestExclusive - function, which can be used by a widget in order to obtain exclusive state.
-         *
-         * @instance
-         * @memberof WidgetExclusive
-         * @method mergeExclusiveProps
-         * @param {Object} obj The properties container which should be merged with the properties, related
-         *    to exclusive state.
-         * @param {Object} itemKey They key of an React Widget which should be rendered exclusively.
-         * @return {Object} The merged object.
-         */
-        mergeExclusiveProps: function(obj, itemKey) {
-            return CKEDITOR.tools.merge(obj, {
-                cancelExclusive: this.cancelExclusive.bind(this, itemKey),
-                renderExclusive: (this.state.itemExclusive === itemKey),
-                requestExclusive: this.requestExclusive.bind(this, itemKey)
-            });
-        },
+		/**
+		 * Merges the provided object with three more properties:
+		 * - cancelExclusive - function, which can be used by a widget in order to cancel executive state.
+		 * - renderExclusive - boolean flag which indicates if an widget should be rendered exclusively.
+		 * - requestExclusive - function, which can be used by a widget in order to obtain exclusive state.
+		 *
+		 * @instance
+		 * @memberof WidgetExclusive
+		 * @method mergeExclusiveProps
+		 * @param {Object} obj The properties container which should be merged with the properties, related
+		 *    to exclusive state.
+		 * @param {Object} itemKey They key of an React Widget which should be rendered exclusively.
+		 * @return {Object} The merged object.
+		 */
+		mergeExclusiveProps(obj, itemKey) {
+			return CKEDITOR.tools.merge(obj, {
+				cancelExclusive: this.cancelExclusive.bind(this, itemKey),
+				renderExclusive: this.state.itemExclusive === itemKey,
+				requestExclusive: this.requestExclusive.bind(this, itemKey),
+			});
+		},
 
-        /**
-         * Requests and sets exclusive state of an widget.
-         *
-         * @instance
-         * @memberof WidgetExclusive
-         * @method requestExclusive
-         * @param {Object} itemExclusive The widget which requests exclusive state.
-         */
-        requestExclusive: function(itemExclusive) {
-            this.setState({
-                itemExclusive: itemExclusive
-            });
-        }
-    };
+		/**
+		 * Requests and sets exclusive state of an widget.
+		 *
+		 * @instance
+		 * @memberof WidgetExclusive
+		 * @method requestExclusive
+		 * @param {Object} itemExclusive The widget which requests exclusive state.
+		 */
+		requestExclusive(itemExclusive) {
+			this.setState({
+				itemExclusive,
+			});
+		},
+	};
 
-    AlloyEditor.WidgetExclusive = WidgetExclusive;
-}());
+	AlloyEditor.WidgetExclusive = WidgetExclusive;
+})();

--- a/src/components/compat/widget-exclusive.js
+++ b/src/components/compat/widget-exclusive.js
@@ -1,107 +1,108 @@
-(function() {
-	'use strict';
-
+/**
+ * Provides functionality for managing exclusive state of an widget.
+ * The exclusive state means that a button may request to be the only rendered
+ * widget in its parent container. WidgetExclusive will manage this state by
+ * filtering and suppressing the other sibling widgets from displaying.
+ *
+ * @class WidgetExclusive
+ */
+const WidgetExclusive = {
 	/**
-	 * Provides functionality for managing exclusive state of an widget.
-	 * The exclusive state means that a button may request to be the only rendered
-	 * widget in its parent container. WidgetExclusive will manage this state by
-	 * filtering and suppressing the other sibling widgets from displaying.
+	 * Cancels the exclusive state of an widget.
 	 *
-	 * @class WidgetExclusive
+	 * @instance
+	 * @memberof WidgetExclusive
+	 * @method cancelExclusive
+	 * @param {Object} itemExclusive The widget which exclusive state should be canceled.
 	 */
-	var WidgetExclusive = {
-		/**
-		 * Cancels the exclusive state of an widget.
-		 *
-		 * @instance
-		 * @memberof WidgetExclusive
-		 * @method cancelExclusive
-		 * @param {Object} itemExclusive The widget which exclusive state should be canceled.
-		 */
-		cancelExclusive(itemExclusive) {
-			if (this.state.itemExclusive === itemExclusive) {
-				this.setState({
-					itemExclusive: null,
-				});
-			}
-		},
-
-		/**
-		 * Lifecycle. Invoked when a component is receiving new props.
-		 * This method is not called for the initial render.
-		 * Calling this.setState() within this function will not trigger an additional render.
-		 *
-		 * @instance
-		 * @memberof WidgetExclusive
-		 * @method componentWillReceiveProps
-		 * @param {Object} nextProps Object containing the current set of properties.
-		 */
-		componentWillReceiveProps(_nextProps) {
-			// Receiving properties means that the component is being re-rendered.
-			// Re-rendering is triggered by editorInteraction, so we have to
-			// reset the exclusive state and render the UI according to the new selection.
+	cancelExclusive(itemExclusive) {
+		if (this.state.itemExclusive === itemExclusive) {
 			this.setState({
 				itemExclusive: null,
 			});
-		},
+		}
+	},
 
-		/**
-		 * Filters the items and returns only those with exclusive state.
-		 *
-		 * @instance
-		 * @memberof WidgetExclusive
-		 * @method filterExclusive
-		 * @param {Array} items The widgets to be filtered.
-		 * @return {Array|Object} The item with executive state.
-		 */
-		filterExclusive(items) {
-			return items.filter(item => {
-				if (this.state.itemExclusive) {
-					if (this.state.itemExclusive === item.key) {
-						return item;
-					}
-				} else {
+	/**
+	 * Lifecycle. Invoked when a component is receiving new props.
+	 * This method is not called for the initial render.
+	 * Calling this.setState() within this function will not trigger an
+	 * additional render.
+	 *
+	 * @instance
+	 * @memberof WidgetExclusive
+	 * @method componentWillReceiveProps
+	 * @param {Object} nextProps Object containing the current set of properties.
+	 */
+	componentWillReceiveProps(_nextProps) {
+		// Receiving properties means that the component is being
+		// re-rendered.  Re-rendering is triggered by editorInteraction,
+		// so we have to reset the exclusive state and render the UI
+		// according to the new selection.
+		this.setState({
+			itemExclusive: null,
+		});
+	},
+
+	/**
+	 * Filters the items and returns only those with exclusive state.
+	 *
+	 * @instance
+	 * @memberof WidgetExclusive
+	 * @method filterExclusive
+	 * @param {Array} items The widgets to be filtered.
+	 * @return {Array|Object} The item with executive state.
+	 */
+	filterExclusive(items) {
+		return items.filter(item => {
+			if (this.state.itemExclusive) {
+				if (this.state.itemExclusive === item.key) {
 					return item;
 				}
-			});
-		},
+			} else {
+				return item;
+			}
+		});
+	},
 
-		/**
-		 * Merges the provided object with three more properties:
-		 * - cancelExclusive - function, which can be used by a widget in order to cancel executive state.
-		 * - renderExclusive - boolean flag which indicates if an widget should be rendered exclusively.
-		 * - requestExclusive - function, which can be used by a widget in order to obtain exclusive state.
-		 *
-		 * @instance
-		 * @memberof WidgetExclusive
-		 * @method mergeExclusiveProps
-		 * @param {Object} obj The properties container which should be merged with the properties, related
-		 *    to exclusive state.
-		 * @param {Object} itemKey They key of an React Widget which should be rendered exclusively.
-		 * @return {Object} The merged object.
-		 */
-		mergeExclusiveProps(obj, itemKey) {
-			return CKEDITOR.tools.merge(obj, {
-				cancelExclusive: this.cancelExclusive.bind(this, itemKey),
-				renderExclusive: this.state.itemExclusive === itemKey,
-				requestExclusive: this.requestExclusive.bind(this, itemKey),
-			});
-		},
+	/**
+	 * Merges the provided object with three more properties:
+	 * - cancelExclusive - function, which can be used by a widget in
+	 *   order to cancel executive state.
+	 * - renderExclusive - boolean flag which indicates if an widget
+	 *   should be rendered exclusively.
+	 * - requestExclusive - function, which can be used by a widget in
+	 *   order to obtain exclusive state.
+	 *
+	 * @instance
+	 * @memberof WidgetExclusive
+	 * @method mergeExclusiveProps
+	 * @param {Object} obj The properties container which should be merged with the properties, related
+	 *    to exclusive state.
+	 * @param {Object} itemKey They key of an React Widget which should be rendered exclusively.
+	 * @return {Object} The merged object.
+	 */
+	mergeExclusiveProps(obj, itemKey) {
+		return CKEDITOR.tools.merge(obj, {
+			cancelExclusive: this.cancelExclusive.bind(this, itemKey),
+			renderExclusive: this.state.itemExclusive === itemKey,
+			requestExclusive: this.requestExclusive.bind(this, itemKey),
+		});
+	},
 
-		/**
-		 * Requests and sets exclusive state of an widget.
-		 *
-		 * @instance
-		 * @memberof WidgetExclusive
-		 * @method requestExclusive
-		 * @param {Object} itemExclusive The widget which requests exclusive state.
-		 */
-		requestExclusive(itemExclusive) {
-			this.setState({
-				itemExclusive,
-			});
-		},
-	};
+	/**
+	 * Requests and sets exclusive state of an widget.
+	 *
+	 * @instance
+	 * @memberof WidgetExclusive
+	 * @method requestExclusive
+	 * @param {Object} itemExclusive The widget which requests exclusive state.
+	 */
+	requestExclusive(itemExclusive) {
+		this.setState({
+			itemExclusive,
+		});
+	},
+};
 
-	AlloyEditor.WidgetExclusive = WidgetExclusive;
-})();
+export default WidgetExclusive;

--- a/src/components/compat/widget-focus-manager.js
+++ b/src/components/compat/widget-focus-manager.js
@@ -1,0 +1,392 @@
+(function() {
+    'use strict';
+
+    var DIRECTION_NONE = 0;
+    var DIRECTION_NEXT = 1;
+    var DIRECTION_PREV = -1;
+
+    var ACTION_NONE = 0;
+    var ACTION_MOVE_FOCUS = 1;
+    var ACTION_DISMISS_FOCUS = 2;
+
+    /**
+     * WidgetFocusManager is a mixin that provides keyboard navigation inside a widget. To do this,
+     * it exposes the following props and methods:
+     *
+     * @class WidgetFocusManager
+     */
+    var WidgetFocusManager = {
+        // Allows validating props being passed to the component.
+        propTypes: {
+
+            /**
+             * Callback method to be invoked when the focus manager is to be dismissed. This happens
+             * in the following scenarios if a dismiss callback has been specified:
+             * - A dismiss key has been pressed
+             * - In a non-circular focus manager, when:
+             *     - The active descendant is the first one and a prev key has been pressed.
+             *     - The active descendant is the last one and a next key has been pressed.
+             *
+             * @instance
+             * @memberof WidgetFocusManager
+             * @property {Function} onDismiss
+             */
+            onDismiss: PropTypes.func,
+
+            /**
+             * Indicates if focus should be set to the first/last descendant when the limits are reached.
+             *
+             * @instance
+             * @memberof WidgetFocusManager
+             * @property {boolean} circular
+             */
+            circular: PropTypes.bool.isRequired,
+
+            /**
+             * Indicate if should focus the first child of a container
+             * @instance
+             * @memberof WidgetFocusManager
+             * @property {Boolean} focusFirstChild
+             */
+            focusFirstChild: PropTypes.bool,
+
+            /**
+             * String representing the CSS selector used to define the elements that should be handled.
+             *
+             * @instance
+             * @memberof WidgetFocusManager
+             * @property {String} descendants
+             */
+            descendants: PropTypes.string.isRequired,
+
+            /**
+             * Object representing the keys used to navigate between descendants. The format for the prop is:
+             * `{dismiss: value, dismissNext: value, dismissPrev: value, next: value, prev: value}` where
+             * value can be both a number or an array of numbers with the allowed keyCodes.
+             *
+             * @instance
+             * @memberof WidgetFocusManager
+             * @property {Object} keys
+             */
+            keys: PropTypes.object.isRequired
+        },
+
+        /**
+         * Lifecycle. Invoked once, only on the client, immediately after the initial rendering occurs.
+         *
+         * @instance
+         * @memberof WidgetFocusManager
+         * @method componentDidMount
+         */
+        componentDidMount: function() {
+            this._refresh();
+        },
+
+        /**
+         * Lifecycle. Invoked immediately after the component's updates are flushed to the DOM.
+         * Refreshes the descendants list.
+         *
+         * @instance
+         * @memberof WidgetFocusManager
+         * @method componentDidUpdate
+         */
+        componentDidUpdate: function() {
+            this._refresh();
+        },
+
+        /**
+         * Focuses the current active descendant.
+         *
+         * Several Widgets can be nested in a component hierarchy by attaching this focus method to
+         * the widget DOM node, transferring the DOM focus control to the inner FocusManager.
+         *
+         * @instance
+         * @memberof WidgetFocusManager
+         * @method focus
+         */
+        focus: function(event) {
+            if (!event || this._isValidTarget(event.target)) {
+                if (this._descendants && this._descendants.length) {
+                    var activeDescendantEl = this._descendants[this._activeDescendant];
+                    // When user clicks with the mouse, the activeElement is already set and there
+                    // is no need to focus it. Focusing of the active descendant (usually some button) is required
+                    // in case of keyboard navigation, because the focused element might be not the first button,
+                    // but the div element, which contains the button.
+                    if (document.activeElement !== activeDescendantEl && !this.props.focusFirstChild) {
+                        if (this._descendants.indexOf(document.activeElement) === -1) {
+                            activeDescendantEl.focus();
+                        }
+                    }
+
+                    if (event) {
+                        event.stopPropagation();
+                        event.preventDefault();
+                    }
+                }
+            }
+        },
+
+        /**
+         * Handles the key events on a DOM node to execute the appropriate navigation when needed.
+         *
+         * @instance
+         * @memberof WidgetFocusManager
+         * @param {Object} event The Keyboard event that was detected on the widget DOM node.
+         * @method handleKey
+         */
+        handleKey: function(event) {
+            if (this._isValidTarget(event.target) && this._descendants) {
+                var action = this._getFocusAction(event);
+
+                if (action.type) {
+                    event.stopPropagation();
+                    event.preventDefault();
+
+                    if (action.type === ACTION_MOVE_FOCUS) {
+                        this._moveFocus(action.direction);
+                    }
+
+                    if (action.type === ACTION_DISMISS_FOCUS) {
+                        this.props.onDismiss(action.direction);
+                    }
+                }
+            }
+        },
+
+        /**
+         * Moves the focus among descendants in the especified direction.
+         *
+         * @instance
+         * @memberof WidgetFocusManager
+         * @method moveFocus
+         * @param {number} direction The direction (1 or -1) of the focus movement among descendants.
+         */
+        moveFocus: function(direction) {
+            direction = AlloyEditor.Lang.isNumber(direction) ? direction : 0;
+
+            this._moveFocus(direction);
+        },
+
+        /**
+         * Returns the action, if any, that a keyboard event in the current focus manager state
+         * should produce.
+         *
+         * @instance
+         * @memberof WidgetFocusManager
+         * @method _getFocusAction
+         * @param {object} event The Keyboard event.
+         * @protected
+         * @return {Object} An action object with type and direction properties.
+         */
+        _getFocusAction: function(event) {
+            var action = {
+                type: ACTION_NONE
+            };
+
+            if (this.props.keys) {
+                var direction = this._getFocusMoveDirection(event);
+
+                if (direction) {
+                    action.direction = direction;
+                    action.type = ACTION_MOVE_FOCUS;
+                }
+
+                var dismissAction = this._getFocusDismissAction(event, direction);
+
+                if (dismissAction.dismiss) {
+                    action.direction = dismissAction.direction;
+                    action.type = ACTION_DISMISS_FOCUS;
+                }
+            }
+
+            return action;
+        },
+
+        /**
+         * Returns the dismiss action, if any, the focus manager should execute to yield the focus. This
+         * will happen in any of these scenarios if a dismiss callback has been specified:
+         * - A dismiss key has been pressed
+         * - In a non-circular focus manager, when:
+         *     - The active descendant is the first one and a prev key has been pressed.
+         *     - The active descendant is the last one and a next key has been pressed.
+         *
+         * @instance
+         * @memberof WidgetFocusManager
+         * @method _getFocusDismissAction
+         * @param {Number} focusMoveDirection The focus movement direction (if any).
+         * @param {Object} event The Keyboard event.
+         * @protected
+         * @return {Object} A dismiss action with dismiss and direction properties.
+         */
+        _getFocusDismissAction: function(event, focusMoveDirection) {
+            var dismissAction = {
+                direction: focusMoveDirection,
+                dismiss: false
+            };
+
+            if (this.props.onDismiss) {
+                if (this._isValidKey(event.keyCode, this.props.keys.dismiss)) {
+                    dismissAction.dismiss = true;
+                }
+                if (this._isValidKey(event.keyCode, this.props.keys.dismissNext)) {
+                    dismissAction.dismiss = true;
+                    dismissAction.direction = DIRECTION_NEXT;
+                }
+                if (this._isValidKey(event.keyCode, this.props.keys.dismissPrev)) {
+                    dismissAction.dismiss = true;
+                    dismissAction.direction = DIRECTION_PREV;
+                }
+
+                if (!dismissAction.dismiss && !this.props.circular && focusMoveDirection) {
+                    dismissAction.dismiss = (
+                        focusMoveDirection === DIRECTION_PREV && this._activeDescendant === 0 ||
+                        focusMoveDirection === DIRECTION_NEXT && this._activeDescendant === this._descendants.length - 1
+                    );
+                }
+            }
+
+            return dismissAction;
+        },
+
+        /**
+         * Returns the direction, if any, in which the focus should be moved. In presence of the
+         * shift key modifier, the direction of the movement is inverted.
+         *
+         * @instance
+         * @memberof WidgetFocusManager
+         * @method _getFocusMoveDirection
+         * @param {Object} event The Keyboard event.
+         * @protected
+         * @return {Number} The computed direction of the expected focus movement.
+         */
+        _getFocusMoveDirection: function(event) {
+            var direction = DIRECTION_NONE;
+
+            if (this._isValidKey(event.keyCode, this.props.keys.next)) {
+                direction = DIRECTION_NEXT;
+            }
+            if (this._isValidKey(event.keyCode, this.props.keys.prev)) {
+                direction = DIRECTION_PREV;
+            }
+
+            if (event.shifKey) {
+                direction *= -1;
+            }
+
+            return direction;
+        },
+
+        /**
+         * Indicates if a given keyCode is valid for the given set of keys.
+         *
+         * @instance
+         * @memberof WidgetFocusManager
+         * @method _isValidKey
+         * @param {Array|Number} keys A key set. Can be a number an array of numbers representing the allowed keyCodes.
+         * @param {Number} keyCode An event keyCode.
+         * @protected
+         * @return {Boolean} A boolean value indicating if the key is valid.
+         */
+        _isValidKey: function(keyCode, keys) {
+            return AlloyEditor.Lang.isArray(keys) ? (keys.indexOf(keyCode) !== -1) : (keyCode === keys);
+        },
+
+        /**
+         * Indicates if a given element is valid for focus management. User input elements such as
+         * input, select or textarea are excluded.
+         *
+         * @instance
+         * @memberof WidgetFocusManager
+         * @method _isValidKey
+         * @param {DOMNode} element A DOM element.
+         * @protected
+         * @return {Boolean} A boolean value indicating if the element is valid.
+         */
+        _isValidTarget: function(element) {
+            var tagName = element.tagName.toLowerCase();
+
+            return (tagName !== 'input' && tagName !== 'select' && tagName !== 'textarea');
+        },
+
+        /**
+         * Moves the focus among descendants in the especified direction.
+         *
+         * @instance
+         * @memberof WidgetFocusManager
+         * @method _moveFocus
+         * @param {number} direction The direction (1 or -1) of the focus movement among descendants.
+         * @protected
+         */
+        _moveFocus: function(direction) {
+            var numDescendants = this._descendants.length;
+
+            var descendant = this._descendants[this._activeDescendant];
+
+            descendant.setAttribute('tabIndex', -1);
+
+            this._activeDescendant += direction;
+
+            if (this.props.circular) {
+                // Calculate proper modulo result since remainder operator doesn't behave in the
+                // same way for negative numbers
+                this._activeDescendant = ((this._activeDescendant % numDescendants) + numDescendants) % numDescendants;
+            } else {
+                this._activeDescendant = Math.max(Math.min(this._activeDescendant, numDescendants - 1), 0);
+            }
+
+            descendant = this._descendants[this._activeDescendant];
+
+            descendant.setAttribute('tabIndex', 0);
+            descendant.focus();
+        },
+
+        /**
+         * Refreshes the descendants list by executing the CSS selector again and resets the descendants tabIndex.
+         *
+         * @instance
+         * @memberof WidgetFocusManager
+         * @method _refresh
+         * @protected
+         */
+        _refresh: function() {
+            var domNode = ReactDOM.findDOMNode(this);
+
+            if (domNode) {
+                var descendants = domNode.querySelectorAll(this.props.descendants);
+
+                var priorityDescendants = [];
+
+                this._descendants = [];
+
+                Array.prototype.slice.call(descendants).forEach(function(item) {
+                    var dataTabIndex = item.getAttribute('data-tabindex');
+
+                    if (dataTabIndex) {
+                        priorityDescendants.push(item);
+                    } else {
+                        this._descendants.push(item);
+                    }
+                }.bind(this));
+
+                priorityDescendants = priorityDescendants.sort(function(a, b) {
+                    return (AlloyEditor.Lang.toInt(a.getAttribute('data-tabindex')) > AlloyEditor.Lang.toInt(b.getAttribute('data-tabindex')));
+                });
+
+                this._descendants = priorityDescendants.concat(this._descendants);
+
+                this._activeDescendant = 0;
+
+                this._descendants.some(function(item, index) {
+                    if (item.getAttribute('tabindex') === '0') {
+                        this._activeDescendant = index;
+                        this.focus();
+
+                        return true;
+                    }
+                }.bind(this));
+            }
+        }
+    };
+
+    AlloyEditor.WidgetFocusManager = WidgetFocusManager;
+}());

--- a/src/components/compat/widget-focus-manager.js
+++ b/src/components/compat/widget-focus-manager.js
@@ -1,224 +1,28 @@
 import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
 
-(function() {
-	'use strict';
+import Lang from '../../oop/lang';
 
-	var DIRECTION_NONE = 0;
-	var DIRECTION_NEXT = 1;
-	var DIRECTION_PREV = -1;
+const DIRECTION_NONE = 0;
+const DIRECTION_NEXT = 1;
+const DIRECTION_PREV = -1;
 
-	var ACTION_NONE = 0;
-	var ACTION_MOVE_FOCUS = 1;
-	var ACTION_DISMISS_FOCUS = 2;
+const ACTION_NONE = 0;
+const ACTION_MOVE_FOCUS = 1;
+const ACTION_DISMISS_FOCUS = 2;
 
-	/**
-	 * WidgetFocusManager is a mixin that provides keyboard navigation inside a widget. To do this,
-	 * it exposes the following props and methods:
-	 *
-	 * @class WidgetFocusManager
-	 */
-	var WidgetFocusManager = {
-		// Allows validating props being passed to the component.
-		propTypes: {
-			/**
-			 * Callback method to be invoked when the focus manager is to be dismissed. This happens
-			 * in the following scenarios if a dismiss callback has been specified:
-			 * - A dismiss key has been pressed
-			 * - In a non-circular focus manager, when:
-			 *     - The active descendant is the first one and a prev key has been pressed.
-			 *     - The active descendant is the last one and a next key has been pressed.
-			 *
-			 * @instance
-			 * @memberof WidgetFocusManager
-			 * @property {Function} onDismiss
-			 */
-			onDismiss: PropTypes.func,
-
-			/**
-			 * Indicates if focus should be set to the first/last descendant when the limits are reached.
-			 *
-			 * @instance
-			 * @memberof WidgetFocusManager
-			 * @property {boolean} circular
-			 */
-			circular: PropTypes.bool.isRequired,
-
-			/**
-			 * Indicate if should focus the first child of a container
-			 * @instance
-			 * @memberof WidgetFocusManager
-			 * @property {Boolean} focusFirstChild
-			 */
-			focusFirstChild: PropTypes.bool,
-
-			/**
-			 * String representing the CSS selector used to define the elements that should be handled.
-			 *
-			 * @instance
-			 * @memberof WidgetFocusManager
-			 * @property {String} descendants
-			 */
-			descendants: PropTypes.string.isRequired,
-
-			/**
-			 * Object representing the keys used to navigate between descendants. The format for the prop is:
-			 * `{dismiss: value, dismissNext: value, dismissPrev: value, next: value, prev: value}` where
-			 * value can be both a number or an array of numbers with the allowed keyCodes.
-			 *
-			 * @instance
-			 * @memberof WidgetFocusManager
-			 * @property {Object} keys
-			 */
-			keys: PropTypes.object.isRequired,
-		},
-
+/**
+ * WidgetFocusManager is a mixin that provides keyboard navigation inside a widget. To do this,
+ * it exposes the following props and methods:
+ *
+ * @class WidgetFocusManager
+ */
+const WidgetFocusManager = {
+	// Allows validating props being passed to the component.
+	propTypes: {
 		/**
-		 * Lifecycle. Invoked once, only on the client, immediately after the initial rendering occurs.
-		 *
-		 * @instance
-		 * @memberof WidgetFocusManager
-		 * @method componentDidMount
-		 */
-		componentDidMount() {
-			this._refresh();
-		},
-
-		/**
-		 * Lifecycle. Invoked immediately after the component's updates are flushed to the DOM.
-		 * Refreshes the descendants list.
-		 *
-		 * @instance
-		 * @memberof WidgetFocusManager
-		 * @method componentDidUpdate
-		 */
-		componentDidUpdate() {
-			this._refresh();
-		},
-
-		/**
-		 * Focuses the current active descendant.
-		 *
-		 * Several Widgets can be nested in a component hierarchy by attaching this focus method to
-		 * the widget DOM node, transferring the DOM focus control to the inner FocusManager.
-		 *
-		 * @instance
-		 * @memberof WidgetFocusManager
-		 * @method focus
-		 */
-		focus(event) {
-			if (!event || this._isValidTarget(event.target)) {
-				if (this._descendants && this._descendants.length) {
-					var activeDescendantEl = this._descendants[
-						this._activeDescendant
-					];
-					// When user clicks with the mouse, the activeElement is already set and there
-					// is no need to focus it. Focusing of the active descendant (usually some button) is required
-					// in case of keyboard navigation, because the focused element might be not the first button,
-					// but the div element, which contains the button.
-					if (
-						document.activeElement !== activeDescendantEl &&
-						!this.props.focusFirstChild
-					) {
-						if (
-							this._descendants.indexOf(
-								document.activeElement
-							) === -1
-						) {
-							activeDescendantEl.focus();
-						}
-					}
-
-					if (event) {
-						event.stopPropagation();
-						event.preventDefault();
-					}
-				}
-			}
-		},
-
-		/**
-		 * Handles the key events on a DOM node to execute the appropriate navigation when needed.
-		 *
-		 * @instance
-		 * @memberof WidgetFocusManager
-		 * @param {Object} event The Keyboard event that was detected on the widget DOM node.
-		 * @method handleKey
-		 */
-		handleKey(event) {
-			if (this._isValidTarget(event.target) && this._descendants) {
-				var action = this._getFocusAction(event);
-
-				if (action.type) {
-					event.stopPropagation();
-					event.preventDefault();
-
-					if (action.type === ACTION_MOVE_FOCUS) {
-						this._moveFocus(action.direction);
-					}
-
-					if (action.type === ACTION_DISMISS_FOCUS) {
-						this.props.onDismiss(action.direction);
-					}
-				}
-			}
-		},
-
-		/**
-		 * Moves the focus among descendants in the especified direction.
-		 *
-		 * @instance
-		 * @memberof WidgetFocusManager
-		 * @method moveFocus
-		 * @param {number} direction The direction (1 or -1) of the focus movement among descendants.
-		 */
-		moveFocus(direction) {
-			direction = AlloyEditor.Lang.isNumber(direction) ? direction : 0;
-
-			this._moveFocus(direction);
-		},
-
-		/**
-		 * Returns the action, if any, that a keyboard event in the current focus manager state
-		 * should produce.
-		 *
-		 * @instance
-		 * @memberof WidgetFocusManager
-		 * @method _getFocusAction
-		 * @param {object} event The Keyboard event.
-		 * @protected
-		 * @return {Object} An action object with type and direction properties.
-		 */
-		_getFocusAction(event) {
-			var action = {
-				type: ACTION_NONE,
-			};
-
-			if (this.props.keys) {
-				var direction = this._getFocusMoveDirection(event);
-
-				if (direction) {
-					action.direction = direction;
-					action.type = ACTION_MOVE_FOCUS;
-				}
-
-				var dismissAction = this._getFocusDismissAction(
-					event,
-					direction
-				);
-
-				if (dismissAction.dismiss) {
-					action.direction = dismissAction.direction;
-					action.type = ACTION_DISMISS_FOCUS;
-				}
-			}
-
-			return action;
-		},
-
-		/**
-		 * Returns the dismiss action, if any, the focus manager should execute to yield the focus. This
-		 * will happen in any of these scenarios if a dismiss callback has been specified:
+		 * Callback method to be invoked when the focus manager is to be dismissed. This happens
+		 * in the following scenarios if a dismiss callback has been specified:
 		 * - A dismiss key has been pressed
 		 * - In a non-circular focus manager, when:
 		 *     - The active descendant is the first one and a prev key has been pressed.
@@ -226,212 +30,392 @@ import ReactDOM from 'react-dom';
 		 *
 		 * @instance
 		 * @memberof WidgetFocusManager
-		 * @method _getFocusDismissAction
-		 * @param {Number} focusMoveDirection The focus movement direction (if any).
-		 * @param {Object} event The Keyboard event.
-		 * @protected
-		 * @return {Object} A dismiss action with dismiss and direction properties.
+		 * @property {Function} onDismiss
 		 */
-		_getFocusDismissAction(event, focusMoveDirection) {
-			var dismissAction = {
-				direction: focusMoveDirection,
-				dismiss: false,
-			};
-
-			if (this.props.onDismiss) {
-				if (this._isValidKey(event.keyCode, this.props.keys.dismiss)) {
-					dismissAction.dismiss = true;
-				}
-				if (
-					this._isValidKey(event.keyCode, this.props.keys.dismissNext)
-				) {
-					dismissAction.dismiss = true;
-					dismissAction.direction = DIRECTION_NEXT;
-				}
-				if (
-					this._isValidKey(event.keyCode, this.props.keys.dismissPrev)
-				) {
-					dismissAction.dismiss = true;
-					dismissAction.direction = DIRECTION_PREV;
-				}
-
-				if (
-					!dismissAction.dismiss &&
-					!this.props.circular &&
-					focusMoveDirection
-				) {
-					dismissAction.dismiss =
-						(focusMoveDirection === DIRECTION_PREV &&
-							this._activeDescendant === 0) ||
-						(focusMoveDirection === DIRECTION_NEXT &&
-							this._activeDescendant ===
-								this._descendants.length - 1);
-				}
-			}
-
-			return dismissAction;
-		},
+		onDismiss: PropTypes.func,
 
 		/**
-		 * Returns the direction, if any, in which the focus should be moved. In presence of the
-		 * shift key modifier, the direction of the movement is inverted.
+		 * Indicates if focus should be set to the first/last descendant when the limits are reached.
 		 *
 		 * @instance
 		 * @memberof WidgetFocusManager
-		 * @method _getFocusMoveDirection
-		 * @param {Object} event The Keyboard event.
-		 * @protected
-		 * @return {Number} The computed direction of the expected focus movement.
+		 * @property {boolean} circular
 		 */
-		_getFocusMoveDirection(event) {
-			var direction = DIRECTION_NONE;
-
-			if (this._isValidKey(event.keyCode, this.props.keys.next)) {
-				direction = DIRECTION_NEXT;
-			}
-			if (this._isValidKey(event.keyCode, this.props.keys.prev)) {
-				direction = DIRECTION_PREV;
-			}
-
-			if (event.shifKey) {
-				direction *= -1;
-			}
-
-			return direction;
-		},
+		circular: PropTypes.bool.isRequired,
 
 		/**
-		 * Indicates if a given keyCode is valid for the given set of keys.
+		 * Indicate if should focus the first child of a container
+		 * @instance
+		 * @memberof WidgetFocusManager
+		 * @property {Boolean} focusFirstChild
+		 */
+		focusFirstChild: PropTypes.bool,
+
+		/**
+		 * String representing the CSS selector used to define the elements that should be handled.
 		 *
 		 * @instance
 		 * @memberof WidgetFocusManager
-		 * @method _isValidKey
-		 * @param {Array|Number} keys A key set. Can be a number an array of numbers representing the allowed keyCodes.
-		 * @param {Number} keyCode An event keyCode.
-		 * @protected
-		 * @return {Boolean} A boolean value indicating if the key is valid.
+		 * @property {String} descendants
 		 */
-		_isValidKey(keyCode, keys) {
-			return AlloyEditor.Lang.isArray(keys)
-				? keys.indexOf(keyCode) !== -1
-				: keyCode === keys;
-		},
+		descendants: PropTypes.string.isRequired,
 
 		/**
-		 * Indicates if a given element is valid for focus management. User input elements such as
-		 * input, select or textarea are excluded.
+		 * Object representing the keys used to navigate between descendants. The format for the prop is:
+		 * `{dismiss: value, dismissNext: value, dismissPrev: value, next: value, prev: value}` where
+		 * value can be both a number or an array of numbers with the allowed keyCodes.
 		 *
 		 * @instance
 		 * @memberof WidgetFocusManager
-		 * @method _isValidKey
-		 * @param {DOMNode} element A DOM element.
-		 * @protected
-		 * @return {Boolean} A boolean value indicating if the element is valid.
+		 * @property {Object} keys
 		 */
-		_isValidTarget(element) {
-			var tagName = element.tagName.toLowerCase();
+		keys: PropTypes.object.isRequired,
+	},
 
-			return (
-				tagName !== 'input' &&
-				tagName !== 'select' &&
-				tagName !== 'textarea'
+	/**
+	 * Lifecycle. Invoked once, only on the client, immediately after the initial rendering occurs.
+	 *
+	 * @instance
+	 * @memberof WidgetFocusManager
+	 * @method componentDidMount
+	 */
+	componentDidMount() {
+		this._refresh();
+	},
+
+	/**
+	 * Lifecycle. Invoked immediately after the component's updates are flushed to the DOM.
+	 * Refreshes the descendants list.
+	 *
+	 * @instance
+	 * @memberof WidgetFocusManager
+	 * @method componentDidUpdate
+	 */
+	componentDidUpdate() {
+		this._refresh();
+	},
+
+	/**
+	 * Focuses the current active descendant.
+	 *
+	 * Several Widgets can be nested in a component hierarchy by attaching this focus method to
+	 * the widget DOM node, transferring the DOM focus control to the inner FocusManager.
+	 *
+	 * @instance
+	 * @memberof WidgetFocusManager
+	 * @method focus
+	 */
+	focus(event) {
+		if (!event || this._isValidTarget(event.target)) {
+			if (this._descendants && this._descendants.length) {
+				const activeDescendantEl = this._descendants[
+					this._activeDescendant
+				];
+				// When user clicks with the mouse, the activeElement is already set and there
+				// is no need to focus it. Focusing of the active descendant (usually some button) is required
+				// in case of keyboard navigation, because the focused element might be not the first button,
+				// but the div element, which contains the button.
+				if (
+					document.activeElement !== activeDescendantEl &&
+					!this.props.focusFirstChild
+				) {
+					if (
+						this._descendants.indexOf(document.activeElement) === -1
+					) {
+						activeDescendantEl.focus();
+					}
+				}
+
+				if (event) {
+					event.stopPropagation();
+					event.preventDefault();
+				}
+			}
+		}
+	},
+
+	/**
+	 * Handles the key events on a DOM node to execute the appropriate navigation when needed.
+	 *
+	 * @instance
+	 * @memberof WidgetFocusManager
+	 * @param {Object} event The Keyboard event that was detected on the widget DOM node.
+	 * @method handleKey
+	 */
+	handleKey(event) {
+		if (this._isValidTarget(event.target) && this._descendants) {
+			const action = this._getFocusAction(event);
+
+			if (action.type) {
+				event.stopPropagation();
+				event.preventDefault();
+
+				if (action.type === ACTION_MOVE_FOCUS) {
+					this._moveFocus(action.direction);
+				}
+
+				if (action.type === ACTION_DISMISS_FOCUS) {
+					this.props.onDismiss(action.direction);
+				}
+			}
+		}
+	},
+
+	/**
+	 * Moves the focus among descendants in the especified direction.
+	 *
+	 * @instance
+	 * @memberof WidgetFocusManager
+	 * @method moveFocus
+	 * @param {number} direction The direction (1 or -1) of the focus movement among descendants.
+	 */
+	moveFocus(direction) {
+		direction = Lang.isNumber(direction) ? direction : 0;
+
+		this._moveFocus(direction);
+	},
+
+	/**
+	 * Returns the action, if any, that a keyboard event in the current focus manager state
+	 * should produce.
+	 *
+	 * @instance
+	 * @memberof WidgetFocusManager
+	 * @method _getFocusAction
+	 * @param {object} event The Keyboard event.
+	 * @protected
+	 * @return {Object} An action object with type and direction properties.
+	 */
+	_getFocusAction(event) {
+		const action = {
+			type: ACTION_NONE,
+		};
+
+		if (this.props.keys) {
+			const direction = this._getFocusMoveDirection(event);
+
+			if (direction) {
+				action.direction = direction;
+				action.type = ACTION_MOVE_FOCUS;
+			}
+
+			const dismissAction = this._getFocusDismissAction(event, direction);
+
+			if (dismissAction.dismiss) {
+				action.direction = dismissAction.direction;
+				action.type = ACTION_DISMISS_FOCUS;
+			}
+		}
+
+		return action;
+	},
+
+	/**
+	 * Returns the dismiss action, if any, the focus manager should execute to yield the focus. This
+	 * will happen in any of these scenarios if a dismiss callback has been specified:
+	 * - A dismiss key has been pressed
+	 * - In a non-circular focus manager, when:
+	 *     - The active descendant is the first one and a prev key has been pressed.
+	 *     - The active descendant is the last one and a next key has been pressed.
+	 *
+	 * @instance
+	 * @memberof WidgetFocusManager
+	 * @method _getFocusDismissAction
+	 * @param {Number} focusMoveDirection The focus movement direction (if any).
+	 * @param {Object} event The Keyboard event.
+	 * @protected
+	 * @return {Object} A dismiss action with dismiss and direction properties.
+	 */
+	_getFocusDismissAction(event, focusMoveDirection) {
+		const dismissAction = {
+			direction: focusMoveDirection,
+			dismiss: false,
+		};
+
+		if (this.props.onDismiss) {
+			if (this._isValidKey(event.keyCode, this.props.keys.dismiss)) {
+				dismissAction.dismiss = true;
+			}
+			if (this._isValidKey(event.keyCode, this.props.keys.dismissNext)) {
+				dismissAction.dismiss = true;
+				dismissAction.direction = DIRECTION_NEXT;
+			}
+			if (this._isValidKey(event.keyCode, this.props.keys.dismissPrev)) {
+				dismissAction.dismiss = true;
+				dismissAction.direction = DIRECTION_PREV;
+			}
+
+			if (
+				!dismissAction.dismiss &&
+				!this.props.circular &&
+				focusMoveDirection
+			) {
+				dismissAction.dismiss =
+					(focusMoveDirection === DIRECTION_PREV &&
+						this._activeDescendant === 0) ||
+					(focusMoveDirection === DIRECTION_NEXT &&
+						this._activeDescendant ===
+							this._descendants.length - 1);
+			}
+		}
+
+		return dismissAction;
+	},
+
+	/**
+	 * Returns the direction, if any, in which the focus should be moved. In presence of the
+	 * shift key modifier, the direction of the movement is inverted.
+	 *
+	 * @instance
+	 * @memberof WidgetFocusManager
+	 * @method _getFocusMoveDirection
+	 * @param {Object} event The Keyboard event.
+	 * @protected
+	 * @return {Number} The computed direction of the expected focus movement.
+	 */
+	_getFocusMoveDirection(event) {
+		let direction = DIRECTION_NONE;
+
+		if (this._isValidKey(event.keyCode, this.props.keys.next)) {
+			direction = DIRECTION_NEXT;
+		}
+		if (this._isValidKey(event.keyCode, this.props.keys.prev)) {
+			direction = DIRECTION_PREV;
+		}
+
+		if (event.shifKey) {
+			direction *= -1;
+		}
+
+		return direction;
+	},
+
+	/**
+	 * Indicates if a given keyCode is valid for the given set of keys.
+	 *
+	 * @instance
+	 * @memberof WidgetFocusManager
+	 * @method _isValidKey
+	 * @param {Array|Number} keys A key set. Can be a number an array of numbers representing the allowed keyCodes.
+	 * @param {Number} keyCode An event keyCode.
+	 * @protected
+	 * @return {Boolean} A boolean value indicating if the key is valid.
+	 */
+	_isValidKey(keyCode, keys) {
+		return Lang.isArray(keys)
+			? keys.indexOf(keyCode) !== -1
+			: keyCode === keys;
+	},
+
+	/**
+	 * Indicates if a given element is valid for focus management. User input elements such as
+	 * input, select or textarea are excluded.
+	 *
+	 * @instance
+	 * @memberof WidgetFocusManager
+	 * @method _isValidKey
+	 * @param {DOMNode} element A DOM element.
+	 * @protected
+	 * @return {Boolean} A boolean value indicating if the element is valid.
+	 */
+	_isValidTarget(element) {
+		const tagName = element.tagName.toLowerCase();
+
+		return (
+			tagName !== 'input' &&
+			tagName !== 'select' &&
+			tagName !== 'textarea'
+		);
+	},
+
+	/**
+	 * Moves the focus among descendants in the especified direction.
+	 *
+	 * @instance
+	 * @memberof WidgetFocusManager
+	 * @method _moveFocus
+	 * @param {number} direction The direction (1 or -1) of the focus movement among descendants.
+	 * @protected
+	 */
+	_moveFocus(direction) {
+		const numDescendants = this._descendants.length;
+
+		let descendant = this._descendants[this._activeDescendant];
+
+		descendant.setAttribute('tabIndex', -1);
+
+		this._activeDescendant += direction;
+
+		if (this.props.circular) {
+			// Calculate proper modulo result since remainder operator doesn't behave in the
+			// same way for negative numbers
+			this._activeDescendant =
+				((this._activeDescendant % numDescendants) + numDescendants) %
+				numDescendants;
+		} else {
+			this._activeDescendant = Math.max(
+				Math.min(this._activeDescendant, numDescendants - 1),
+				0
 			);
-		},
+		}
 
-		/**
-		 * Moves the focus among descendants in the especified direction.
-		 *
-		 * @instance
-		 * @memberof WidgetFocusManager
-		 * @method _moveFocus
-		 * @param {number} direction The direction (1 or -1) of the focus movement among descendants.
-		 * @protected
-		 */
-		_moveFocus(direction) {
-			var numDescendants = this._descendants.length;
+		descendant = this._descendants[this._activeDescendant];
 
-			var descendant = this._descendants[this._activeDescendant];
+		descendant.setAttribute('tabIndex', 0);
+		descendant.focus();
+	},
 
-			descendant.setAttribute('tabIndex', -1);
+	/**
+	 * Refreshes the descendants list by executing the CSS selector again and resets the descendants tabIndex.
+	 *
+	 * @instance
+	 * @memberof WidgetFocusManager
+	 * @method _refresh
+	 * @protected
+	 */
+	_refresh() {
+		const domNode = ReactDOM.findDOMNode(this);
 
-			this._activeDescendant += direction;
+		if (domNode) {
+			const descendants = domNode.querySelectorAll(
+				this.props.descendants
+			);
 
-			if (this.props.circular) {
-				// Calculate proper modulo result since remainder operator doesn't behave in the
-				// same way for negative numbers
-				this._activeDescendant =
-					((this._activeDescendant % numDescendants) +
-						numDescendants) %
-					numDescendants;
-			} else {
-				this._activeDescendant = Math.max(
-					Math.min(this._activeDescendant, numDescendants - 1),
-					0
+			let priorityDescendants = [];
+
+			this._descendants = [];
+
+			Array.prototype.slice.call(descendants).forEach(item => {
+				const dataTabIndex = item.getAttribute('data-tabindex');
+
+				if (dataTabIndex) {
+					priorityDescendants.push(item);
+				} else {
+					this._descendants.push(item);
+				}
+			});
+
+			priorityDescendants = priorityDescendants.sort((a, b) => {
+				return (
+					Lang.toInt(a.getAttribute('data-tabindex')) >
+					Lang.toInt(b.getAttribute('data-tabindex'))
 				);
-			}
+			});
 
-			descendant = this._descendants[this._activeDescendant];
+			this._descendants = priorityDescendants.concat(this._descendants);
 
-			descendant.setAttribute('tabIndex', 0);
-			descendant.focus();
-		},
+			this._activeDescendant = 0;
 
-		/**
-		 * Refreshes the descendants list by executing the CSS selector again and resets the descendants tabIndex.
-		 *
-		 * @instance
-		 * @memberof WidgetFocusManager
-		 * @method _refresh
-		 * @protected
-		 */
-		_refresh() {
-			var domNode = ReactDOM.findDOMNode(this);
+			this._descendants.some((item, index) => {
+				if (item.getAttribute('tabindex') === '0') {
+					this._activeDescendant = index;
+					this.focus();
 
-			if (domNode) {
-				var descendants = domNode.querySelectorAll(
-					this.props.descendants
-				);
+					return true;
+				}
+			});
+		}
+	},
+};
 
-				var priorityDescendants = [];
-
-				this._descendants = [];
-
-				Array.prototype.slice.call(descendants).forEach(item => {
-					var dataTabIndex = item.getAttribute('data-tabindex');
-
-					if (dataTabIndex) {
-						priorityDescendants.push(item);
-					} else {
-						this._descendants.push(item);
-					}
-				});
-
-				priorityDescendants = priorityDescendants.sort((a, b) => {
-					return (
-						AlloyEditor.Lang.toInt(
-							a.getAttribute('data-tabindex')
-						) >
-						AlloyEditor.Lang.toInt(b.getAttribute('data-tabindex'))
-					);
-				});
-
-				this._descendants = priorityDescendants.concat(
-					this._descendants
-				);
-
-				this._activeDescendant = 0;
-
-				this._descendants.some((item, index) => {
-					if (item.getAttribute('tabindex') === '0') {
-						this._activeDescendant = index;
-						this.focus();
-
-						return true;
-					}
-				});
-			}
-		},
-	};
-
-	AlloyEditor.WidgetFocusManager = WidgetFocusManager;
-})();
+export default WidgetFocusManager;

--- a/src/components/compat/widget-focus-manager.js
+++ b/src/components/compat/widget-focus-manager.js
@@ -1,392 +1,434 @@
 (function() {
-    'use strict';
+	'use strict';
 
-    var DIRECTION_NONE = 0;
-    var DIRECTION_NEXT = 1;
-    var DIRECTION_PREV = -1;
+	var DIRECTION_NONE = 0;
+	var DIRECTION_NEXT = 1;
+	var DIRECTION_PREV = -1;
 
-    var ACTION_NONE = 0;
-    var ACTION_MOVE_FOCUS = 1;
-    var ACTION_DISMISS_FOCUS = 2;
+	var ACTION_NONE = 0;
+	var ACTION_MOVE_FOCUS = 1;
+	var ACTION_DISMISS_FOCUS = 2;
 
-    /**
-     * WidgetFocusManager is a mixin that provides keyboard navigation inside a widget. To do this,
-     * it exposes the following props and methods:
-     *
-     * @class WidgetFocusManager
-     */
-    var WidgetFocusManager = {
-        // Allows validating props being passed to the component.
-        propTypes: {
+	/**
+	 * WidgetFocusManager is a mixin that provides keyboard navigation inside a widget. To do this,
+	 * it exposes the following props and methods:
+	 *
+	 * @class WidgetFocusManager
+	 */
+	var WidgetFocusManager = {
+		// Allows validating props being passed to the component.
+		propTypes: {
+			/**
+			 * Callback method to be invoked when the focus manager is to be dismissed. This happens
+			 * in the following scenarios if a dismiss callback has been specified:
+			 * - A dismiss key has been pressed
+			 * - In a non-circular focus manager, when:
+			 *     - The active descendant is the first one and a prev key has been pressed.
+			 *     - The active descendant is the last one and a next key has been pressed.
+			 *
+			 * @instance
+			 * @memberof WidgetFocusManager
+			 * @property {Function} onDismiss
+			 */
+			onDismiss: PropTypes.func,
 
-            /**
-             * Callback method to be invoked when the focus manager is to be dismissed. This happens
-             * in the following scenarios if a dismiss callback has been specified:
-             * - A dismiss key has been pressed
-             * - In a non-circular focus manager, when:
-             *     - The active descendant is the first one and a prev key has been pressed.
-             *     - The active descendant is the last one and a next key has been pressed.
-             *
-             * @instance
-             * @memberof WidgetFocusManager
-             * @property {Function} onDismiss
-             */
-            onDismiss: PropTypes.func,
+			/**
+			 * Indicates if focus should be set to the first/last descendant when the limits are reached.
+			 *
+			 * @instance
+			 * @memberof WidgetFocusManager
+			 * @property {boolean} circular
+			 */
+			circular: PropTypes.bool.isRequired,
 
-            /**
-             * Indicates if focus should be set to the first/last descendant when the limits are reached.
-             *
-             * @instance
-             * @memberof WidgetFocusManager
-             * @property {boolean} circular
-             */
-            circular: PropTypes.bool.isRequired,
+			/**
+			 * Indicate if should focus the first child of a container
+			 * @instance
+			 * @memberof WidgetFocusManager
+			 * @property {Boolean} focusFirstChild
+			 */
+			focusFirstChild: PropTypes.bool,
 
-            /**
-             * Indicate if should focus the first child of a container
-             * @instance
-             * @memberof WidgetFocusManager
-             * @property {Boolean} focusFirstChild
-             */
-            focusFirstChild: PropTypes.bool,
+			/**
+			 * String representing the CSS selector used to define the elements that should be handled.
+			 *
+			 * @instance
+			 * @memberof WidgetFocusManager
+			 * @property {String} descendants
+			 */
+			descendants: PropTypes.string.isRequired,
 
-            /**
-             * String representing the CSS selector used to define the elements that should be handled.
-             *
-             * @instance
-             * @memberof WidgetFocusManager
-             * @property {String} descendants
-             */
-            descendants: PropTypes.string.isRequired,
+			/**
+			 * Object representing the keys used to navigate between descendants. The format for the prop is:
+			 * `{dismiss: value, dismissNext: value, dismissPrev: value, next: value, prev: value}` where
+			 * value can be both a number or an array of numbers with the allowed keyCodes.
+			 *
+			 * @instance
+			 * @memberof WidgetFocusManager
+			 * @property {Object} keys
+			 */
+			keys: PropTypes.object.isRequired,
+		},
 
-            /**
-             * Object representing the keys used to navigate between descendants. The format for the prop is:
-             * `{dismiss: value, dismissNext: value, dismissPrev: value, next: value, prev: value}` where
-             * value can be both a number or an array of numbers with the allowed keyCodes.
-             *
-             * @instance
-             * @memberof WidgetFocusManager
-             * @property {Object} keys
-             */
-            keys: PropTypes.object.isRequired
-        },
+		/**
+		 * Lifecycle. Invoked once, only on the client, immediately after the initial rendering occurs.
+		 *
+		 * @instance
+		 * @memberof WidgetFocusManager
+		 * @method componentDidMount
+		 */
+		componentDidMount() {
+			this._refresh();
+		},
 
-        /**
-         * Lifecycle. Invoked once, only on the client, immediately after the initial rendering occurs.
-         *
-         * @instance
-         * @memberof WidgetFocusManager
-         * @method componentDidMount
-         */
-        componentDidMount: function() {
-            this._refresh();
-        },
+		/**
+		 * Lifecycle. Invoked immediately after the component's updates are flushed to the DOM.
+		 * Refreshes the descendants list.
+		 *
+		 * @instance
+		 * @memberof WidgetFocusManager
+		 * @method componentDidUpdate
+		 */
+		componentDidUpdate() {
+			this._refresh();
+		},
 
-        /**
-         * Lifecycle. Invoked immediately after the component's updates are flushed to the DOM.
-         * Refreshes the descendants list.
-         *
-         * @instance
-         * @memberof WidgetFocusManager
-         * @method componentDidUpdate
-         */
-        componentDidUpdate: function() {
-            this._refresh();
-        },
+		/**
+		 * Focuses the current active descendant.
+		 *
+		 * Several Widgets can be nested in a component hierarchy by attaching this focus method to
+		 * the widget DOM node, transferring the DOM focus control to the inner FocusManager.
+		 *
+		 * @instance
+		 * @memberof WidgetFocusManager
+		 * @method focus
+		 */
+		focus(event) {
+			if (!event || this._isValidTarget(event.target)) {
+				if (this._descendants && this._descendants.length) {
+					var activeDescendantEl = this._descendants[
+						this._activeDescendant
+					];
+					// When user clicks with the mouse, the activeElement is already set and there
+					// is no need to focus it. Focusing of the active descendant (usually some button) is required
+					// in case of keyboard navigation, because the focused element might be not the first button,
+					// but the div element, which contains the button.
+					if (
+						document.activeElement !== activeDescendantEl &&
+						!this.props.focusFirstChild
+					) {
+						if (
+							this._descendants.indexOf(
+								document.activeElement
+							) === -1
+						) {
+							activeDescendantEl.focus();
+						}
+					}
 
-        /**
-         * Focuses the current active descendant.
-         *
-         * Several Widgets can be nested in a component hierarchy by attaching this focus method to
-         * the widget DOM node, transferring the DOM focus control to the inner FocusManager.
-         *
-         * @instance
-         * @memberof WidgetFocusManager
-         * @method focus
-         */
-        focus: function(event) {
-            if (!event || this._isValidTarget(event.target)) {
-                if (this._descendants && this._descendants.length) {
-                    var activeDescendantEl = this._descendants[this._activeDescendant];
-                    // When user clicks with the mouse, the activeElement is already set and there
-                    // is no need to focus it. Focusing of the active descendant (usually some button) is required
-                    // in case of keyboard navigation, because the focused element might be not the first button,
-                    // but the div element, which contains the button.
-                    if (document.activeElement !== activeDescendantEl && !this.props.focusFirstChild) {
-                        if (this._descendants.indexOf(document.activeElement) === -1) {
-                            activeDescendantEl.focus();
-                        }
-                    }
+					if (event) {
+						event.stopPropagation();
+						event.preventDefault();
+					}
+				}
+			}
+		},
 
-                    if (event) {
-                        event.stopPropagation();
-                        event.preventDefault();
-                    }
-                }
-            }
-        },
+		/**
+		 * Handles the key events on a DOM node to execute the appropriate navigation when needed.
+		 *
+		 * @instance
+		 * @memberof WidgetFocusManager
+		 * @param {Object} event The Keyboard event that was detected on the widget DOM node.
+		 * @method handleKey
+		 */
+		handleKey(event) {
+			if (this._isValidTarget(event.target) && this._descendants) {
+				var action = this._getFocusAction(event);
 
-        /**
-         * Handles the key events on a DOM node to execute the appropriate navigation when needed.
-         *
-         * @instance
-         * @memberof WidgetFocusManager
-         * @param {Object} event The Keyboard event that was detected on the widget DOM node.
-         * @method handleKey
-         */
-        handleKey: function(event) {
-            if (this._isValidTarget(event.target) && this._descendants) {
-                var action = this._getFocusAction(event);
+				if (action.type) {
+					event.stopPropagation();
+					event.preventDefault();
 
-                if (action.type) {
-                    event.stopPropagation();
-                    event.preventDefault();
+					if (action.type === ACTION_MOVE_FOCUS) {
+						this._moveFocus(action.direction);
+					}
 
-                    if (action.type === ACTION_MOVE_FOCUS) {
-                        this._moveFocus(action.direction);
-                    }
+					if (action.type === ACTION_DISMISS_FOCUS) {
+						this.props.onDismiss(action.direction);
+					}
+				}
+			}
+		},
 
-                    if (action.type === ACTION_DISMISS_FOCUS) {
-                        this.props.onDismiss(action.direction);
-                    }
-                }
-            }
-        },
+		/**
+		 * Moves the focus among descendants in the especified direction.
+		 *
+		 * @instance
+		 * @memberof WidgetFocusManager
+		 * @method moveFocus
+		 * @param {number} direction The direction (1 or -1) of the focus movement among descendants.
+		 */
+		moveFocus(direction) {
+			direction = AlloyEditor.Lang.isNumber(direction) ? direction : 0;
 
-        /**
-         * Moves the focus among descendants in the especified direction.
-         *
-         * @instance
-         * @memberof WidgetFocusManager
-         * @method moveFocus
-         * @param {number} direction The direction (1 or -1) of the focus movement among descendants.
-         */
-        moveFocus: function(direction) {
-            direction = AlloyEditor.Lang.isNumber(direction) ? direction : 0;
+			this._moveFocus(direction);
+		},
 
-            this._moveFocus(direction);
-        },
+		/**
+		 * Returns the action, if any, that a keyboard event in the current focus manager state
+		 * should produce.
+		 *
+		 * @instance
+		 * @memberof WidgetFocusManager
+		 * @method _getFocusAction
+		 * @param {object} event The Keyboard event.
+		 * @protected
+		 * @return {Object} An action object with type and direction properties.
+		 */
+		_getFocusAction(event) {
+			var action = {
+				type: ACTION_NONE,
+			};
 
-        /**
-         * Returns the action, if any, that a keyboard event in the current focus manager state
-         * should produce.
-         *
-         * @instance
-         * @memberof WidgetFocusManager
-         * @method _getFocusAction
-         * @param {object} event The Keyboard event.
-         * @protected
-         * @return {Object} An action object with type and direction properties.
-         */
-        _getFocusAction: function(event) {
-            var action = {
-                type: ACTION_NONE
-            };
+			if (this.props.keys) {
+				var direction = this._getFocusMoveDirection(event);
 
-            if (this.props.keys) {
-                var direction = this._getFocusMoveDirection(event);
+				if (direction) {
+					action.direction = direction;
+					action.type = ACTION_MOVE_FOCUS;
+				}
 
-                if (direction) {
-                    action.direction = direction;
-                    action.type = ACTION_MOVE_FOCUS;
-                }
+				var dismissAction = this._getFocusDismissAction(
+					event,
+					direction
+				);
 
-                var dismissAction = this._getFocusDismissAction(event, direction);
+				if (dismissAction.dismiss) {
+					action.direction = dismissAction.direction;
+					action.type = ACTION_DISMISS_FOCUS;
+				}
+			}
 
-                if (dismissAction.dismiss) {
-                    action.direction = dismissAction.direction;
-                    action.type = ACTION_DISMISS_FOCUS;
-                }
-            }
+			return action;
+		},
 
-            return action;
-        },
+		/**
+		 * Returns the dismiss action, if any, the focus manager should execute to yield the focus. This
+		 * will happen in any of these scenarios if a dismiss callback has been specified:
+		 * - A dismiss key has been pressed
+		 * - In a non-circular focus manager, when:
+		 *     - The active descendant is the first one and a prev key has been pressed.
+		 *     - The active descendant is the last one and a next key has been pressed.
+		 *
+		 * @instance
+		 * @memberof WidgetFocusManager
+		 * @method _getFocusDismissAction
+		 * @param {Number} focusMoveDirection The focus movement direction (if any).
+		 * @param {Object} event The Keyboard event.
+		 * @protected
+		 * @return {Object} A dismiss action with dismiss and direction properties.
+		 */
+		_getFocusDismissAction(event, focusMoveDirection) {
+			var dismissAction = {
+				direction: focusMoveDirection,
+				dismiss: false,
+			};
 
-        /**
-         * Returns the dismiss action, if any, the focus manager should execute to yield the focus. This
-         * will happen in any of these scenarios if a dismiss callback has been specified:
-         * - A dismiss key has been pressed
-         * - In a non-circular focus manager, when:
-         *     - The active descendant is the first one and a prev key has been pressed.
-         *     - The active descendant is the last one and a next key has been pressed.
-         *
-         * @instance
-         * @memberof WidgetFocusManager
-         * @method _getFocusDismissAction
-         * @param {Number} focusMoveDirection The focus movement direction (if any).
-         * @param {Object} event The Keyboard event.
-         * @protected
-         * @return {Object} A dismiss action with dismiss and direction properties.
-         */
-        _getFocusDismissAction: function(event, focusMoveDirection) {
-            var dismissAction = {
-                direction: focusMoveDirection,
-                dismiss: false
-            };
+			if (this.props.onDismiss) {
+				if (this._isValidKey(event.keyCode, this.props.keys.dismiss)) {
+					dismissAction.dismiss = true;
+				}
+				if (
+					this._isValidKey(event.keyCode, this.props.keys.dismissNext)
+				) {
+					dismissAction.dismiss = true;
+					dismissAction.direction = DIRECTION_NEXT;
+				}
+				if (
+					this._isValidKey(event.keyCode, this.props.keys.dismissPrev)
+				) {
+					dismissAction.dismiss = true;
+					dismissAction.direction = DIRECTION_PREV;
+				}
 
-            if (this.props.onDismiss) {
-                if (this._isValidKey(event.keyCode, this.props.keys.dismiss)) {
-                    dismissAction.dismiss = true;
-                }
-                if (this._isValidKey(event.keyCode, this.props.keys.dismissNext)) {
-                    dismissAction.dismiss = true;
-                    dismissAction.direction = DIRECTION_NEXT;
-                }
-                if (this._isValidKey(event.keyCode, this.props.keys.dismissPrev)) {
-                    dismissAction.dismiss = true;
-                    dismissAction.direction = DIRECTION_PREV;
-                }
+				if (
+					!dismissAction.dismiss &&
+					!this.props.circular &&
+					focusMoveDirection
+				) {
+					dismissAction.dismiss =
+						(focusMoveDirection === DIRECTION_PREV &&
+							this._activeDescendant === 0) ||
+						(focusMoveDirection === DIRECTION_NEXT &&
+							this._activeDescendant ===
+								this._descendants.length - 1);
+				}
+			}
 
-                if (!dismissAction.dismiss && !this.props.circular && focusMoveDirection) {
-                    dismissAction.dismiss = (
-                        focusMoveDirection === DIRECTION_PREV && this._activeDescendant === 0 ||
-                        focusMoveDirection === DIRECTION_NEXT && this._activeDescendant === this._descendants.length - 1
-                    );
-                }
-            }
+			return dismissAction;
+		},
 
-            return dismissAction;
-        },
+		/**
+		 * Returns the direction, if any, in which the focus should be moved. In presence of the
+		 * shift key modifier, the direction of the movement is inverted.
+		 *
+		 * @instance
+		 * @memberof WidgetFocusManager
+		 * @method _getFocusMoveDirection
+		 * @param {Object} event The Keyboard event.
+		 * @protected
+		 * @return {Number} The computed direction of the expected focus movement.
+		 */
+		_getFocusMoveDirection(event) {
+			var direction = DIRECTION_NONE;
 
-        /**
-         * Returns the direction, if any, in which the focus should be moved. In presence of the
-         * shift key modifier, the direction of the movement is inverted.
-         *
-         * @instance
-         * @memberof WidgetFocusManager
-         * @method _getFocusMoveDirection
-         * @param {Object} event The Keyboard event.
-         * @protected
-         * @return {Number} The computed direction of the expected focus movement.
-         */
-        _getFocusMoveDirection: function(event) {
-            var direction = DIRECTION_NONE;
+			if (this._isValidKey(event.keyCode, this.props.keys.next)) {
+				direction = DIRECTION_NEXT;
+			}
+			if (this._isValidKey(event.keyCode, this.props.keys.prev)) {
+				direction = DIRECTION_PREV;
+			}
 
-            if (this._isValidKey(event.keyCode, this.props.keys.next)) {
-                direction = DIRECTION_NEXT;
-            }
-            if (this._isValidKey(event.keyCode, this.props.keys.prev)) {
-                direction = DIRECTION_PREV;
-            }
+			if (event.shifKey) {
+				direction *= -1;
+			}
 
-            if (event.shifKey) {
-                direction *= -1;
-            }
+			return direction;
+		},
 
-            return direction;
-        },
+		/**
+		 * Indicates if a given keyCode is valid for the given set of keys.
+		 *
+		 * @instance
+		 * @memberof WidgetFocusManager
+		 * @method _isValidKey
+		 * @param {Array|Number} keys A key set. Can be a number an array of numbers representing the allowed keyCodes.
+		 * @param {Number} keyCode An event keyCode.
+		 * @protected
+		 * @return {Boolean} A boolean value indicating if the key is valid.
+		 */
+		_isValidKey(keyCode, keys) {
+			return AlloyEditor.Lang.isArray(keys)
+				? keys.indexOf(keyCode) !== -1
+				: keyCode === keys;
+		},
 
-        /**
-         * Indicates if a given keyCode is valid for the given set of keys.
-         *
-         * @instance
-         * @memberof WidgetFocusManager
-         * @method _isValidKey
-         * @param {Array|Number} keys A key set. Can be a number an array of numbers representing the allowed keyCodes.
-         * @param {Number} keyCode An event keyCode.
-         * @protected
-         * @return {Boolean} A boolean value indicating if the key is valid.
-         */
-        _isValidKey: function(keyCode, keys) {
-            return AlloyEditor.Lang.isArray(keys) ? (keys.indexOf(keyCode) !== -1) : (keyCode === keys);
-        },
+		/**
+		 * Indicates if a given element is valid for focus management. User input elements such as
+		 * input, select or textarea are excluded.
+		 *
+		 * @instance
+		 * @memberof WidgetFocusManager
+		 * @method _isValidKey
+		 * @param {DOMNode} element A DOM element.
+		 * @protected
+		 * @return {Boolean} A boolean value indicating if the element is valid.
+		 */
+		_isValidTarget(element) {
+			var tagName = element.tagName.toLowerCase();
 
-        /**
-         * Indicates if a given element is valid for focus management. User input elements such as
-         * input, select or textarea are excluded.
-         *
-         * @instance
-         * @memberof WidgetFocusManager
-         * @method _isValidKey
-         * @param {DOMNode} element A DOM element.
-         * @protected
-         * @return {Boolean} A boolean value indicating if the element is valid.
-         */
-        _isValidTarget: function(element) {
-            var tagName = element.tagName.toLowerCase();
+			return (
+				tagName !== 'input' &&
+				tagName !== 'select' &&
+				tagName !== 'textarea'
+			);
+		},
 
-            return (tagName !== 'input' && tagName !== 'select' && tagName !== 'textarea');
-        },
+		/**
+		 * Moves the focus among descendants in the especified direction.
+		 *
+		 * @instance
+		 * @memberof WidgetFocusManager
+		 * @method _moveFocus
+		 * @param {number} direction The direction (1 or -1) of the focus movement among descendants.
+		 * @protected
+		 */
+		_moveFocus(direction) {
+			var numDescendants = this._descendants.length;
 
-        /**
-         * Moves the focus among descendants in the especified direction.
-         *
-         * @instance
-         * @memberof WidgetFocusManager
-         * @method _moveFocus
-         * @param {number} direction The direction (1 or -1) of the focus movement among descendants.
-         * @protected
-         */
-        _moveFocus: function(direction) {
-            var numDescendants = this._descendants.length;
+			var descendant = this._descendants[this._activeDescendant];
 
-            var descendant = this._descendants[this._activeDescendant];
+			descendant.setAttribute('tabIndex', -1);
 
-            descendant.setAttribute('tabIndex', -1);
+			this._activeDescendant += direction;
 
-            this._activeDescendant += direction;
+			if (this.props.circular) {
+				// Calculate proper modulo result since remainder operator doesn't behave in the
+				// same way for negative numbers
+				this._activeDescendant =
+					((this._activeDescendant % numDescendants) +
+						numDescendants) %
+					numDescendants;
+			} else {
+				this._activeDescendant = Math.max(
+					Math.min(this._activeDescendant, numDescendants - 1),
+					0
+				);
+			}
 
-            if (this.props.circular) {
-                // Calculate proper modulo result since remainder operator doesn't behave in the
-                // same way for negative numbers
-                this._activeDescendant = ((this._activeDescendant % numDescendants) + numDescendants) % numDescendants;
-            } else {
-                this._activeDescendant = Math.max(Math.min(this._activeDescendant, numDescendants - 1), 0);
-            }
+			descendant = this._descendants[this._activeDescendant];
 
-            descendant = this._descendants[this._activeDescendant];
+			descendant.setAttribute('tabIndex', 0);
+			descendant.focus();
+		},
 
-            descendant.setAttribute('tabIndex', 0);
-            descendant.focus();
-        },
+		/**
+		 * Refreshes the descendants list by executing the CSS selector again and resets the descendants tabIndex.
+		 *
+		 * @instance
+		 * @memberof WidgetFocusManager
+		 * @method _refresh
+		 * @protected
+		 */
+		_refresh() {
+			var domNode = ReactDOM.findDOMNode(this);
 
-        /**
-         * Refreshes the descendants list by executing the CSS selector again and resets the descendants tabIndex.
-         *
-         * @instance
-         * @memberof WidgetFocusManager
-         * @method _refresh
-         * @protected
-         */
-        _refresh: function() {
-            var domNode = ReactDOM.findDOMNode(this);
+			if (domNode) {
+				var descendants = domNode.querySelectorAll(
+					this.props.descendants
+				);
 
-            if (domNode) {
-                var descendants = domNode.querySelectorAll(this.props.descendants);
+				var priorityDescendants = [];
 
-                var priorityDescendants = [];
+				this._descendants = [];
 
-                this._descendants = [];
+				Array.prototype.slice.call(descendants).forEach(item => {
+					var dataTabIndex = item.getAttribute('data-tabindex');
 
-                Array.prototype.slice.call(descendants).forEach(function(item) {
-                    var dataTabIndex = item.getAttribute('data-tabindex');
+					if (dataTabIndex) {
+						priorityDescendants.push(item);
+					} else {
+						this._descendants.push(item);
+					}
+				});
 
-                    if (dataTabIndex) {
-                        priorityDescendants.push(item);
-                    } else {
-                        this._descendants.push(item);
-                    }
-                }.bind(this));
+				priorityDescendants = priorityDescendants.sort((a, b) => {
+					return (
+						AlloyEditor.Lang.toInt(
+							a.getAttribute('data-tabindex')
+						) >
+						AlloyEditor.Lang.toInt(b.getAttribute('data-tabindex'))
+					);
+				});
 
-                priorityDescendants = priorityDescendants.sort(function(a, b) {
-                    return (AlloyEditor.Lang.toInt(a.getAttribute('data-tabindex')) > AlloyEditor.Lang.toInt(b.getAttribute('data-tabindex')));
-                });
+				this._descendants = priorityDescendants.concat(
+					this._descendants
+				);
 
-                this._descendants = priorityDescendants.concat(this._descendants);
+				this._activeDescendant = 0;
 
-                this._activeDescendant = 0;
+				this._descendants.some((item, index) => {
+					if (item.getAttribute('tabindex') === '0') {
+						this._activeDescendant = index;
+						this.focus();
 
-                this._descendants.some(function(item, index) {
-                    if (item.getAttribute('tabindex') === '0') {
-                        this._activeDescendant = index;
-                        this.focus();
+						return true;
+					}
+				});
+			}
+		},
+	};
 
-                        return true;
-                    }
-                }.bind(this));
-            }
-        }
-    };
-
-    AlloyEditor.WidgetFocusManager = WidgetFocusManager;
-}());
+	AlloyEditor.WidgetFocusManager = WidgetFocusManager;
+})();

--- a/src/components/compat/widget-focus-manager.js
+++ b/src/components/compat/widget-focus-manager.js
@@ -1,3 +1,6 @@
+import PropTypes from 'prop-types';
+import ReactDOM from 'react-dom';
+
 (function() {
 	'use strict';
 

--- a/src/components/compat/widget-interaction-point.js
+++ b/src/components/compat/widget-interaction-point.js
@@ -1,0 +1,163 @@
+(function() {
+    'use strict';
+
+    /**
+     * Provides functionality for calculating the point of interaction of the user with the Editor.
+     *
+     * @class WidgetInteractionPoint
+     */
+    var WidgetInteractionPoint = {
+        // Allows validating props being passed to the component.
+        propTypes: {
+            /**
+             * The provided editor event.
+             *
+             * @instance
+             * @memberof WidgetInteractionPoint
+             * @property {SyntheticEvent} editorEvent
+             */
+            editorEvent: PropTypes.object
+        },
+
+        /**
+         * Returns the position, in page coordinates, according to which a widget should appear.
+         * Depending on the direction of the selection, the wdiget may appear above of or on bottom of the selection.
+         *
+         * It depends on the props editorEvent to analyze the following user-interaction parameters:
+         * - {Object} selectionData The data about the selection in the editor as returned from
+         * {{#crossLink "CKEDITOR.plugins.ae_selectionregion/getSelectionData:method"}}{{/crossLink}}
+         * - {Number} pos Contains the coordinates of the position, considered as most appropriate.
+         * This may be the point where the user released the mouse, or just the beginning or the end of
+         * the selection.
+         *
+         * @instance
+         * @memberof WidgetInteractionPoint
+         * @method getInteractionPoint
+         * @return {Object} An Object which contains the following properties:
+         * direction, x, y, where x and y are in page coordinates and direction can be one of these:
+         * CKEDITOR.SELECTION_BOTTOM_TO_TOP or CKEDITOR.SELECTION_TOP_TO_BOTTOM
+         */
+        getInteractionPoint: function() {
+            var eventPayload = this.props.editorEvent ? this.props.editorEvent.data : null;
+
+            if (!eventPayload) {
+                return;
+            }
+
+            var selectionData = eventPayload.selectionData;
+
+            var nativeEvent = eventPayload.nativeEvent;
+
+            var pos = {
+                x: eventPayload.nativeEvent.pageX,
+                y: selectionData.region.top
+            };
+
+            var direction = selectionData.region.direction;
+
+            var endRect = selectionData.region.endRect;
+
+            var startRect = selectionData.region.startRect;
+
+            if (endRect && startRect && startRect.top === endRect.top) {
+                direction = CKEDITOR.SELECTION_BOTTOM_TO_TOP;
+            }
+
+            var x;
+            var y;
+
+            // If we have the point where user released the mouse, show Toolbar at this point
+            // otherwise show it on the middle of the selection.
+
+            if (pos.x && pos.y) {
+                x = this._getXPoint(selectionData, pos.x);
+
+                if (direction === CKEDITOR.SELECTION_BOTTOM_TO_TOP) {
+                    y = Math.min(pos.y, selectionData.region.top);
+                } else {
+                    y = Math.max(pos.y, this._getYPoint(selectionData, nativeEvent));
+                }
+            } else {
+                x = selectionData.region.left + selectionData.region.width / 2;
+
+                if (direction === CKEDITOR.SELECTION_TOP_TO_BOTTOM) {
+
+                    y = this._getYPoint(selectionData, nativeEvent);
+
+                } else {
+                    y = selectionData.region.top;
+                }
+            }
+
+            return {
+                direction: direction,
+                x: x,
+                y: y
+            };
+        },
+
+        /**
+         * Returns the position of the Widget.
+         *
+         * @instance
+         * @memberof WidgetInteractionPoint
+         * @method _getXPoint
+         * @param {Object} eventX The X coordinate received from the native event (mouseup).
+         * @param {Object} selectionData The data about the selection in the editor as returned from {{#crossLink "CKEDITOR.plugins.ae_selectionregion/getSelectionData:method"}}{{/crossLink}}
+         * @protected
+         * @return {Number} The calculated X point in page coordinates.
+         */
+        _getXPoint: function(selectionData, eventX) {
+            var region = selectionData.region;
+
+            var left = region.startRect ? region.startRect.left : region.left;
+            var right = region.endRect ? region.endRect.right : region.right;
+
+            var x;
+
+            if (left < eventX && right > eventX) {
+                x = eventX;
+            } else {
+                var leftDist = Math.abs(left - eventX);
+                var rightDist = Math.abs(right - eventX);
+
+                if (leftDist < rightDist) { // user raised the mouse on left on the selection
+                    x = left;
+                } else {
+                    x = right;
+                }
+            }
+
+            return x;
+        },
+
+        /**
+         * Returns the position of the Widget.
+         *
+         * @instance
+         * @memberof WidgetInteractionPoint
+         * @method _getYPoint
+         * @param {Object} nativeEvent The data about event is fired
+         * @param {Object} selectionData The data about the selection in the editor as returned from {{#crossLink "CKEDITOR.plugins.ae_selectionregion/getSelectionData:method"}}{{/crossLink}}
+         * @protected
+         * @return {Number} The calculated Y point in page coordinates.
+         */
+        _getYPoint: function(selectionData, nativeEvent) {
+            var y = 0;
+
+            if (selectionData && nativeEvent) {
+                var elementTarget = new CKEDITOR.dom.element(nativeEvent.target);
+
+                if (elementTarget.$ && elementTarget.getStyle('overflow') === 'auto') {
+                    y = nativeEvent.target.offsetTop + nativeEvent.target.offsetHeight;
+                } else {
+                    y = selectionData.region.bottom;
+                }
+            }
+
+            return y;
+        }
+    };
+
+    AlloyEditor.WidgetInteractionPoint = WidgetInteractionPoint;
+}());

--- a/src/components/compat/widget-interaction-point.js
+++ b/src/components/compat/widget-interaction-point.js
@@ -1,3 +1,5 @@
+import PropTypes from 'prop-types';
+
 (function() {
 	'use strict';
 

--- a/src/components/compat/widget-interaction-point.js
+++ b/src/components/compat/widget-interaction-point.js
@@ -1,163 +1,174 @@
 (function() {
-    'use strict';
+	'use strict';
 
-    /**
-     * Provides functionality for calculating the point of interaction of the user with the Editor.
-     *
-     * @class WidgetInteractionPoint
-     */
-    var WidgetInteractionPoint = {
-        // Allows validating props being passed to the component.
-        propTypes: {
-            /**
-             * The provided editor event.
-             *
-             * @instance
-             * @memberof WidgetInteractionPoint
-             * @property {SyntheticEvent} editorEvent
-             */
-            editorEvent: PropTypes.object
-        },
+	/**
+	 * Provides functionality for calculating the point of interaction of the user with the Editor.
+	 *
+	 * @class WidgetInteractionPoint
+	 */
+	var WidgetInteractionPoint = {
+		// Allows validating props being passed to the component.
+		propTypes: {
+			/**
+			 * The provided editor event.
+			 *
+			 * @instance
+			 * @memberof WidgetInteractionPoint
+			 * @property {SyntheticEvent} editorEvent
+			 */
+			editorEvent: PropTypes.object,
+		},
 
-        /**
-         * Returns the position, in page coordinates, according to which a widget should appear.
-         * Depending on the direction of the selection, the wdiget may appear above of or on bottom of the selection.
-         *
-         * It depends on the props editorEvent to analyze the following user-interaction parameters:
-         * - {Object} selectionData The data about the selection in the editor as returned from
-         * {{#crossLink "CKEDITOR.plugins.ae_selectionregion/getSelectionData:method"}}{{/crossLink}}
-         * - {Number} pos Contains the coordinates of the position, considered as most appropriate.
-         * This may be the point where the user released the mouse, or just the beginning or the end of
-         * the selection.
-         *
-         * @instance
-         * @memberof WidgetInteractionPoint
-         * @method getInteractionPoint
-         * @return {Object} An Object which contains the following properties:
-         * direction, x, y, where x and y are in page coordinates and direction can be one of these:
-         * CKEDITOR.SELECTION_BOTTOM_TO_TOP or CKEDITOR.SELECTION_TOP_TO_BOTTOM
-         */
-        getInteractionPoint: function() {
-            var eventPayload = this.props.editorEvent ? this.props.editorEvent.data : null;
+		/**
+		 * Returns the position, in page coordinates, according to which a widget should appear.
+		 * Depending on the direction of the selection, the wdiget may appear above of or on bottom of the selection.
+		 *
+		 * It depends on the props editorEvent to analyze the following user-interaction parameters:
+		 * - {Object} selectionData The data about the selection in the editor as returned from
+		 * {{#crossLink "CKEDITOR.plugins.ae_selectionregion/getSelectionData:method"}}{{/crossLink}}
+		 * - {Number} pos Contains the coordinates of the position, considered as most appropriate.
+		 * This may be the point where the user released the mouse, or just the beginning or the end of
+		 * the selection.
+		 *
+		 * @instance
+		 * @memberof WidgetInteractionPoint
+		 * @method getInteractionPoint
+		 * @return {Object} An Object which contains the following properties:
+		 * direction, x, y, where x and y are in page coordinates and direction can be one of these:
+		 * CKEDITOR.SELECTION_BOTTOM_TO_TOP or CKEDITOR.SELECTION_TOP_TO_BOTTOM
+		 */
+		getInteractionPoint() {
+			var eventPayload = this.props.editorEvent
+				? this.props.editorEvent.data
+				: null;
 
-            if (!eventPayload) {
-                return;
-            }
+			if (!eventPayload) {
+				return;
+			}
 
-            var selectionData = eventPayload.selectionData;
+			var selectionData = eventPayload.selectionData;
 
-            var nativeEvent = eventPayload.nativeEvent;
+			var nativeEvent = eventPayload.nativeEvent;
 
-            var pos = {
-                x: eventPayload.nativeEvent.pageX,
-                y: selectionData.region.top
-            };
+			var pos = {
+				x: eventPayload.nativeEvent.pageX,
+				y: selectionData.region.top,
+			};
 
-            var direction = selectionData.region.direction;
+			var direction = selectionData.region.direction;
 
-            var endRect = selectionData.region.endRect;
+			var endRect = selectionData.region.endRect;
 
-            var startRect = selectionData.region.startRect;
+			var startRect = selectionData.region.startRect;
 
-            if (endRect && startRect && startRect.top === endRect.top) {
-                direction = CKEDITOR.SELECTION_BOTTOM_TO_TOP;
-            }
+			if (endRect && startRect && startRect.top === endRect.top) {
+				direction = CKEDITOR.SELECTION_BOTTOM_TO_TOP;
+			}
 
-            var x;
-            var y;
+			var x;
+			var y;
 
-            // If we have the point where user released the mouse, show Toolbar at this point
-            // otherwise show it on the middle of the selection.
+			// If we have the point where user released the mouse, show Toolbar at this point
+			// otherwise show it on the middle of the selection.
 
-            if (pos.x && pos.y) {
-                x = this._getXPoint(selectionData, pos.x);
+			if (pos.x && pos.y) {
+				x = this._getXPoint(selectionData, pos.x);
 
-                if (direction === CKEDITOR.SELECTION_BOTTOM_TO_TOP) {
-                    y = Math.min(pos.y, selectionData.region.top);
-                } else {
-                    y = Math.max(pos.y, this._getYPoint(selectionData, nativeEvent));
-                }
-            } else {
-                x = selectionData.region.left + selectionData.region.width / 2;
+				if (direction === CKEDITOR.SELECTION_BOTTOM_TO_TOP) {
+					y = Math.min(pos.y, selectionData.region.top);
+				} else {
+					y = Math.max(
+						pos.y,
+						this._getYPoint(selectionData, nativeEvent)
+					);
+				}
+			} else {
+				x = selectionData.region.left + selectionData.region.width / 2;
 
-                if (direction === CKEDITOR.SELECTION_TOP_TO_BOTTOM) {
+				if (direction === CKEDITOR.SELECTION_TOP_TO_BOTTOM) {
+					y = this._getYPoint(selectionData, nativeEvent);
+				} else {
+					y = selectionData.region.top;
+				}
+			}
 
-                    y = this._getYPoint(selectionData, nativeEvent);
+			return {
+				direction,
+				x,
+				y,
+			};
+		},
 
-                } else {
-                    y = selectionData.region.top;
-                }
-            }
+		/**
+		 * Returns the position of the Widget.
+		 *
+		 * @instance
+		 * @memberof WidgetInteractionPoint
+		 * @method _getXPoint
+		 * @param {Object} eventX The X coordinate received from the native event (mouseup).
+		 * @param {Object} selectionData The data about the selection in the editor as returned from {{#crossLink "CKEDITOR.plugins.ae_selectionregion/getSelectionData:method"}}{{/crossLink}}
+		 * @protected
+		 * @return {Number} The calculated X point in page coordinates.
+		 */
+		_getXPoint(selectionData, eventX) {
+			var region = selectionData.region;
 
-            return {
-                direction: direction,
-                x: x,
-                y: y
-            };
-        },
+			var left = region.startRect ? region.startRect.left : region.left;
+			var right = region.endRect ? region.endRect.right : region.right;
 
-        /**
-         * Returns the position of the Widget.
-         *
-         * @instance
-         * @memberof WidgetInteractionPoint
-         * @method _getXPoint
-         * @param {Object} eventX The X coordinate received from the native event (mouseup).
-         * @param {Object} selectionData The data about the selection in the editor as returned from {{#crossLink "CKEDITOR.plugins.ae_selectionregion/getSelectionData:method"}}{{/crossLink}}
-         * @protected
-         * @return {Number} The calculated X point in page coordinates.
-         */
-        _getXPoint: function(selectionData, eventX) {
-            var region = selectionData.region;
+			var x;
 
-            var left = region.startRect ? region.startRect.left : region.left;
-            var right = region.endRect ? region.endRect.right : region.right;
+			if (left < eventX && right > eventX) {
+				x = eventX;
+			} else {
+				var leftDist = Math.abs(left - eventX);
+				var rightDist = Math.abs(right - eventX);
 
-            var x;
+				if (leftDist < rightDist) {
+					// user raised the mouse on left on the selection
+					x = left;
+				} else {
+					x = right;
+				}
+			}
 
-            if (left < eventX && right > eventX) {
-                x = eventX;
-            } else {
-                var leftDist = Math.abs(left - eventX);
-                var rightDist = Math.abs(right - eventX);
+			return x;
+		},
 
-                if (leftDist < rightDist) { // user raised the mouse on left on the selection
-                    x = left;
-                } else {
-                    x = right;
-                }
-            }
+		/**
+		 * Returns the position of the Widget.
+		 *
+		 * @instance
+		 * @memberof WidgetInteractionPoint
+		 * @method _getYPoint
+		 * @param {Object} nativeEvent The data about event is fired
+		 * @param {Object} selectionData The data about the selection in the editor as returned from {{#crossLink "CKEDITOR.plugins.ae_selectionregion/getSelectionData:method"}}{{/crossLink}}
+		 * @protected
+		 * @return {Number} The calculated Y point in page coordinates.
+		 */
+		_getYPoint(selectionData, nativeEvent) {
+			var y = 0;
 
-            return x;
-        },
+			if (selectionData && nativeEvent) {
+				var elementTarget = new CKEDITOR.dom.element(
+					nativeEvent.target
+				);
 
-        /**
-         * Returns the position of the Widget.
-         *
-         * @instance
-         * @memberof WidgetInteractionPoint
-         * @method _getYPoint
-         * @param {Object} nativeEvent The data about event is fired
-         * @param {Object} selectionData The data about the selection in the editor as returned from {{#crossLink "CKEDITOR.plugins.ae_selectionregion/getSelectionData:method"}}{{/crossLink}}
-         * @protected
-         * @return {Number} The calculated Y point in page coordinates.
-         */
-        _getYPoint: function(selectionData, nativeEvent) {
-            var y = 0;
+				if (
+					elementTarget.$ &&
+					elementTarget.getStyle('overflow') === 'auto'
+				) {
+					y =
+						nativeEvent.target.offsetTop +
+						nativeEvent.target.offsetHeight;
+				} else {
+					y = selectionData.region.bottom;
+				}
+			}
 
-            if (selectionData && nativeEvent) {
-                var elementTarget = new CKEDITOR.dom.element(nativeEvent.target);
+			return y;
+		},
+	};
 
-                if (elementTarget.$ && elementTarget.getStyle('overflow') === 'auto') {
-                    y = nativeEvent.target.offsetTop + nativeEvent.target.offsetHeight;
-                } else {
-                    y = selectionData.region.bottom;
-                }
-            }
-
-            return y;
-        }
-    };
-
-    AlloyEditor.WidgetInteractionPoint = WidgetInteractionPoint;
-}());
+	AlloyEditor.WidgetInteractionPoint = WidgetInteractionPoint;
+})();

--- a/src/components/compat/widget-interaction-point.js
+++ b/src/components/compat/widget-interaction-point.js
@@ -1,176 +1,170 @@
 import PropTypes from 'prop-types';
 
-(function() {
-	'use strict';
+/**
+ * Provides functionality for calculating the point of interaction of the user with the Editor.
+ *
+ * @class WidgetInteractionPoint
+ */
+const WidgetInteractionPoint = {
+	// Allows validating props being passed to the component.
+	propTypes: {
+		/**
+		 * The provided editor event.
+		 *
+		 * @instance
+		 * @memberof WidgetInteractionPoint
+		 * @property {SyntheticEvent} editorEvent
+		 */
+		editorEvent: PropTypes.object,
+	},
 
 	/**
-	 * Provides functionality for calculating the point of interaction of the user with the Editor.
+	 * Returns the position, in page coordinates, according to which a widget should appear.
+	 * Depending on the direction of the selection, the wdiget may appear above of or on bottom of the selection.
 	 *
-	 * @class WidgetInteractionPoint
+	 * It depends on the props editorEvent to analyze the following user-interaction parameters:
+	 * - {Object} selectionData The data about the selection in the editor as returned from
+	 * {{#crossLink "CKEDITOR.plugins.ae_selectionregion/getSelectionData:method"}}{{/crossLink}}
+	 * - {Number} pos Contains the coordinates of the position, considered as most appropriate.
+	 * This may be the point where the user released the mouse, or just the beginning or the end of
+	 * the selection.
+	 *
+	 * @instance
+	 * @memberof WidgetInteractionPoint
+	 * @method getInteractionPoint
+	 * @return {Object} An Object which contains the following properties:
+	 * direction, x, y, where x and y are in page coordinates and direction can be one of these:
+	 * CKEDITOR.SELECTION_BOTTOM_TO_TOP or CKEDITOR.SELECTION_TOP_TO_BOTTOM
 	 */
-	var WidgetInteractionPoint = {
-		// Allows validating props being passed to the component.
-		propTypes: {
-			/**
-			 * The provided editor event.
-			 *
-			 * @instance
-			 * @memberof WidgetInteractionPoint
-			 * @property {SyntheticEvent} editorEvent
-			 */
-			editorEvent: PropTypes.object,
-		},
+	getInteractionPoint() {
+		const eventPayload = this.props.editorEvent
+			? this.props.editorEvent.data
+			: null;
 
-		/**
-		 * Returns the position, in page coordinates, according to which a widget should appear.
-		 * Depending on the direction of the selection, the wdiget may appear above of or on bottom of the selection.
-		 *
-		 * It depends on the props editorEvent to analyze the following user-interaction parameters:
-		 * - {Object} selectionData The data about the selection in the editor as returned from
-		 * {{#crossLink "CKEDITOR.plugins.ae_selectionregion/getSelectionData:method"}}{{/crossLink}}
-		 * - {Number} pos Contains the coordinates of the position, considered as most appropriate.
-		 * This may be the point where the user released the mouse, or just the beginning or the end of
-		 * the selection.
-		 *
-		 * @instance
-		 * @memberof WidgetInteractionPoint
-		 * @method getInteractionPoint
-		 * @return {Object} An Object which contains the following properties:
-		 * direction, x, y, where x and y are in page coordinates and direction can be one of these:
-		 * CKEDITOR.SELECTION_BOTTOM_TO_TOP or CKEDITOR.SELECTION_TOP_TO_BOTTOM
-		 */
-		getInteractionPoint() {
-			var eventPayload = this.props.editorEvent
-				? this.props.editorEvent.data
-				: null;
+		if (!eventPayload) {
+			return;
+		}
 
-			if (!eventPayload) {
-				return;
-			}
+		const selectionData = eventPayload.selectionData;
 
-			var selectionData = eventPayload.selectionData;
+		const nativeEvent = eventPayload.nativeEvent;
 
-			var nativeEvent = eventPayload.nativeEvent;
+		const pos = {
+			x: eventPayload.nativeEvent.pageX,
+			y: selectionData.region.top,
+		};
 
-			var pos = {
-				x: eventPayload.nativeEvent.pageX,
-				y: selectionData.region.top,
-			};
+		let direction = selectionData.region.direction;
 
-			var direction = selectionData.region.direction;
+		const endRect = selectionData.region.endRect;
 
-			var endRect = selectionData.region.endRect;
+		const startRect = selectionData.region.startRect;
 
-			var startRect = selectionData.region.startRect;
+		if (endRect && startRect && startRect.top === endRect.top) {
+			direction = CKEDITOR.SELECTION_BOTTOM_TO_TOP;
+		}
 
-			if (endRect && startRect && startRect.top === endRect.top) {
-				direction = CKEDITOR.SELECTION_BOTTOM_TO_TOP;
-			}
+		let x;
+		let y;
 
-			var x;
-			var y;
+		// If we have the point where user released the mouse, show Toolbar at this point
+		// otherwise show it on the middle of the selection.
 
-			// If we have the point where user released the mouse, show Toolbar at this point
-			// otherwise show it on the middle of the selection.
+		if (pos.x && pos.y) {
+			x = this._getXPoint(selectionData, pos.x);
 
-			if (pos.x && pos.y) {
-				x = this._getXPoint(selectionData, pos.x);
-
-				if (direction === CKEDITOR.SELECTION_BOTTOM_TO_TOP) {
-					y = Math.min(pos.y, selectionData.region.top);
-				} else {
-					y = Math.max(
-						pos.y,
-						this._getYPoint(selectionData, nativeEvent)
-					);
-				}
+			if (direction === CKEDITOR.SELECTION_BOTTOM_TO_TOP) {
+				y = Math.min(pos.y, selectionData.region.top);
 			} else {
-				x = selectionData.region.left + selectionData.region.width / 2;
-
-				if (direction === CKEDITOR.SELECTION_TOP_TO_BOTTOM) {
-					y = this._getYPoint(selectionData, nativeEvent);
-				} else {
-					y = selectionData.region.top;
-				}
-			}
-
-			return {
-				direction,
-				x,
-				y,
-			};
-		},
-
-		/**
-		 * Returns the position of the Widget.
-		 *
-		 * @instance
-		 * @memberof WidgetInteractionPoint
-		 * @method _getXPoint
-		 * @param {Object} eventX The X coordinate received from the native event (mouseup).
-		 * @param {Object} selectionData The data about the selection in the editor as returned from {{#crossLink "CKEDITOR.plugins.ae_selectionregion/getSelectionData:method"}}{{/crossLink}}
-		 * @protected
-		 * @return {Number} The calculated X point in page coordinates.
-		 */
-		_getXPoint(selectionData, eventX) {
-			var region = selectionData.region;
-
-			var left = region.startRect ? region.startRect.left : region.left;
-			var right = region.endRect ? region.endRect.right : region.right;
-
-			var x;
-
-			if (left < eventX && right > eventX) {
-				x = eventX;
-			} else {
-				var leftDist = Math.abs(left - eventX);
-				var rightDist = Math.abs(right - eventX);
-
-				if (leftDist < rightDist) {
-					// user raised the mouse on left on the selection
-					x = left;
-				} else {
-					x = right;
-				}
-			}
-
-			return x;
-		},
-
-		/**
-		 * Returns the position of the Widget.
-		 *
-		 * @instance
-		 * @memberof WidgetInteractionPoint
-		 * @method _getYPoint
-		 * @param {Object} nativeEvent The data about event is fired
-		 * @param {Object} selectionData The data about the selection in the editor as returned from {{#crossLink "CKEDITOR.plugins.ae_selectionregion/getSelectionData:method"}}{{/crossLink}}
-		 * @protected
-		 * @return {Number} The calculated Y point in page coordinates.
-		 */
-		_getYPoint(selectionData, nativeEvent) {
-			var y = 0;
-
-			if (selectionData && nativeEvent) {
-				var elementTarget = new CKEDITOR.dom.element(
-					nativeEvent.target
+				y = Math.max(
+					pos.y,
+					this._getYPoint(selectionData, nativeEvent)
 				);
-
-				if (
-					elementTarget.$ &&
-					elementTarget.getStyle('overflow') === 'auto'
-				) {
-					y =
-						nativeEvent.target.offsetTop +
-						nativeEvent.target.offsetHeight;
-				} else {
-					y = selectionData.region.bottom;
-				}
 			}
+		} else {
+			x = selectionData.region.left + selectionData.region.width / 2;
 
-			return y;
-		},
-	};
+			if (direction === CKEDITOR.SELECTION_TOP_TO_BOTTOM) {
+				y = this._getYPoint(selectionData, nativeEvent);
+			} else {
+				y = selectionData.region.top;
+			}
+		}
 
-	AlloyEditor.WidgetInteractionPoint = WidgetInteractionPoint;
-})();
+		return {
+			direction,
+			x,
+			y,
+		};
+	},
+
+	/**
+	 * Returns the position of the Widget.
+	 *
+	 * @instance
+	 * @memberof WidgetInteractionPoint
+	 * @method _getXPoint
+	 * @param {Object} eventX The X coordinate received from the native event (mouseup).
+	 * @param {Object} selectionData The data about the selection in the editor as returned from {{#crossLink "CKEDITOR.plugins.ae_selectionregion/getSelectionData:method"}}{{/crossLink}}
+	 * @protected
+	 * @return {Number} The calculated X point in page coordinates.
+	 */
+	_getXPoint(selectionData, eventX) {
+		const region = selectionData.region;
+
+		const left = region.startRect ? region.startRect.left : region.left;
+		const right = region.endRect ? region.endRect.right : region.right;
+
+		let x;
+
+		if (left < eventX && right > eventX) {
+			x = eventX;
+		} else {
+			const leftDist = Math.abs(left - eventX);
+			const rightDist = Math.abs(right - eventX);
+
+			if (leftDist < rightDist) {
+				// user raised the mouse on left on the selection
+				x = left;
+			} else {
+				x = right;
+			}
+		}
+
+		return x;
+	},
+
+	/**
+	 * Returns the position of the Widget.
+	 *
+	 * @instance
+	 * @memberof WidgetInteractionPoint
+	 * @method _getYPoint
+	 * @param {Object} nativeEvent The data about event is fired
+	 * @param {Object} selectionData The data about the selection in the editor as returned from {{#crossLink "CKEDITOR.plugins.ae_selectionregion/getSelectionData:method"}}{{/crossLink}}
+	 * @protected
+	 * @return {Number} The calculated Y point in page coordinates.
+	 */
+	_getYPoint(selectionData, nativeEvent) {
+		let y = 0;
+
+		if (selectionData && nativeEvent) {
+			const elementTarget = new CKEDITOR.dom.element(nativeEvent.target);
+
+			if (
+				elementTarget.$ &&
+				elementTarget.getStyle('overflow') === 'auto'
+			) {
+				y =
+					nativeEvent.target.offsetTop +
+					nativeEvent.target.offsetHeight;
+			} else {
+				y = selectionData.region.bottom;
+			}
+		}
+
+		return y;
+	},
+};
+
+export default WidgetInteractionPoint;

--- a/src/components/compat/widget-position.js
+++ b/src/components/compat/widget-position.js
@@ -1,330 +1,350 @@
 (function() {
-    'use strict';
+	'use strict';
 
-    /**
-     * Calculates the position where an Widget should be displayed based on the point
-     * where user interacted with the editor.
-     *
-     * @class WidgetPosition
-     * @uses WidgetInteractionPoint
-     */
-    var WidgetPosition = {
-        mixins: [AlloyEditor.WidgetInteractionPoint],
+	/**
+	 * Calculates the position where an Widget should be displayed based on the point
+	 * where user interacted with the editor.
+	 *
+	 * @class WidgetPosition
+	 * @uses WidgetInteractionPoint
+	 */
+	var WidgetPosition = {
+		mixins: [AlloyEditor.WidgetInteractionPoint],
 
-        // Allows validating props being passed to the component.
-        propTypes: {
-            /**
-             * Should the widget to be restricted to the viewport, or not.
-             *
-             * @instance
-             * @memberof WidgetPosition
-             * @property {Boolean} constrainToViewport
-             * @default true
-             */
-            constrainToViewport: PropTypes.bool,
+		// Allows validating props being passed to the component.
+		propTypes: {
+			/**
+			 * Should the widget to be restricted to the viewport, or not.
+			 *
+			 * @instance
+			 * @memberof WidgetPosition
+			 * @property {Boolean} constrainToViewport
+			 * @default true
+			 */
+			constrainToViewport: PropTypes.bool,
 
-            /**
-             * The gutter (vertical and horizontal) between the interaction point and where the widget
-             * should be rendered.
-             *
-             * @instance
-             * @memberof WidgetPosition
-             * @property {Object} gutter
-             * @default {
-             *     left: 0,
-             *     top: 10
-             * }
-             */
-            gutter: PropTypes.object
-        },
+			/**
+			 * The gutter (vertical and horizontal) between the interaction point and where the widget
+			 * should be rendered.
+			 *
+			 * @instance
+			 * @memberof WidgetPosition
+			 * @property {Object} gutter
+			 * @default {
+			 *     left: 0,
+			 *     top: 10
+			 * }
+			 */
+			gutter: PropTypes.object,
+		},
 
-        /**
-         * Lifecycle. Returns the default values of the properties used in the widget.
-         *
-         * @instance
-         * @memberof WidgetPosition
-         * @method getDefaultProps
-         */
-        getDefaultProps: function() {
-            return {
-                gutter: {
-                    left: 0,
-                    top: 10
-                },
-                constrainToViewport: true
-            };
-        },
+		/**
+		 * Lifecycle. Returns the default values of the properties used in the widget.
+		 *
+		 * @instance
+		 * @memberof WidgetPosition
+		 * @method getDefaultProps
+		 */
+		getDefaultProps() {
+			return {
+				gutter: {
+					left: 0,
+					top: 10,
+				},
+				constrainToViewport: true,
+			};
+		},
 
-        /**
-         * Cancels an scheduled animation frame.
-         *
-         * @instance
-         * @memberof WidgetPosition
-         * @method cancelAnimation
-         */
-        cancelAnimation: function() {
-            if (window.cancelAnimationFrame) {
-                window.cancelAnimationFrame(this._animationFrameId);
-            }
-        },
+		/**
+		 * Cancels an scheduled animation frame.
+		 *
+		 * @instance
+		 * @memberof WidgetPosition
+		 * @method cancelAnimation
+		 */
+		cancelAnimation() {
+			if (window.cancelAnimationFrame) {
+				window.cancelAnimationFrame(this._animationFrameId);
+			}
+		},
 
-        /**
-         * Returns an object which contains the position of the element in page coordinates,
-         * restricted to fit to given viewport.
-         *
-         * @instance
-         * @memberof WidgetPosition
-         * @method getConstrainedPosition
-         * @param {Object} attrs The following properties, provided as numbers:
-         * - height
-         * - left
-         * - top
-         * - width
-         * @param {Object} viewPaneSize Optional. If not provided, the current viewport will be used. Should contain at least these properties:
-         * - width
-         * @return {Object} An object with `x` and `y` properties, which represent the constrained position of the
-         * element.
-         */
-        getConstrainedPosition: function(attrs, viewPaneSize) {
-            viewPaneSize = viewPaneSize || new CKEDITOR.dom.window(window).getViewPaneSize();
+		/**
+		 * Returns an object which contains the position of the element in page coordinates,
+		 * restricted to fit to given viewport.
+		 *
+		 * @instance
+		 * @memberof WidgetPosition
+		 * @method getConstrainedPosition
+		 * @param {Object} attrs The following properties, provided as numbers:
+		 * - height
+		 * - left
+		 * - top
+		 * - width
+		 * @param {Object} viewPaneSize Optional. If not provided, the current viewport will be used. Should contain at least these properties:
+		 * - width
+		 * @return {Object} An object with `x` and `y` properties, which represent the constrained position of the
+		 * element.
+		 */
+		getConstrainedPosition(attrs, viewPaneSize) {
+			viewPaneSize =
+				viewPaneSize ||
+				new CKEDITOR.dom.window(window).getViewPaneSize();
 
-            var x = attrs.left;
-            var y = attrs.top;
+			var x = attrs.left;
+			var y = attrs.top;
 
-            if (attrs.left + attrs.width > viewPaneSize.width) {
-                x -= (attrs.left + attrs.width - viewPaneSize.width);
-            }
+			if (attrs.left + attrs.width > viewPaneSize.width) {
+				x -= attrs.left + attrs.width - viewPaneSize.width;
+			}
 
-            if (y < 0) {
-                y = 0;
-            }
+			if (y < 0) {
+				y = 0;
+			}
 
-            return {
-                x: x,
-                y: y
-            };
-        },
+			return {
+				x,
+				y,
+			};
+		},
 
-        /**
-         * Returns the position of the Widget taking in consideration the
-         * {{#crossLink "WidgetPosition/gutter:attribute"}}{{/crossLink}} attribute.
-         *
-         * @instance
-         * @memberof WidgetPosition
-         * @protected
-         * @method  getWidgetXYPoint
-         * @param {Number} left The left offset in page coordinates where Toolbar should be shown.
-         * @param {Number} top The top offset in page coordinates where Toolbar should be shown.
-         * @param {Number} direction The direction of the selection. May be one of the following:
-         * CKEDITOR.SELECTION_BOTTOM_TO_TOP or CKEDITOR.SELECTION_TOP_TO_BOTTOM
-         * @return {Array} An Array with left and top offsets in page coordinates.
-         */
-        getWidgetXYPoint: function(left, top, direction) {
-            var domNode = ReactDOM.findDOMNode(this);
+		/**
+		 * Returns the position of the Widget taking in consideration the
+		 * {{#crossLink "WidgetPosition/gutter:attribute"}}{{/crossLink}} attribute.
+		 *
+		 * @instance
+		 * @memberof WidgetPosition
+		 * @protected
+		 * @method  getWidgetXYPoint
+		 * @param {Number} left The left offset in page coordinates where Toolbar should be shown.
+		 * @param {Number} top The top offset in page coordinates where Toolbar should be shown.
+		 * @param {Number} direction The direction of the selection. May be one of the following:
+		 * CKEDITOR.SELECTION_BOTTOM_TO_TOP or CKEDITOR.SELECTION_TOP_TO_BOTTOM
+		 * @return {Array} An Array with left and top offsets in page coordinates.
+		 */
+		getWidgetXYPoint(left, top, direction) {
+			var domNode = ReactDOM.findDOMNode(this);
 
-            var gutter = this.props.gutter;
-            var offsetWidth = domNode.offsetWidth;
-            var halfWidth = offsetWidth / 2;
+			var gutter = this.props.gutter;
+			var offsetWidth = domNode.offsetWidth;
+			var halfWidth = offsetWidth / 2;
 
+			if (
+				direction === CKEDITOR.SELECTION_TOP_TO_BOTTOM ||
+				direction === CKEDITOR.SELECTION_BOTTOM_TO_TOP
+			) {
+				left = left - gutter.left - halfWidth;
 
-            if (direction === CKEDITOR.SELECTION_TOP_TO_BOTTOM || direction === CKEDITOR.SELECTION_BOTTOM_TO_TOP) {
-                left = left - gutter.left - halfWidth;
+				top =
+					direction === CKEDITOR.SELECTION_TOP_TO_BOTTOM
+						? top + gutter.top
+						: top - domNode.offsetHeight - gutter.top;
+			} else if (
+				direction === CKEDITOR.SELECTION_LEFT_TO_RIGHT ||
+				direction === CKEDITOR.SELECTION_RIGHT_TO_LEFT
+			) {
+				left =
+					direction === CKEDITOR.SELECTION_LEFT_TO_RIGHT
+						? left + gutter.left + domNode.offsetHeight / 2
+						: left - (3 * domNode.offsetHeight) / 2 - gutter.left;
 
-                top = (direction === CKEDITOR.SELECTION_TOP_TO_BOTTOM) ? (top + gutter.top) :
-                    (top - domNode.offsetHeight - gutter.top);
+				top = top - gutter.top - domNode.offsetHeight / 2;
+			}
 
-            } else if (direction === CKEDITOR.SELECTION_LEFT_TO_RIGHT ||
-                direction === CKEDITOR.SELECTION_RIGHT_TO_LEFT) {
+			if (left < 0) {
+				left = 0;
+			}
 
-                left = (direction === CKEDITOR.SELECTION_LEFT_TO_RIGHT) ?
-                    (left + gutter.left + domNode.offsetHeight / 2) :
-                    (left - 3 * domNode.offsetHeight / 2 - gutter.left);
+			if (left > document.body.offsetWidth - halfWidth) {
+				left = document.body.offsetWidth - halfWidth;
+			}
 
-                top = top - gutter.top - (domNode.offsetHeight / 2);
-            }
+			if (top < 0) {
+				top = 0;
+			}
 
-            if (left < 0) {
-                left = 0;
-            }
+			return [left, top];
+		},
 
+		/**
+		 * Returns true if the widget is visible, false otherwise
+		 *
+		 * @instance
+		 * @memberof WidgetPosition
+		 * @method isVisible
+		 * @return {Boolean} True if the widget is visible, false otherwise
+		 */
+		isVisible() {
+			var domNode = ReactDOM.findDOMNode(this);
 
-            if (left > document.body.offsetWidth - halfWidth) {
-                left = document.body.offsetWidth - halfWidth;
-            }
+			if (domNode) {
+				var domElement = new CKEDITOR.dom.element(domNode);
 
-            if (top < 0) {
-                top = 0;
-            }
+				return domElement.hasClass('alloy-editor-visible');
+			}
 
+			return false;
+		},
 
+		/**
+		 * Moves a widget from a starting point to a destination point.
+		 *
+		 * @instance
+		 * @memberof WidgetPosition
+		 * @method moveToPoint
+		 * @param  {Object} startPoint The starting point for the movement.
+		 * @param  {Object} endPoint The destination point for the movement.
+		 */
+		moveToPoint(startPoint, endPoint) {
+			var domElement = new CKEDITOR.dom.element(
+				ReactDOM.findDOMNode(this)
+			);
 
-            return [left, top];
-        },
+			domElement.setStyles({
+				left: startPoint[0] + 'px',
+				top: startPoint[1] + 'px',
+				opacity: 0,
+				pointerEvents: 'none',
+			});
 
-        /**
-         * Returns true if the widget is visible, false otherwise
-         *
-         * @instance
-         * @memberof WidgetPosition
-         * @method isVisible
-         * @return {Boolean} True if the widget is visible, false otherwise
-         */
-        isVisible: function() {
-            var domNode = ReactDOM.findDOMNode(this);
+			domElement.removeClass('alloy-editor-invisible');
 
-            if (domNode) {
-                var domElement = new CKEDITOR.dom.element(domNode);
+			this._animate(() => {
+				domElement.addClass('ae-toolbar-transition');
+				domElement.addClass('alloy-editor-visible');
+				domElement.setStyles({
+					left: endPoint[0] + 'px',
+					top: endPoint[1] + 'px',
+					opacity: 1,
+				});
 
-                return domElement.hasClass('alloy-editor-visible');
-            }
-
-            return false;
-        },
-
-        /**
-         * Moves a widget from a starting point to a destination point.
-         *
-         * @instance
-         * @memberof WidgetPosition
-         * @method moveToPoint
-         * @param  {Object} startPoint The starting point for the movement.
-         * @param  {Object} endPoint The destination point for the movement.
-         */
-        moveToPoint: function(startPoint, endPoint) {
-            var domElement = new CKEDITOR.dom.element(ReactDOM.findDOMNode(this));
-
-            domElement.setStyles({
-                left: startPoint[0] + 'px',
-                top: startPoint[1] + 'px',
-                opacity: 0,
-                pointerEvents: 'none',
-            });
-
-            domElement.removeClass('alloy-editor-invisible');
-
-            this._animate(function() {
-                domElement.addClass('ae-toolbar-transition');
-                domElement.addClass('alloy-editor-visible');
-                domElement.setStyles({
-                    left: endPoint[0] + 'px',
-                    top: endPoint[1] + 'px',
-                    opacity: 1
-                });
-				
 				// 150ms to match transition-duration for .ae-toolbar-transition:
 				setTimeout(() => {
 					domElement.setStyles({
 						pointerEvents: '',
 					});
 				}, 150);
-            });
-        },
+			});
+		},
 
-        /**
-         * Shows the widget with the default animation transition.
-         *
-         * @instance
-         * @memberof WidgetPosition
-         * @method show
-         */
-        show: function() {
-            var domNode = ReactDOM.findDOMNode(this);
-            var uiNode = this.props.editor.get('uiNode');
+		/**
+		 * Shows the widget with the default animation transition.
+		 *
+		 * @instance
+		 * @memberof WidgetPosition
+		 * @method show
+		 */
+		show() {
+			var domNode = ReactDOM.findDOMNode(this);
+			var uiNode = this.props.editor.get('uiNode');
 
-            var scrollTop = uiNode ? uiNode.scrollTop : 0;
+			var scrollTop = uiNode ? uiNode.scrollTop : 0;
 
-            if (!this.isVisible() && domNode) {
-                var interactionPoint = this.getInteractionPoint();
+			if (!this.isVisible() && domNode) {
+				var interactionPoint = this.getInteractionPoint();
 
-                if (interactionPoint) {
-                    var domElement = new CKEDITOR.dom.element(domNode);
+				if (interactionPoint) {
+					var domElement = new CKEDITOR.dom.element(domNode);
 
-                    var finalX,
-                        finalY,
-                        initialX,
-                        initialY;
+					var finalX, finalY, initialX, initialY;
 
-                    finalX = initialX = parseFloat(domElement.getStyle('left'));
-                    finalY = initialY = parseFloat(domElement.getStyle('top'));
+					finalX = initialX = parseFloat(domElement.getStyle('left'));
+					finalY = initialY = parseFloat(domElement.getStyle('top'));
 
-                    if (this.props.constrainToViewport) {
-                        var res = this.getConstrainedPosition({
-                            height: parseFloat(domNode.offsetHeight),
-                            left: finalX,
-                            top: finalY,
-                            width: parseFloat(domNode.offsetWidth)
-                        });
+					if (this.props.constrainToViewport) {
+						var res = this.getConstrainedPosition({
+							height: parseFloat(domNode.offsetHeight),
+							left: finalX,
+							top: finalY,
+							width: parseFloat(domNode.offsetWidth),
+						});
 
-                        finalX = res.x;
-                        finalY = res.y;
-                    }
+						finalX = res.x;
+						finalY = res.y;
+					}
 
-                    if (interactionPoint.direction === CKEDITOR.SELECTION_TOP_TO_BOTTOM) {
-                        initialY = this.props.selectionData.region.bottom + scrollTop;
-                    } else {
-                        initialY = this.props.selectionData.region.top + scrollTop;
-                    }
+					if (
+						interactionPoint.direction ===
+						CKEDITOR.SELECTION_TOP_TO_BOTTOM
+					) {
+						initialY =
+							this.props.selectionData.region.bottom + scrollTop;
+					} else {
+						initialY =
+							this.props.selectionData.region.top + scrollTop;
+					}
 
-                    this.moveToPoint([initialX, initialY], [finalX, finalY]);
-                }
-            }
-        },
+					this.moveToPoint([initialX, initialY], [finalX, finalY]);
+				}
+			}
+		},
 
-        /**
-         * Updates the widget position based on the current interaction point.
-         *
-         * @instance
-         * @memberof WidgetPosition
-         * @method updatePosition
-         */
-        updatePosition: function() {
-            var interactionPoint = this.getInteractionPoint();
+		/**
+		 * Updates the widget position based on the current interaction point.
+		 *
+		 * @instance
+		 * @memberof WidgetPosition
+		 * @method updatePosition
+		 */
+		updatePosition() {
+			var interactionPoint = this.getInteractionPoint();
 
-            var domNode = ReactDOM.findDOMNode(this);
+			var domNode = ReactDOM.findDOMNode(this);
 
-            if (interactionPoint && domNode) {
-                var uiNode = this.props.editor.get('uiNode') || document.body;
-                var uiNodeStyle = getComputedStyle(uiNode);
-                var uiNodeMarginLeft = parseInt(uiNodeStyle.getPropertyValue('margin-left'), 10);
-                var uiNodeMarginRight = parseInt(uiNodeStyle.getPropertyValue('margin-right'), 10);
-                var totalWidth = uiNodeMarginLeft + uiNode.clientWidth + uiNodeMarginRight;
+			if (interactionPoint && domNode) {
+				var uiNode = this.props.editor.get('uiNode') || document.body;
+				var uiNodeStyle = getComputedStyle(uiNode);
+				var uiNodeMarginLeft = parseInt(
+					uiNodeStyle.getPropertyValue('margin-left'),
+					10
+				);
+				var uiNodeMarginRight = parseInt(
+					uiNodeStyle.getPropertyValue('margin-right'),
+					10
+				);
+				var totalWidth =
+					uiNodeMarginLeft + uiNode.clientWidth + uiNodeMarginRight;
 
-                var scrollTop = uiNode.tagName !== 'BODY' ? uiNode.scrollTop : 0;
+				var scrollTop =
+					uiNode.tagName !== 'BODY' ? uiNode.scrollTop : 0;
 
-                var xy = this.getWidgetXYPoint(interactionPoint.x, interactionPoint.y, interactionPoint.direction);
-                xy[1] += scrollTop;
+				var xy = this.getWidgetXYPoint(
+					interactionPoint.x,
+					interactionPoint.y,
+					interactionPoint.direction
+				);
+				xy[1] += scrollTop;
 
-                if (xy[0] < 0) {
-                    xy[0] = 0;
-                }
-                if (xy[0] > totalWidth - domNode.offsetWidth) {
-                    xy[0] = totalWidth - domNode.offsetWidth;
-                }
+				if (xy[0] < 0) {
+					xy[0] = 0;
+				}
+				if (xy[0] > totalWidth - domNode.offsetWidth) {
+					xy[0] = totalWidth - domNode.offsetWidth;
+				}
 
-                new CKEDITOR.dom.element(domNode).setStyles({
-                    left: xy[0] + 'px',
-                    top: xy[1] + 'px'
-                });
-            }
-        },
+				new CKEDITOR.dom.element(domNode).setStyles({
+					left: xy[0] + 'px',
+					top: xy[1] + 'px',
+				});
+			}
+		},
 
-        /**
-         * Requests an animation frame, if possible, to simulate an animation.
-         *
-         * @instance
-         * @memberof WidgetPosition
-         * @method _animate
-         * @param {Function} callback The function to be executed on the scheduled frame.
-         * @protected
-         */
-        _animate: function(callback) {
-            if (window.requestAnimationFrame) {
-                this._animationFrameId = window.requestAnimationFrame(callback);
-            } else {
-                callback();
-            }
-        }
-    };
+		/**
+		 * Requests an animation frame, if possible, to simulate an animation.
+		 *
+		 * @instance
+		 * @memberof WidgetPosition
+		 * @method _animate
+		 * @param {Function} callback The function to be executed on the scheduled frame.
+		 * @protected
+		 */
+		_animate(callback) {
+			if (window.requestAnimationFrame) {
+				this._animationFrameId = window.requestAnimationFrame(callback);
+			} else {
+				callback();
+			}
+		},
+	};
 
-    AlloyEditor.WidgetPosition = WidgetPosition;
-}());
+	AlloyEditor.WidgetPosition = WidgetPosition;
+})();

--- a/src/components/compat/widget-position.js
+++ b/src/components/compat/widget-position.js
@@ -1,0 +1,330 @@
+(function() {
+    'use strict';
+
+    /**
+     * Calculates the position where an Widget should be displayed based on the point
+     * where user interacted with the editor.
+     *
+     * @class WidgetPosition
+     * @uses WidgetInteractionPoint
+     */
+    var WidgetPosition = {
+        mixins: [AlloyEditor.WidgetInteractionPoint],
+
+        // Allows validating props being passed to the component.
+        propTypes: {
+            /**
+             * Should the widget to be restricted to the viewport, or not.
+             *
+             * @instance
+             * @memberof WidgetPosition
+             * @property {Boolean} constrainToViewport
+             * @default true
+             */
+            constrainToViewport: PropTypes.bool,
+
+            /**
+             * The gutter (vertical and horizontal) between the interaction point and where the widget
+             * should be rendered.
+             *
+             * @instance
+             * @memberof WidgetPosition
+             * @property {Object} gutter
+             * @default {
+             *     left: 0,
+             *     top: 10
+             * }
+             */
+            gutter: PropTypes.object
+        },
+
+        /**
+         * Lifecycle. Returns the default values of the properties used in the widget.
+         *
+         * @instance
+         * @memberof WidgetPosition
+         * @method getDefaultProps
+         */
+        getDefaultProps: function() {
+            return {
+                gutter: {
+                    left: 0,
+                    top: 10
+                },
+                constrainToViewport: true
+            };
+        },
+
+        /**
+         * Cancels an scheduled animation frame.
+         *
+         * @instance
+         * @memberof WidgetPosition
+         * @method cancelAnimation
+         */
+        cancelAnimation: function() {
+            if (window.cancelAnimationFrame) {
+                window.cancelAnimationFrame(this._animationFrameId);
+            }
+        },
+
+        /**
+         * Returns an object which contains the position of the element in page coordinates,
+         * restricted to fit to given viewport.
+         *
+         * @instance
+         * @memberof WidgetPosition
+         * @method getConstrainedPosition
+         * @param {Object} attrs The following properties, provided as numbers:
+         * - height
+         * - left
+         * - top
+         * - width
+         * @param {Object} viewPaneSize Optional. If not provided, the current viewport will be used. Should contain at least these properties:
+         * - width
+         * @return {Object} An object with `x` and `y` properties, which represent the constrained position of the
+         * element.
+         */
+        getConstrainedPosition: function(attrs, viewPaneSize) {
+            viewPaneSize = viewPaneSize || new CKEDITOR.dom.window(window).getViewPaneSize();
+
+            var x = attrs.left;
+            var y = attrs.top;
+
+            if (attrs.left + attrs.width > viewPaneSize.width) {
+                x -= (attrs.left + attrs.width - viewPaneSize.width);
+            }
+
+            if (y < 0) {
+                y = 0;
+            }
+
+            return {
+                x: x,
+                y: y
+            };
+        },
+
+        /**
+         * Returns the position of the Widget taking in consideration the
+         * {{#crossLink "WidgetPosition/gutter:attribute"}}{{/crossLink}} attribute.
+         *
+         * @instance
+         * @memberof WidgetPosition
+         * @protected
+         * @method  getWidgetXYPoint
+         * @param {Number} left The left offset in page coordinates where Toolbar should be shown.
+         * @param {Number} top The top offset in page coordinates where Toolbar should be shown.
+         * @param {Number} direction The direction of the selection. May be one of the following:
+         * CKEDITOR.SELECTION_BOTTOM_TO_TOP or CKEDITOR.SELECTION_TOP_TO_BOTTOM
+         * @return {Array} An Array with left and top offsets in page coordinates.
+         */
+        getWidgetXYPoint: function(left, top, direction) {
+            var domNode = ReactDOM.findDOMNode(this);
+
+            var gutter = this.props.gutter;
+            var offsetWidth = domNode.offsetWidth;
+            var halfWidth = offsetWidth / 2;
+
+
+            if (direction === CKEDITOR.SELECTION_TOP_TO_BOTTOM || direction === CKEDITOR.SELECTION_BOTTOM_TO_TOP) {
+                left = left - gutter.left - halfWidth;
+
+                top = (direction === CKEDITOR.SELECTION_TOP_TO_BOTTOM) ? (top + gutter.top) :
+                    (top - domNode.offsetHeight - gutter.top);
+
+            } else if (direction === CKEDITOR.SELECTION_LEFT_TO_RIGHT ||
+                direction === CKEDITOR.SELECTION_RIGHT_TO_LEFT) {
+
+                left = (direction === CKEDITOR.SELECTION_LEFT_TO_RIGHT) ?
+                    (left + gutter.left + domNode.offsetHeight / 2) :
+                    (left - 3 * domNode.offsetHeight / 2 - gutter.left);
+
+                top = top - gutter.top - (domNode.offsetHeight / 2);
+            }
+
+            if (left < 0) {
+                left = 0;
+            }
+
+
+            if (left > document.body.offsetWidth - halfWidth) {
+                left = document.body.offsetWidth - halfWidth;
+            }
+
+            if (top < 0) {
+                top = 0;
+            }
+
+
+
+            return [left, top];
+        },
+
+        /**
+         * Returns true if the widget is visible, false otherwise
+         *
+         * @instance
+         * @memberof WidgetPosition
+         * @method isVisible
+         * @return {Boolean} True if the widget is visible, false otherwise
+         */
+        isVisible: function() {
+            var domNode = ReactDOM.findDOMNode(this);
+
+            if (domNode) {
+                var domElement = new CKEDITOR.dom.element(domNode);
+
+                return domElement.hasClass('alloy-editor-visible');
+            }
+
+            return false;
+        },
+
+        /**
+         * Moves a widget from a starting point to a destination point.
+         *
+         * @instance
+         * @memberof WidgetPosition
+         * @method moveToPoint
+         * @param  {Object} startPoint The starting point for the movement.
+         * @param  {Object} endPoint The destination point for the movement.
+         */
+        moveToPoint: function(startPoint, endPoint) {
+            var domElement = new CKEDITOR.dom.element(ReactDOM.findDOMNode(this));
+
+            domElement.setStyles({
+                left: startPoint[0] + 'px',
+                top: startPoint[1] + 'px',
+                opacity: 0,
+                pointerEvents: 'none',
+            });
+
+            domElement.removeClass('alloy-editor-invisible');
+
+            this._animate(function() {
+                domElement.addClass('ae-toolbar-transition');
+                domElement.addClass('alloy-editor-visible');
+                domElement.setStyles({
+                    left: endPoint[0] + 'px',
+                    top: endPoint[1] + 'px',
+                    opacity: 1
+                });
+				
+				// 150ms to match transition-duration for .ae-toolbar-transition:
+				setTimeout(() => {
+					domElement.setStyles({
+						pointerEvents: '',
+					});
+				}, 150);
+            });
+        },
+
+        /**
+         * Shows the widget with the default animation transition.
+         *
+         * @instance
+         * @memberof WidgetPosition
+         * @method show
+         */
+        show: function() {
+            var domNode = ReactDOM.findDOMNode(this);
+            var uiNode = this.props.editor.get('uiNode');
+
+            var scrollTop = uiNode ? uiNode.scrollTop : 0;
+
+            if (!this.isVisible() && domNode) {
+                var interactionPoint = this.getInteractionPoint();
+
+                if (interactionPoint) {
+                    var domElement = new CKEDITOR.dom.element(domNode);
+
+                    var finalX,
+                        finalY,
+                        initialX,
+                        initialY;
+
+                    finalX = initialX = parseFloat(domElement.getStyle('left'));
+                    finalY = initialY = parseFloat(domElement.getStyle('top'));
+
+                    if (this.props.constrainToViewport) {
+                        var res = this.getConstrainedPosition({
+                            height: parseFloat(domNode.offsetHeight),
+                            left: finalX,
+                            top: finalY,
+                            width: parseFloat(domNode.offsetWidth)
+                        });
+
+                        finalX = res.x;
+                        finalY = res.y;
+                    }
+
+                    if (interactionPoint.direction === CKEDITOR.SELECTION_TOP_TO_BOTTOM) {
+                        initialY = this.props.selectionData.region.bottom + scrollTop;
+                    } else {
+                        initialY = this.props.selectionData.region.top + scrollTop;
+                    }
+
+                    this.moveToPoint([initialX, initialY], [finalX, finalY]);
+                }
+            }
+        },
+
+        /**
+         * Updates the widget position based on the current interaction point.
+         *
+         * @instance
+         * @memberof WidgetPosition
+         * @method updatePosition
+         */
+        updatePosition: function() {
+            var interactionPoint = this.getInteractionPoint();
+
+            var domNode = ReactDOM.findDOMNode(this);
+
+            if (interactionPoint && domNode) {
+                var uiNode = this.props.editor.get('uiNode') || document.body;
+                var uiNodeStyle = getComputedStyle(uiNode);
+                var uiNodeMarginLeft = parseInt(uiNodeStyle.getPropertyValue('margin-left'), 10);
+                var uiNodeMarginRight = parseInt(uiNodeStyle.getPropertyValue('margin-right'), 10);
+                var totalWidth = uiNodeMarginLeft + uiNode.clientWidth + uiNodeMarginRight;
+
+                var scrollTop = uiNode.tagName !== 'BODY' ? uiNode.scrollTop : 0;
+
+                var xy = this.getWidgetXYPoint(interactionPoint.x, interactionPoint.y, interactionPoint.direction);
+                xy[1] += scrollTop;
+
+                if (xy[0] < 0) {
+                    xy[0] = 0;
+                }
+                if (xy[0] > totalWidth - domNode.offsetWidth) {
+                    xy[0] = totalWidth - domNode.offsetWidth;
+                }
+
+                new CKEDITOR.dom.element(domNode).setStyles({
+                    left: xy[0] + 'px',
+                    top: xy[1] + 'px'
+                });
+            }
+        },
+
+        /**
+         * Requests an animation frame, if possible, to simulate an animation.
+         *
+         * @instance
+         * @memberof WidgetPosition
+         * @method _animate
+         * @param {Function} callback The function to be executed on the scheduled frame.
+         * @protected
+         */
+        _animate: function(callback) {
+            if (window.requestAnimationFrame) {
+                this._animationFrameId = window.requestAnimationFrame(callback);
+            } else {
+                callback();
+            }
+        }
+    };
+
+    AlloyEditor.WidgetPosition = WidgetPosition;
+}());

--- a/src/components/compat/widget-position.js
+++ b/src/components/compat/widget-position.js
@@ -1,353 +1,347 @@
 import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
 
-(function() {
-	'use strict';
+import WidgetInteractionPoint from './widget-interaction-point';
+
+/**
+ * Calculates the position where an Widget should be displayed based on
+ * the point where user interacted with the editor.
+ *
+ * @class WidgetPosition
+ * @uses WidgetInteractionPoint
+ */
+const WidgetPosition = {
+	mixins: [WidgetInteractionPoint],
+
+	// Allows validating props being passed to the component.
+	propTypes: {
+		/**
+		 * Should the widget to be restricted to the viewport, or not.
+		 *
+		 * @instance
+		 * @memberof WidgetPosition
+		 * @property {Boolean} constrainToViewport
+		 * @default true
+		 */
+		constrainToViewport: PropTypes.bool,
+
+		/**
+		 * The gutter (vertical and horizontal) between the interaction
+		 * point and where the widget should be rendered.
+		 *
+		 * @instance
+		 * @memberof WidgetPosition
+		 * @property {Object} gutter
+		 * @default {
+		 *     left: 0,
+		 *     top: 10
+		 * }
+		 */
+		gutter: PropTypes.object,
+	},
 
 	/**
-	 * Calculates the position where an Widget should be displayed based on the point
-	 * where user interacted with the editor.
+	 * Lifecycle. Returns the default values of the properties used in
+	 * the widget.
 	 *
-	 * @class WidgetPosition
-	 * @uses WidgetInteractionPoint
+	 * @instance
+	 * @memberof WidgetPosition
+	 * @method getDefaultProps
 	 */
-	var WidgetPosition = {
-		mixins: [AlloyEditor.WidgetInteractionPoint],
+	getDefaultProps() {
+		return {
+			gutter: {
+				left: 0,
+				top: 10,
+			},
+			constrainToViewport: true,
+		};
+	},
 
-		// Allows validating props being passed to the component.
-		propTypes: {
-			/**
-			 * Should the widget to be restricted to the viewport, or not.
-			 *
-			 * @instance
-			 * @memberof WidgetPosition
-			 * @property {Boolean} constrainToViewport
-			 * @default true
-			 */
-			constrainToViewport: PropTypes.bool,
+	/**
+	 * Cancels an scheduled animation frame.
+	 *
+	 * @instance
+	 * @memberof WidgetPosition
+	 * @method cancelAnimation
+	 */
+	cancelAnimation() {
+		if (window.cancelAnimationFrame) {
+			window.cancelAnimationFrame(this._animationFrameId);
+		}
+	},
 
-			/**
-			 * The gutter (vertical and horizontal) between the interaction point and where the widget
-			 * should be rendered.
-			 *
-			 * @instance
-			 * @memberof WidgetPosition
-			 * @property {Object} gutter
-			 * @default {
-			 *     left: 0,
-			 *     top: 10
-			 * }
-			 */
-			gutter: PropTypes.object,
-		},
+	/**
+	 * Returns an object which contains the position of the element in
+	 * page coordinates, restricted to fit to given viewport.
+	 *
+	 * @instance
+	 * @memberof WidgetPosition
+	 * @method getConstrainedPosition
+	 * @param {Object} attrs The following properties, provided as numbers:
+	 * - height
+	 * - left
+	 * - top
+	 * - width
+	 * @param {Object} viewPaneSize Optional. If not provided, the current viewport will be used. Should contain at least these properties:
+	 * - width
+	 * @return {Object} An object with `x` and `y` properties, which represent the constrained position of the
+	 * element.
+	 */
+	getConstrainedPosition(attrs, viewPaneSize) {
+		viewPaneSize =
+			viewPaneSize || new CKEDITOR.dom.window(window).getViewPaneSize();
 
-		/**
-		 * Lifecycle. Returns the default values of the properties used in the widget.
-		 *
-		 * @instance
-		 * @memberof WidgetPosition
-		 * @method getDefaultProps
-		 */
-		getDefaultProps() {
-			return {
-				gutter: {
-					left: 0,
-					top: 10,
-				},
-				constrainToViewport: true,
-			};
-		},
+		let x = attrs.left;
+		let y = attrs.top;
 
-		/**
-		 * Cancels an scheduled animation frame.
-		 *
-		 * @instance
-		 * @memberof WidgetPosition
-		 * @method cancelAnimation
-		 */
-		cancelAnimation() {
-			if (window.cancelAnimationFrame) {
-				window.cancelAnimationFrame(this._animationFrameId);
-			}
-		},
+		if (attrs.left + attrs.width > viewPaneSize.width) {
+			x -= attrs.left + attrs.width - viewPaneSize.width;
+		}
 
-		/**
-		 * Returns an object which contains the position of the element in page coordinates,
-		 * restricted to fit to given viewport.
-		 *
-		 * @instance
-		 * @memberof WidgetPosition
-		 * @method getConstrainedPosition
-		 * @param {Object} attrs The following properties, provided as numbers:
-		 * - height
-		 * - left
-		 * - top
-		 * - width
-		 * @param {Object} viewPaneSize Optional. If not provided, the current viewport will be used. Should contain at least these properties:
-		 * - width
-		 * @return {Object} An object with `x` and `y` properties, which represent the constrained position of the
-		 * element.
-		 */
-		getConstrainedPosition(attrs, viewPaneSize) {
-			viewPaneSize =
-				viewPaneSize ||
-				new CKEDITOR.dom.window(window).getViewPaneSize();
+		if (y < 0) {
+			y = 0;
+		}
 
-			var x = attrs.left;
-			var y = attrs.top;
+		return {
+			x,
+			y,
+		};
+	},
 
-			if (attrs.left + attrs.width > viewPaneSize.width) {
-				x -= attrs.left + attrs.width - viewPaneSize.width;
-			}
+	/**
+	 * Returns the position of the Widget taking in consideration the
+	 * {{#crossLink "WidgetPosition/gutter:attribute"}}{{/crossLink}} attribute.
+	 *
+	 * @instance
+	 * @memberof WidgetPosition
+	 * @protected
+	 * @method  getWidgetXYPoint
+	 * @param {Number} left The left offset in page coordinates where Toolbar should be shown.
+	 * @param {Number} top The top offset in page coordinates where Toolbar should be shown.
+	 * @param {Number} direction The direction of the selection. May be one of the following:
+	 * CKEDITOR.SELECTION_BOTTOM_TO_TOP or CKEDITOR.SELECTION_TOP_TO_BOTTOM
+	 * @return {Array} An Array with left and top offsets in page coordinates.
+	 */
+	getWidgetXYPoint(left, top, direction) {
+		const domNode = ReactDOM.findDOMNode(this);
 
-			if (y < 0) {
-				y = 0;
-			}
+		const gutter = this.props.gutter;
+		const offsetWidth = domNode.offsetWidth;
+		const halfWidth = offsetWidth / 2;
 
-			return {
-				x,
-				y,
-			};
-		},
+		if (
+			direction === CKEDITOR.SELECTION_TOP_TO_BOTTOM ||
+			direction === CKEDITOR.SELECTION_BOTTOM_TO_TOP
+		) {
+			left = left - gutter.left - halfWidth;
 
-		/**
-		 * Returns the position of the Widget taking in consideration the
-		 * {{#crossLink "WidgetPosition/gutter:attribute"}}{{/crossLink}} attribute.
-		 *
-		 * @instance
-		 * @memberof WidgetPosition
-		 * @protected
-		 * @method  getWidgetXYPoint
-		 * @param {Number} left The left offset in page coordinates where Toolbar should be shown.
-		 * @param {Number} top The top offset in page coordinates where Toolbar should be shown.
-		 * @param {Number} direction The direction of the selection. May be one of the following:
-		 * CKEDITOR.SELECTION_BOTTOM_TO_TOP or CKEDITOR.SELECTION_TOP_TO_BOTTOM
-		 * @return {Array} An Array with left and top offsets in page coordinates.
-		 */
-		getWidgetXYPoint(left, top, direction) {
-			var domNode = ReactDOM.findDOMNode(this);
+			top =
+				direction === CKEDITOR.SELECTION_TOP_TO_BOTTOM
+					? top + gutter.top
+					: top - domNode.offsetHeight - gutter.top;
+		} else if (
+			direction === CKEDITOR.SELECTION_LEFT_TO_RIGHT ||
+			direction === CKEDITOR.SELECTION_RIGHT_TO_LEFT
+		) {
+			left =
+				direction === CKEDITOR.SELECTION_LEFT_TO_RIGHT
+					? left + gutter.left + domNode.offsetHeight / 2
+					: left - (3 * domNode.offsetHeight) / 2 - gutter.left;
 
-			var gutter = this.props.gutter;
-			var offsetWidth = domNode.offsetWidth;
-			var halfWidth = offsetWidth / 2;
+			top = top - gutter.top - domNode.offsetHeight / 2;
+		}
 
-			if (
-				direction === CKEDITOR.SELECTION_TOP_TO_BOTTOM ||
-				direction === CKEDITOR.SELECTION_BOTTOM_TO_TOP
-			) {
-				left = left - gutter.left - halfWidth;
+		if (left < 0) {
+			left = 0;
+		}
 
-				top =
-					direction === CKEDITOR.SELECTION_TOP_TO_BOTTOM
-						? top + gutter.top
-						: top - domNode.offsetHeight - gutter.top;
-			} else if (
-				direction === CKEDITOR.SELECTION_LEFT_TO_RIGHT ||
-				direction === CKEDITOR.SELECTION_RIGHT_TO_LEFT
-			) {
-				left =
-					direction === CKEDITOR.SELECTION_LEFT_TO_RIGHT
-						? left + gutter.left + domNode.offsetHeight / 2
-						: left - (3 * domNode.offsetHeight) / 2 - gutter.left;
+		if (left > document.body.offsetWidth - halfWidth) {
+			left = document.body.offsetWidth - halfWidth;
+		}
 
-				top = top - gutter.top - domNode.offsetHeight / 2;
-			}
+		if (top < 0) {
+			top = 0;
+		}
 
-			if (left < 0) {
-				left = 0;
-			}
+		return [left, top];
+	},
 
-			if (left > document.body.offsetWidth - halfWidth) {
-				left = document.body.offsetWidth - halfWidth;
-			}
+	/**
+	 * Returns true if the widget is visible, false otherwise
+	 *
+	 * @instance
+	 * @memberof WidgetPosition
+	 * @method isVisible
+	 * @return {Boolean} True if the widget is visible, false otherwise
+	 */
+	isVisible() {
+		const domNode = ReactDOM.findDOMNode(this);
 
-			if (top < 0) {
-				top = 0;
-			}
+		if (domNode) {
+			const domElement = new CKEDITOR.dom.element(domNode);
 
-			return [left, top];
-		},
+			return domElement.hasClass('alloy-editor-visible');
+		}
 
-		/**
-		 * Returns true if the widget is visible, false otherwise
-		 *
-		 * @instance
-		 * @memberof WidgetPosition
-		 * @method isVisible
-		 * @return {Boolean} True if the widget is visible, false otherwise
-		 */
-		isVisible() {
-			var domNode = ReactDOM.findDOMNode(this);
+		return false;
+	},
 
-			if (domNode) {
-				var domElement = new CKEDITOR.dom.element(domNode);
+	/**
+	 * Moves a widget from a starting point to a destination point.
+	 *
+	 * @instance
+	 * @memberof WidgetPosition
+	 * @method moveToPoint
+	 * @param  {Object} startPoint The starting point for the movement.
+	 * @param  {Object} endPoint The destination point for the movement.
+	 */
+	moveToPoint(startPoint, endPoint) {
+		const domElement = new CKEDITOR.dom.element(ReactDOM.findDOMNode(this));
 
-				return domElement.hasClass('alloy-editor-visible');
-			}
+		domElement.setStyles({
+			left: startPoint[0] + 'px',
+			top: startPoint[1] + 'px',
+			opacity: 0,
+			pointerEvents: 'none',
+		});
 
-			return false;
-		},
+		domElement.removeClass('alloy-editor-invisible');
 
-		/**
-		 * Moves a widget from a starting point to a destination point.
-		 *
-		 * @instance
-		 * @memberof WidgetPosition
-		 * @method moveToPoint
-		 * @param  {Object} startPoint The starting point for the movement.
-		 * @param  {Object} endPoint The destination point for the movement.
-		 */
-		moveToPoint(startPoint, endPoint) {
-			var domElement = new CKEDITOR.dom.element(
-				ReactDOM.findDOMNode(this)
-			);
-
+		this._animate(() => {
+			domElement.addClass('ae-toolbar-transition');
+			domElement.addClass('alloy-editor-visible');
 			domElement.setStyles({
-				left: startPoint[0] + 'px',
-				top: startPoint[1] + 'px',
-				opacity: 0,
-				pointerEvents: 'none',
+				left: endPoint[0] + 'px',
+				top: endPoint[1] + 'px',
+				opacity: 1,
 			});
 
-			domElement.removeClass('alloy-editor-invisible');
-
-			this._animate(() => {
-				domElement.addClass('ae-toolbar-transition');
-				domElement.addClass('alloy-editor-visible');
+			// 150ms to match transition-duration for .ae-toolbar-transition:
+			setTimeout(() => {
 				domElement.setStyles({
-					left: endPoint[0] + 'px',
-					top: endPoint[1] + 'px',
-					opacity: 1,
+					pointerEvents: '',
 				});
+			}, 150);
+		});
+	},
 
-				// 150ms to match transition-duration for .ae-toolbar-transition:
-				setTimeout(() => {
-					domElement.setStyles({
-						pointerEvents: '',
+	/**
+	 * Shows the widget with the default animation transition.
+	 *
+	 * @instance
+	 * @memberof WidgetPosition
+	 * @method show
+	 */
+	show() {
+		const domNode = ReactDOM.findDOMNode(this);
+		const uiNode = this.props.editor.get('uiNode');
+
+		const scrollTop = uiNode ? uiNode.scrollTop : 0;
+
+		if (!this.isVisible() && domNode) {
+			const interactionPoint = this.getInteractionPoint();
+
+			if (interactionPoint) {
+				const domElement = new CKEDITOR.dom.element(domNode);
+
+				let finalX, finalY, initialX, initialY;
+
+				finalX = initialX = parseFloat(domElement.getStyle('left'));
+				finalY = initialY = parseFloat(domElement.getStyle('top'));
+
+				if (this.props.constrainToViewport) {
+					const res = this.getConstrainedPosition({
+						height: parseFloat(domNode.offsetHeight),
+						left: finalX,
+						top: finalY,
+						width: parseFloat(domNode.offsetWidth),
 					});
-				}, 150);
+
+					finalX = res.x;
+					finalY = res.y;
+				}
+
+				if (
+					interactionPoint.direction ===
+					CKEDITOR.SELECTION_TOP_TO_BOTTOM
+				) {
+					initialY =
+						this.props.selectionData.region.bottom + scrollTop;
+				} else {
+					initialY = this.props.selectionData.region.top + scrollTop;
+				}
+
+				this.moveToPoint([initialX, initialY], [finalX, finalY]);
+			}
+		}
+	},
+
+	/**
+	 * Updates the widget position based on the current interaction point.
+	 *
+	 * @instance
+	 * @memberof WidgetPosition
+	 * @method updatePosition
+	 */
+	updatePosition() {
+		const interactionPoint = this.getInteractionPoint();
+
+		const domNode = ReactDOM.findDOMNode(this);
+
+		if (interactionPoint && domNode) {
+			const uiNode = this.props.editor.get('uiNode') || document.body;
+			const uiNodeStyle = getComputedStyle(uiNode);
+			const uiNodeMarginLeft = parseInt(
+				uiNodeStyle.getPropertyValue('margin-left'),
+				10
+			);
+			const uiNodeMarginRight = parseInt(
+				uiNodeStyle.getPropertyValue('margin-right'),
+				10
+			);
+			const totalWidth =
+				uiNodeMarginLeft + uiNode.clientWidth + uiNodeMarginRight;
+
+			const scrollTop = uiNode.tagName !== 'BODY' ? uiNode.scrollTop : 0;
+
+			const xy = this.getWidgetXYPoint(
+				interactionPoint.x,
+				interactionPoint.y,
+				interactionPoint.direction
+			);
+			xy[1] += scrollTop;
+
+			if (xy[0] < 0) {
+				xy[0] = 0;
+			}
+			if (xy[0] > totalWidth - domNode.offsetWidth) {
+				xy[0] = totalWidth - domNode.offsetWidth;
+			}
+
+			new CKEDITOR.dom.element(domNode).setStyles({
+				left: xy[0] + 'px',
+				top: xy[1] + 'px',
 			});
-		},
+		}
+	},
 
-		/**
-		 * Shows the widget with the default animation transition.
-		 *
-		 * @instance
-		 * @memberof WidgetPosition
-		 * @method show
-		 */
-		show() {
-			var domNode = ReactDOM.findDOMNode(this);
-			var uiNode = this.props.editor.get('uiNode');
+	/**
+	 * Requests an animation frame, if possible, to simulate an animation.
+	 *
+	 * @instance
+	 * @memberof WidgetPosition
+	 * @method _animate
+	 * @param {Function} callback The function to be executed on the scheduled frame.
+	 * @protected
+	 */
+	_animate(callback) {
+		if (window.requestAnimationFrame) {
+			this._animationFrameId = window.requestAnimationFrame(callback);
+		} else {
+			callback();
+		}
+	},
+};
 
-			var scrollTop = uiNode ? uiNode.scrollTop : 0;
-
-			if (!this.isVisible() && domNode) {
-				var interactionPoint = this.getInteractionPoint();
-
-				if (interactionPoint) {
-					var domElement = new CKEDITOR.dom.element(domNode);
-
-					var finalX, finalY, initialX, initialY;
-
-					finalX = initialX = parseFloat(domElement.getStyle('left'));
-					finalY = initialY = parseFloat(domElement.getStyle('top'));
-
-					if (this.props.constrainToViewport) {
-						var res = this.getConstrainedPosition({
-							height: parseFloat(domNode.offsetHeight),
-							left: finalX,
-							top: finalY,
-							width: parseFloat(domNode.offsetWidth),
-						});
-
-						finalX = res.x;
-						finalY = res.y;
-					}
-
-					if (
-						interactionPoint.direction ===
-						CKEDITOR.SELECTION_TOP_TO_BOTTOM
-					) {
-						initialY =
-							this.props.selectionData.region.bottom + scrollTop;
-					} else {
-						initialY =
-							this.props.selectionData.region.top + scrollTop;
-					}
-
-					this.moveToPoint([initialX, initialY], [finalX, finalY]);
-				}
-			}
-		},
-
-		/**
-		 * Updates the widget position based on the current interaction point.
-		 *
-		 * @instance
-		 * @memberof WidgetPosition
-		 * @method updatePosition
-		 */
-		updatePosition() {
-			var interactionPoint = this.getInteractionPoint();
-
-			var domNode = ReactDOM.findDOMNode(this);
-
-			if (interactionPoint && domNode) {
-				var uiNode = this.props.editor.get('uiNode') || document.body;
-				var uiNodeStyle = getComputedStyle(uiNode);
-				var uiNodeMarginLeft = parseInt(
-					uiNodeStyle.getPropertyValue('margin-left'),
-					10
-				);
-				var uiNodeMarginRight = parseInt(
-					uiNodeStyle.getPropertyValue('margin-right'),
-					10
-				);
-				var totalWidth =
-					uiNodeMarginLeft + uiNode.clientWidth + uiNodeMarginRight;
-
-				var scrollTop =
-					uiNode.tagName !== 'BODY' ? uiNode.scrollTop : 0;
-
-				var xy = this.getWidgetXYPoint(
-					interactionPoint.x,
-					interactionPoint.y,
-					interactionPoint.direction
-				);
-				xy[1] += scrollTop;
-
-				if (xy[0] < 0) {
-					xy[0] = 0;
-				}
-				if (xy[0] > totalWidth - domNode.offsetWidth) {
-					xy[0] = totalWidth - domNode.offsetWidth;
-				}
-
-				new CKEDITOR.dom.element(domNode).setStyles({
-					left: xy[0] + 'px',
-					top: xy[1] + 'px',
-				});
-			}
-		},
-
-		/**
-		 * Requests an animation frame, if possible, to simulate an animation.
-		 *
-		 * @instance
-		 * @memberof WidgetPosition
-		 * @method _animate
-		 * @param {Function} callback The function to be executed on the scheduled frame.
-		 * @protected
-		 */
-		_animate(callback) {
-			if (window.requestAnimationFrame) {
-				this._animationFrameId = window.requestAnimationFrame(callback);
-			} else {
-				callback();
-			}
-		},
-	};
-
-	AlloyEditor.WidgetPosition = WidgetPosition;
-})();
+export default WidgetPosition;

--- a/src/components/compat/widget-position.js
+++ b/src/components/compat/widget-position.js
@@ -1,3 +1,6 @@
+import PropTypes from 'prop-types';
+import ReactDOM from 'react-dom';
+
 (function() {
 	'use strict';
 


### PR DESCRIPTION
Please see the commit messages for details. The first one contains the juicy bit:

> Exposes:
>
> - The 2.x HOCs as `AlloyEditor.Base.ButtonCommand` (etc) so that people can write custom buttons using the new ES6-class based style.
> - The 1.x mixins as `AlloyEditor.Compat.ButtonCommand` (etc), for people who have custom buttons written using the old (`React.createClass`) style.
>
> The obvious downside here is that we're shipping more code now, increasing the bundle size and overall complexity, but we think it's worth it because we are prepared to pay quite a high cost in the name of maintaining backwards compatibility.
>
> Having said that, we are not going to go out of our way to document the `Compat` mixins at this time, so as not to overwhelm users; this is just something we want to have up our sleeve to be able to offer it if the need arises (and it may not arise, given that custom buttons probably aren't often implemented).

Closes: https://github.com/liferay/alloy-editor/issues/1314