### PR TITLE
feat: add some useful worktree-related .gitignore entries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,6 @@ node_modules
 public
 sauce_connect.log
 test-results.xml
+/1.x/
+/gh-pages/
 /website/


### PR DESCRIPTION
Makes it convenient to have "1.x" and "gh-pages" checkouts nested in a repo clone (eg. created with `git worktree add gh-pages gh-pages` etc).