### PR TITLE
docs: remove reference to IE9+ from README (#1357)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Alloy Editor is a modern WYSIWYG editor built on top of CKEditor, designed to create modern and gorgeous web content.
 
-Works on IE9+, Chrome, Firefox and Safari.
+Works on IE11, Chrome, Firefox and Safari.
 
 ## Demo
 


### PR DESCRIPTION
We already purged references to IE9 from the website in:

https://github.com/liferay/alloy-editor/pull/1244

But as pointed out in the related issue, the README still has a lingering reference to IE9.

IE11 is our baseline for support, as noted here:

https://github.com/liferay/alloy-editor/issues/1161

Any currently-tracked IE-related bugs and issues should appear under the "browser: ie" label:

https://github.com/liferay/alloy-editor/issues?q=is%3Aissue+is%3Aopen+label%3A%22browser%3A+ie%22

Closes: https://github.com/liferay/alloy-editor/issues/1357