### PR TITLE
fix: include CNAME in public directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,5 +59,8 @@ typings/
 .env
 
 .cache/
-public
+/public/*
 yarn-error.log
+
+# Used by gh-pages to associate site with alloyeditor.com domain.
+!/public/CNAME

--- a/public/CNAME
+++ b/public/CNAME
@@ -1,0 +1,1 @@
+alloyeditor.com


### PR DESCRIPTION
If you look at [the commits on the gh-pages branch to the "CNAME" file](https://github.com/liferay/alloy-editor/commits/0bc43b350037a12132f7178c292ec90a964f40f3/CNAME
) you'll see that it was getting blown away on every site build and we've had to manually restore it each time.

This commit includes it in the "public" directory, which is used by the deploy.sh script as a basis for creating commits on the gh-pages branch, so that the file will stick around on every build.

Test plan: run `deploy.sh` (no need to actually `git push` the result) and inspect the generated commit; see that it did not delete the CNAME file from the `gh-pages` branch.