### PR TITLE
fix: check that the selected element is valid

### DIFF
--- a/src/components/buttons/button-accessibility-image-alt.jsx
+++ b/src/components/buttons/button-accessibility-image-alt.jsx
@@ -20,15 +20,17 @@ class ButtonAccessibilityImageAlt extends React.Component {
 
 	static key = 'imageAlt';
 
-	componentDidMount() {
-		const editor = this.props.context.editor;
-		const nativeEditor = editor.get('nativeEditor');
-		const selection = nativeEditor.getSelection();
+	constructor(props) {
+		super(props);
 
-		const element = selection.getSelectedElement();
-		const startElement = selection.getStartElement();
+		const selection = props.context.editor
+			.get('nativeEditor')
+			.getSelection();
 
-		this._element = element || startElement;
+		const element =
+			selection.getSelectedElement() || selection.getStartElement();
+
+		this._element = element;
 
 		const imageElement = this._element.findOne('img');
 

--- a/src/components/buttons/button-accessibility-image-alt.jsx
+++ b/src/components/buttons/button-accessibility-image-alt.jsx
@@ -23,10 +23,17 @@ class ButtonAccessibilityImageAlt extends React.Component {
 	constructor(props) {
 		super(props);
 
-		const element = props.context.editor
-			.get('nativeEditor')
-			.getSelection()
-			.getSelectedElement();
+		const editor = props.context.editor;
+
+		const nativeEditor = editor.get('nativeEditor');
+
+		const selection = nativeEditor.getSelection();
+
+		const element = selection.getSelectedElement();
+
+		if (!element) {
+			return;
+		}
 
 		const imageElement = element.findOne('img');
 

--- a/src/components/buttons/button-accessibility-image-alt.jsx
+++ b/src/components/buttons/button-accessibility-image-alt.jsx
@@ -36,7 +36,7 @@ class ButtonAccessibilityImageAlt extends React.Component {
 
 		const imageAlt = imageElement
 			? imageElement.getAttribute('alt')
-			: this._element && this._element.getAttribute('alt');
+			: this._element.getAttribute('alt');
 
 		this.state = {
 			imageAlt,

--- a/src/components/buttons/button-accessibility-image-alt.jsx
+++ b/src/components/buttons/button-accessibility-image-alt.jsx
@@ -20,29 +20,23 @@ class ButtonAccessibilityImageAlt extends React.Component {
 
 	static key = 'imageAlt';
 
-	constructor(props) {
-		super(props);
-
-		const editor = props.context.editor;
-
+	componentDidMount() {
+		const editor = this.props.context.editor;
 		const nativeEditor = editor.get('nativeEditor');
-
 		const selection = nativeEditor.getSelection();
 
 		const element = selection.getSelectedElement();
+		const startElement = selection.getStartElement();
 
-		if (!element) {
-			return;
-		}
+		this._element = element || startElement;
 
-		const imageElement = element.findOne('img');
+		const imageElement = this._element.findOne('img');
 
 		const imageAlt = imageElement
 			? imageElement.getAttribute('alt')
-			: element && element.getAttribute('alt');
+			: this._element && this._element.getAttribute('alt');
 
 		this.state = {
-			element,
 			imageAlt,
 		};
 	}
@@ -168,8 +162,8 @@ class ButtonAccessibilityImageAlt extends React.Component {
 			imageAlt,
 		});
 
-		const imageElement = this.state.element.findOne('img');
-		const image = imageElement ? imageElement : this.state.element;
+		const imageElement = this._element.findOne('img');
+		const image = imageElement ? imageElement : this._element;
 
 		image.setAttribute('alt', imageAlt);
 


### PR DESCRIPTION
Sometimes when interacting images in the editor,
the "selected element" can be null, and if this is the
case this code will fail.
An interesting this to note is that this code runs
although we haven't interacted with this
'button-accessibility-image-alt.jsx' component (probably
due to the fact these components are all HOCs)