### PR TITLE
fix: avoid adding target attribute when default is selected

### DIFF
--- a/src/components/buttons/button-link-edit.jsx
+++ b/src/components/buttons/button-link-edit.jsx
@@ -442,13 +442,15 @@ class ButtonLinkEdit extends React.Component {
 		const linkUtils = new CKEDITOR.Link(editor, {
 			appendProtocol: this.props.appendProtocol,
 		});
-		const linkAttrs = {
+		let linkAttrs = {
 			target: this.state.linkTarget,
 		};
 		const modifySelection = {advance: true};
 
 		if (this.state.linkHref) {
 			if (this.state.element) {
+				if (!this.state.linkTarget) linkAttrs.target = null;
+
 				linkAttrs.href = this.state.linkHref;
 
 				linkUtils.update(
@@ -457,6 +459,8 @@ class ButtonLinkEdit extends React.Component {
 					modifySelection
 				);
 			} else {
+				if (!this.state.linkTarget) linkAttrs = {};
+
 				linkUtils.create(
 					this.state.linkHref,
 					linkAttrs,


### PR DESCRIPTION
Hi guys,

This solution is quite tricky, but I was trying to cover all the cases and we need to keep in mind that to achieve our goal:

- If we update the link from anything to default, [we need to pass null](https://github.com/liferay/alloy-editor/blob/master/src/core/link.js#L216-L221) as target.
- If we create the link with _default_ option, [we need to pass no target at all](https://github.com/liferay/alloy-editor/blob/master/src/core/link.js#L85-L91). If we pass null, it will be merged as the string _null_, and we'll get an attribute `target="null"` added to our link element in HTML.

I hope this helps you to understand the changes. 

Thanks.