### PR TITLE
fix: update instructions at end of build script

### DIFF
--- a/scripts/build/build-ckeditor.sh
+++ b/scripts/build/build-ckeditor.sh
@@ -60,6 +60,6 @@ echo "    yarn start # check demo"
 echo
 echo "Don't forget to commit the result!"
 echo
-echo "    git add -A -- ckeditor ckeditor-debug"
-echo "    git commit -m 'Update CKEDITOR to $VERSION'"
+echo "    git add -A -- lib"
+echo "    git commit -m 'chore: Update CKEDITOR to $VERSION'"
 echo


### PR DESCRIPTION
Noticed that this had drifted out of sync since the last time we did a build:

- Built files are now stored under lib/.
- We use Conventional Commits format for our commit messages now.

Originally part of: https://github.com/liferay/alloy-editor/pull/1396

But that got superseded by: https://github.com/liferay/alloy-editor/pull/1402

So I salvaged this commit and am sending it separately.