### PR TITLE
fix: gracefully handle invalid JSON in data-style attribute (#1393)

### DIFF
--- a/src/plugins/embedurl.js
+++ b/src/plugins/embedurl.js
@@ -406,11 +406,19 @@ if (!CKEDITOR.plugins.get('embedurl')) {
 
 					// Sync dimensions and alignment with editor wrapper
 
+					let styles = null;
+
 					const stylesJSON = instance.element.getAttribute(
 						'data-styles'
 					);
 
-					let styles = stylesJSON ? JSON.parse(stylesJSON) : null;
+					if (stylesJSON) {
+						try {
+							styles = JSON.parse(stylesJSON);
+						} catch (_error) {
+							styles = null;
+						}
+					}
 
 					if (!styles) {
 						const iframe = instance.wrapper.findOne('iframe');


### PR DESCRIPTION
Is fixing #1393 If data-style attribute is not a valid JSON an exception will be thrown and the code will stop working.