### PR TITLE
fix(button-spacing): adds missing EditorContext ref

### DIFF
--- a/src/components/buttons/button-spacing.jsx
+++ b/src/components/buttons/button-spacing.jsx
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
+import EditorContext from '../../adapter/editor-context';
 import ButtonIcon from './button-icon.jsx';
 import ButtonStylesList from './button-styles-list.jsx';
 
@@ -10,6 +11,8 @@ import ButtonStylesList from './button-styles-list.jsx';
  * @class ButtonSpacing
  */
 class ButtonSpacing extends React.Component {
+	static contextType = EditorContext;
+
 	static key = 'spacing';
 
 	static propTypes = {

--- a/src/components/buttons/button-spacing.jsx
+++ b/src/components/buttons/button-spacing.jsx
@@ -6,7 +6,7 @@ import ButtonIcon from './button-icon.jsx';
 import ButtonStylesList from './button-styles-list.jsx';
 
 /**
- * The ButtonSpacing class provides functionality for changing text color in a document.
+ * The ButtonSpacing class provides functionality for changing text spacing in a document.
  *
  * @class ButtonSpacing
  */


### PR DESCRIPTION
Hey @wincent, @julien, just saw this in reference to https://issues.liferay.com/browse/LPS-102718 which is actually throwing an error there... it might be a different thing though, but this at least looked off...

Also, I assume there's something wrong in the description here, as it states:

```
* The ButtonSpacing class provides functionality for changing text color in a document.
```

We might need to update that :D