### PR TITLE
chore: update for compliance with current Outbound Licensing Policy

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,2 @@
+/copyright.js
 src/__generated__/*

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/LICENSES/LGPL-3.0-or-later.txt
+++ b/LICENSES/LGPL-3.0-or-later.txt
@@ -1,0 +1,70 @@
+GNU LESSER GENERAL PUBLIC LICENSE
+Version 3, 29 June 2007
+Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
+
+Everyone is permitted to copy and distribute verbatim copies of this license document, but changing it is not allowed.
+
+This version of the GNU Lesser General Public License incorporates the terms and conditions of version 3 of the GNU General Public License, supplemented by the additional permissions listed below.
+
+0. Additional Definitions.
+
+As used herein, "this License" refers to version 3 of the GNU Lesser General Public License, and the "GNU GPL" refers to version 3 of the GNU General Public License.
+
+"The Library" refers to a covered work governed by this License, other than an Application or a Combined Work as defined below.
+
+An "Application" is any work that makes use of an interface provided by the Library, but which is not otherwise based on the Library. Defining a subclass of a class defined by the Library is deemed a mode of using an interface provided by the Library.
+
+A "Combined Work" is a work produced by combining or linking an Application with the Library. The particular version of the Library with which the Combined Work was made is also called the "Linked Version".
+
+The "Minimal Corresponding Source" for a Combined Work means the Corresponding Source for the Combined Work, excluding any source code for portions of the Combined Work that, considered in isolation, are based on the Application, and not on the Linked Version.
+
+The "Corresponding Application Code" for a Combined Work means the object code and/or source code for the Application, including any data and utility programs needed for reproducing the Combined Work from the Application, but excluding the System Libraries of the Combined Work.
+
+1. Exception to Section 3 of the GNU GPL.
+   You may convey a covered work under sections 3 and 4 of this License without being bound by section 3 of the GNU GPL.
+
+2. Conveying Modified Versions.
+   If you modify a copy of the Library, and, in your modifications, a facility refers to a function or data to be supplied by an Application that uses the facility (other than as an argument passed when the facility is invoked), then you may convey a copy of the modified version:
+
+a) under this License, provided that you make a good faith effort to ensure that, in the event an Application does not supply the function or data, the facility still operates, and performs whatever part of its purpose remains meaningful, or
+
+b) under the GNU GPL, with none of the additional permissions of this License applicable to that copy.
+
+3. Object Code Incorporating Material from Library Header Files.
+   The object code form of an Application may incorporate material from a header file that is part of the Library. You may convey such object code under terms of your choice, provided that, if the incorporated material is not limited to numerical parameters, data structure layouts and accessors, or small macros, inline functions and templates (ten or fewer lines in length), you do both of the following:
+
+a) Give prominent notice with each copy of the object code that the Library is used in it and that the Library and its use are covered by this License.
+
+b) Accompany the object code with a copy of the GNU GPL and this license document.
+
+4. Combined Works.
+   You may convey a Combined Work under terms of your choice that, taken together, effectively do not restrict modification of the portions of the Library contained in the Combined Work and reverse engineering for debugging such modifications, if you also do each of the following:
+
+a) Give prominent notice with each copy of the Combined Work that the Library is used in it and that the Library and its use are covered by this License.
+
+b) Accompany the Combined Work with a copy of the GNU GPL and this license document.
+
+c) For a Combined Work that displays copyright notices during execution, include the copyright notice for the Library among these notices, as well as a reference directing the user to the copies of the GNU GPL and this license document.
+
+d) Do one of the following:
+
+0. Convey the Minimal Corresponding Source under the terms of this License, and the Corresponding Application Code in a form suitable for, and under terms that permit, the user to recombine or relink the Application with a modified version of the Linked Version to produce a modified Combined Work, in the manner specified by section 6 of the GNU GPL for conveying Corresponding Source.
+
+1. Use a suitable shared library mechanism for linking with the Library. A suitable mechanism is one that (a) uses at run time a copy of the Library already present on the user's computer system, and (b) will operate properly with a modified version of the Library that is interface-compatible with the Linked Version.
+
+e) Provide Installation Information, but only if you would otherwise be required to provide such information under section 6 of the GNU GPL, and only to the extent that such information is necessary to install and execute a modified version of the Combined Work produced by recombining or relinking the Application with a modified version of the Linked Version. (If you use option 4d0, the Installation Information must accompany the Minimal Corresponding Source and Corresponding Application Code. If you use option 4d1, you must provide the Installation Information in the manner specified by section 6 of the GNU GPL for conveying Corresponding Source.)
+
+5. Combined Libraries.
+   You may place library facilities that are a work based on the Library side by side in a single library together with other library facilities that are not Applications and are not covered by this License, and convey such a combined library under terms of your choice, if you do both of the following:
+
+a) Accompany the combined library with a copy of the same work based on the Library, uncombined with any other library facilities, conveyed under the terms of this License.
+
+b) Give prominent notice with the combined library that part of it is a work based on the Library, and explaining where to find the accompanying uncombined form of the same work.
+
+6. Revised Versions of the GNU Lesser General Public License.
+   The Free Software Foundation may publish revised and/or new versions of the GNU Lesser General Public License from time to time. Such new versions will be similar in spirit to the present version, but may differ in detail to address new problems or concerns.
+
+Each version is given a distinguishing version number. If the Library as you received it specifies that a certain numbered version of the GNU Lesser General Public License "or any later version" applies to it, you have the option of following the terms and conditions either of that published version or of any later version published by the Free Software Foundation. If the Library as you received it does not specify a version number of the GNU Lesser General Public License, you may choose any version of the GNU Lesser General Public License ever published by the Free Software Foundation.
+
+If the Library as you received it specifies that a proxy can decide whether future versions of the GNU Lesser General Public License shall
+apply, that proxy's public statement of acceptance of any version is permanent authorization for you to choose that version for the Library.

--- a/copyright.js
+++ b/copyright.js
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © <%= YEAR %> Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/karma-saucelabs.js
+++ b/karma-saucelabs.js
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/karma.common.js
+++ b/karma.common.js
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/karma.js
+++ b/karma.js
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/adapter/core.js
+++ b/src/adapter/core.js
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/adapter/editor-context.js
+++ b/src/adapter/editor-context.js
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/adapter/main.js
+++ b/src/adapter/main.js
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/commands/index.js
+++ b/src/commands/index.js
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/commands/remove-image.js
+++ b/src/commands/remove-image.js
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/components/base/button-action-style.js
+++ b/src/components/base/button-action-style.js
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/components/base/button-command-active.js
+++ b/src/components/base/button-command-active.js
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/components/base/button-command.js
+++ b/src/components/base/button-command.js
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/components/base/button-keystroke.js
+++ b/src/components/base/button-keystroke.js
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/components/base/button-props.js
+++ b/src/components/base/button-props.js
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/components/base/button-state-classes.js
+++ b/src/components/base/button-state-classes.js
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/components/base/button-style.js
+++ b/src/components/base/button-style.js
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/components/base/index.js
+++ b/src/components/base/index.js
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/components/base/toolbar-buttons.js
+++ b/src/components/base/toolbar-buttons.js
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/components/base/widget-dropdown.js
+++ b/src/components/base/widget-dropdown.js
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/components/base/widget-exclusive.js
+++ b/src/components/base/widget-exclusive.js
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/components/base/widget-focus-manager.js
+++ b/src/components/base/widget-focus-manager.js
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/components/buttons/button-accessibility-image-alt.jsx
+++ b/src/components/buttons/button-accessibility-image-alt.jsx
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/components/buttons/button-background-color.jsx
+++ b/src/components/buttons/button-background-color.jsx
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/components/buttons/button-bold.jsx
+++ b/src/components/buttons/button-bold.jsx
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/components/buttons/button-camera-image.jsx
+++ b/src/components/buttons/button-camera-image.jsx
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/components/buttons/button-camera.jsx
+++ b/src/components/buttons/button-camera.jsx
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/components/buttons/button-code.jsx
+++ b/src/components/buttons/button-code.jsx
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/components/buttons/button-color.jsx
+++ b/src/components/buttons/button-color.jsx
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/components/buttons/button-command-list-item.jsx
+++ b/src/components/buttons/button-command-list-item.jsx
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/components/buttons/button-commands-list.jsx
+++ b/src/components/buttons/button-commands-list.jsx
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/components/buttons/button-dropdown.jsx
+++ b/src/components/buttons/button-dropdown.jsx
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/components/buttons/button-embed-edit.jsx
+++ b/src/components/buttons/button-embed-edit.jsx
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/components/buttons/button-embed-video-edit.jsx
+++ b/src/components/buttons/button-embed-video-edit.jsx
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/components/buttons/button-embed-video.jsx
+++ b/src/components/buttons/button-embed-video.jsx
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/components/buttons/button-embed.jsx
+++ b/src/components/buttons/button-embed.jsx
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/components/buttons/button-h1.jsx
+++ b/src/components/buttons/button-h1.jsx
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/components/buttons/button-h2.jsx
+++ b/src/components/buttons/button-h2.jsx
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/components/buttons/button-hline.jsx
+++ b/src/components/buttons/button-hline.jsx
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/components/buttons/button-icon.jsx
+++ b/src/components/buttons/button-icon.jsx
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/components/buttons/button-image-align-center.jsx
+++ b/src/components/buttons/button-image-align-center.jsx
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/components/buttons/button-image-align-left.jsx
+++ b/src/components/buttons/button-image-align-left.jsx
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/components/buttons/button-image-align-right.jsx
+++ b/src/components/buttons/button-image-align-right.jsx
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/components/buttons/button-image.jsx
+++ b/src/components/buttons/button-image.jsx
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/components/buttons/button-indent-block.jsx
+++ b/src/components/buttons/button-indent-block.jsx
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/components/buttons/button-italic.jsx
+++ b/src/components/buttons/button-italic.jsx
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/components/buttons/button-item-selector-audio.jsx
+++ b/src/components/buttons/button-item-selector-audio.jsx
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/components/buttons/button-item-selector-image.jsx
+++ b/src/components/buttons/button-item-selector-image.jsx
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/components/buttons/button-item-selector-video.jsx
+++ b/src/components/buttons/button-item-selector-video.jsx
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/components/buttons/button-link-autocomplete-list.jsx
+++ b/src/components/buttons/button-link-autocomplete-list.jsx
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/components/buttons/button-link-browse.jsx
+++ b/src/components/buttons/button-link-browse.jsx
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/components/buttons/button-link-edit-browse.jsx
+++ b/src/components/buttons/button-link-edit-browse.jsx
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/components/buttons/button-link-edit.jsx
+++ b/src/components/buttons/button-link-edit.jsx
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/components/buttons/button-link-target-edit.jsx
+++ b/src/components/buttons/button-link-target-edit.jsx
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/components/buttons/button-link.jsx
+++ b/src/components/buttons/button-link.jsx
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/components/buttons/button-ol.jsx
+++ b/src/components/buttons/button-ol.jsx
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/components/buttons/button-outdent-block.jsx
+++ b/src/components/buttons/button-outdent-block.jsx
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/components/buttons/button-paragraph-align-left.jsx
+++ b/src/components/buttons/button-paragraph-align-left.jsx
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/components/buttons/button-paragraph-align-right.jsx
+++ b/src/components/buttons/button-paragraph-align-right.jsx
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/components/buttons/button-paragraph-align.jsx
+++ b/src/components/buttons/button-paragraph-align.jsx
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/components/buttons/button-paragraph-center.jsx
+++ b/src/components/buttons/button-paragraph-center.jsx
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/components/buttons/button-paragraph-justify.jsx
+++ b/src/components/buttons/button-paragraph-justify.jsx
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/components/buttons/button-quote.jsx
+++ b/src/components/buttons/button-quote.jsx
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/components/buttons/button-remove-format.jsx
+++ b/src/components/buttons/button-remove-format.jsx
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/components/buttons/button-remove-image.jsx
+++ b/src/components/buttons/button-remove-image.jsx
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/components/buttons/button-separator.jsx
+++ b/src/components/buttons/button-separator.jsx
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/components/buttons/button-spacing.jsx
+++ b/src/components/buttons/button-spacing.jsx
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/components/buttons/button-strike.jsx
+++ b/src/components/buttons/button-strike.jsx
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/components/buttons/button-styles-list-header.jsx
+++ b/src/components/buttons/button-styles-list-header.jsx
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/components/buttons/button-styles-list-item-remove.jsx
+++ b/src/components/buttons/button-styles-list-item-remove.jsx
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/components/buttons/button-styles-list-item.jsx
+++ b/src/components/buttons/button-styles-list-item.jsx
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/components/buttons/button-styles-list.jsx
+++ b/src/components/buttons/button-styles-list.jsx
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/components/buttons/button-styles.jsx
+++ b/src/components/buttons/button-styles.jsx
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/components/buttons/button-subscript.jsx
+++ b/src/components/buttons/button-subscript.jsx
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/components/buttons/button-superscript.jsx
+++ b/src/components/buttons/button-superscript.jsx
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/components/buttons/button-table-cell.jsx
+++ b/src/components/buttons/button-table-cell.jsx
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/components/buttons/button-table-column.jsx
+++ b/src/components/buttons/button-table-column.jsx
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/components/buttons/button-table-edit.jsx
+++ b/src/components/buttons/button-table-edit.jsx
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/components/buttons/button-table-heading.jsx
+++ b/src/components/buttons/button-table-heading.jsx
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/components/buttons/button-table-remove.jsx
+++ b/src/components/buttons/button-table-remove.jsx
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/components/buttons/button-table-row.jsx
+++ b/src/components/buttons/button-table-row.jsx
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/components/buttons/button-table.jsx
+++ b/src/components/buttons/button-table.jsx
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/components/buttons/button-target-list.jsx
+++ b/src/components/buttons/button-target-list.jsx
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/components/buttons/button-twitter.jsx
+++ b/src/components/buttons/button-twitter.jsx
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/components/buttons/button-ul.jsx
+++ b/src/components/buttons/button-ul.jsx
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/components/buttons/button-underline.jsx
+++ b/src/components/buttons/button-underline.jsx
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/components/buttons/index.js
+++ b/src/components/buttons/index.js
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/components/compat/button-action-style.js
+++ b/src/components/compat/button-action-style.js
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/components/compat/button-command-active.js
+++ b/src/components/compat/button-command-active.js
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/components/compat/button-command.js
+++ b/src/components/compat/button-command.js
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/components/compat/button-keystroke.js
+++ b/src/components/compat/button-keystroke.js
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/components/compat/button-props.js
+++ b/src/components/compat/button-props.js
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/components/compat/button-state-classes.js
+++ b/src/components/compat/button-state-classes.js
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/components/compat/button-style.js
+++ b/src/components/compat/button-style.js
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/components/compat/index.js
+++ b/src/components/compat/index.js
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/components/compat/toolbar-buttons.js
+++ b/src/components/compat/toolbar-buttons.js
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/components/compat/widget-arrow-box.js
+++ b/src/components/compat/widget-arrow-box.js
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/components/compat/widget-dropdown.js
+++ b/src/components/compat/widget-dropdown.js
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/components/compat/widget-exclusive.js
+++ b/src/components/compat/widget-exclusive.js
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/components/compat/widget-focus-manager.js
+++ b/src/components/compat/widget-focus-manager.js
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/components/compat/widget-interaction-point.js
+++ b/src/components/compat/widget-interaction-point.js
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/components/compat/widget-position.js
+++ b/src/components/compat/widget-position.js
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/components/main.jsx
+++ b/src/components/main.jsx
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/components/toolbars/index.js
+++ b/src/components/toolbars/index.js
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/components/toolbars/toolbar-add.jsx
+++ b/src/components/toolbars/toolbar-add.jsx
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/components/toolbars/toolbar-styles.jsx
+++ b/src/components/toolbars/toolbar-styles.jsx
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/components/uibridge/button.jsx
+++ b/src/components/uibridge/button.jsx
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/components/uibridge/index.js
+++ b/src/components/uibridge/index.js
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/components/uibridge/menu-button.jsx
+++ b/src/components/uibridge/menu-button.jsx
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/components/uibridge/menu.jsx
+++ b/src/components/uibridge/menu.jsx
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/components/uibridge/panel-menu-button.jsx
+++ b/src/components/uibridge/panel-menu-button.jsx
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/components/uibridge/richcombo.jsx
+++ b/src/components/uibridge/richcombo.jsx
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/components/uibridge/uibridge.js
+++ b/src/components/uibridge/uibridge.js
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/core/debounce.js
+++ b/src/core/debounce.js
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/core/link.js
+++ b/src/core/link.js
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/core/plugins.js
+++ b/src/core/plugins.js
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/core/selection-region.js
+++ b/src/core/selection-region.js
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/core/table.js
+++ b/src/core/table.js
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/core/tools.js
+++ b/src/core/tools.js
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/core/uicore.js
+++ b/src/core/uicore.js
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/oop/attribute.js
+++ b/src/oop/attribute.js
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/oop/base.js
+++ b/src/oop/base.js
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/oop/lang.js
+++ b/src/oop/lang.js
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/oop/oop.js
+++ b/src/oop/oop.js
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/plugins/DragEvent.es.js
+++ b/src/plugins/DragEvent.es.js
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/plugins/Resizer.es.js
+++ b/src/plugins/Resizer.es.js
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/plugins/addimages.js
+++ b/src/plugins/addimages.js
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/plugins/autolink.js
+++ b/src/plugins/autolink.js
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/plugins/autolist.js
+++ b/src/plugins/autolist.js
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/plugins/dragresize.js
+++ b/src/plugins/dragresize.js
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/plugins/dragresize_ie.js
+++ b/src/plugins/dragresize_ie.js
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/plugins/dragresize_ie11.js
+++ b/src/plugins/dragresize_ie11.js
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/plugins/embed.js
+++ b/src/plugins/embed.js
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/plugins/embedurl.js
+++ b/src/plugins/embedurl.js
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/plugins/imagealignment.js
+++ b/src/plugins/imagealignment.js
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/plugins/index.js
+++ b/src/plugins/index.js
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/plugins/pasteimages.js
+++ b/src/plugins/pasteimages.js
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/plugins/placeholder.js
+++ b/src/plugins/placeholder.js
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/plugins/priorities.js
+++ b/src/plugins/priorities.js
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/plugins/selectionkeystrokes.js
+++ b/src/plugins/selectionkeystrokes.js
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/plugins/tableresize.js
+++ b/src/plugins/tableresize.js
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/plugins/tabletools.js
+++ b/src/plugins/tabletools.js
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/selections/selection-arrowbox.js
+++ b/src/selections/selection-arrowbox.js
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/selections/selection-position.js
+++ b/src/selections/selection-position.js
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/selections/selection-test.js
+++ b/src/selections/selection-test.js
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/src/selections/selections.js
+++ b/src/selections/selections.js
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 

--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -1,6 +1,5 @@
 /**
- * © 2014 Liferay, Inc. <https://liferay.com>
- *
+ * SPDX-FileCopyrightText: © 2014 Liferay, Inc. <https://liferay.com>
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 


### PR DESCRIPTION
This change is analogous to the one I made in:

- https://github.com/liferay/eslint-config-liferay/pull/151
- https://github.com/liferay/liferay-npm-tools/pull/394
- https://github.com/liferay/liferay-js-themes-toolkit/pull/441
- https://github.com/liferay/clay/pull/2947

It updates the license header format to match the latest policy:

https://grow.liferay.com/excellence/Liferay+Outbound+Licensing+Policy

Did this by updating `copyright.js` and running `yarn lint:fix`. I used a Vim macro to strip out the original headers. I then edited the template to use a dynamic `<%= YEAR %>` instead of hard-coded 2014, so that any subsequently created files will use the year of creation.

Adds a copy of the license to `LICENSES/LGPL-3.0-or-later.txt` as required by the policy too.