### PR TITLE
refactor: avoid useless boolean expression

### DIFF
--- a/src/components/buttons/button-accessibility-image-alt.jsx
+++ b/src/components/buttons/button-accessibility-image-alt.jsx
@@ -32,7 +32,7 @@ class ButtonAccessibilityImageAlt extends React.Component {
 		const imageElement = element.findOne('img');
 
 		const imageAlt = imageElement
-			? imageElement && imageElement.getAttribute('alt')
+			? imageElement.getAttribute('alt')
 			: element && element.getAttribute('alt');
 
 		this.state = {


### PR DESCRIPTION
Added in: https://github.com/liferay/alloy-editor/pull/1377

We don't need the `imageElement &&` here; we just checked `imageElement` on the line above.