### PR TITLE
fix: Don't allow users to input a value less than a minimum `row` or `col` value when creating a table

### DIFF
--- a/src/components/buttons/button-table-edit.jsx
+++ b/src/components/buttons/button-table-edit.jsx
@@ -121,12 +121,8 @@ class ButtonTableEdit extends React.Component {
 	_handleChange = (inputName, event) => {
 		const state = {};
 
-		if (
-			inputName === INPUT_NAMES.ROWS ||
-			(inputName === INPUT_NAMES.COLS &&
-				event.target.value < MINIMUM_GRID_VALUE)
-		) {
-			state[inputName] = MINIMUM_GRID_VALUE;
+		if (inputName === INPUT_NAMES.COLS || inputName === INPUT_NAMES.ROWS) {
+			state[inputName] = Math.min(event.target.value, MINIMUM_GRID_VALUE);
 		} else {
 			state[inputName] = event.target.value;
 		}

--- a/src/components/buttons/button-table-edit.jsx
+++ b/src/components/buttons/button-table-edit.jsx
@@ -11,6 +11,13 @@ import ButtonIcon from './button-icon.jsx';
 const KEY_ENTER = 13;
 const KEY_ESC = 27;
 
+const INPUT_NAMES = {
+	COLS: 'cols',
+	ROWS: 'rows',
+};
+
+const MINIMUM_GRID_VALUE = 1;
+
 /**
  * The ButtonTableEdit class provides functionality for creating and editing a table in a document.
  * Provides UI for creating a table.
@@ -113,7 +120,16 @@ class ButtonTableEdit extends React.Component {
 	 */
 	_handleChange = (inputName, event) => {
 		const state = {};
-		state[inputName] = event.target.value;
+
+		if (
+			inputName === INPUT_NAMES.ROWS ||
+			(inputName === INPUT_NAMES.COLS &&
+				event.target.value < MINIMUM_GRID_VALUE)
+		) {
+			state[inputName] = MINIMUM_GRID_VALUE;
+		} else {
+			state[inputName] = event.target.value;
+		}
 
 		this.setState(state);
 	};
@@ -151,8 +167,8 @@ class ButtonTableEdit extends React.Component {
 	 */
 	render() {
 		const time = Date.now();
-		const rowsId = time + 'rows';
-		const colsId = time + 'cols';
+		const rowsId = time + INPUT_NAMES.ROWS;
+		const colsId = time + INPUT_NAMES.COLS;
 
 		return (
 			<div className="ae-container-edit-table">
@@ -161,8 +177,11 @@ class ButtonTableEdit extends React.Component {
 					<input
 						className="ae-input"
 						id={rowsId}
-						min="1"
-						onChange={this._handleChange.bind(this, 'rows')}
+						min={MINIMUM_GRID_VALUE}
+						onChange={this._handleChange.bind(
+							this,
+							INPUT_NAMES.ROWS
+						)}
 						onKeyDown={this._handleKeyDown}
 						placeholder="Rows"
 						ref={this.rowsRef}
@@ -176,8 +195,11 @@ class ButtonTableEdit extends React.Component {
 					<input
 						className="ae-input"
 						id={colsId}
-						min="1"
-						onChange={this._handleChange.bind(this, 'cols')}
+						min={MINIMUM_GRID_VALUE}
+						onChange={this._handleChange.bind(
+							this,
+							INPUT_NAMES.COLS
+						)}
 						onKeyDown={this._handleKeyDown}
 						placeholder="Colums"
 						ref={this.colsRef}

--- a/test/ui/test/button-table-edit.jsx
+++ b/test/ui/test/button-table-edit.jsx
@@ -13,6 +13,34 @@ describe('ButtonTableEdit', function() {
 	beforeEach(Utils.createAlloyEditor);
 	afterEach(Utils.destroyAlloyEditor);
 
+	it('should create a 1x1 table by default when user selects a negative value for rows or columns', function() {
+		var buttonTableEdit = this.render(
+			<ButtonTableEdit cancelExclusive={sinon.stub()} />,
+			this.container
+		);
+
+		Simulate.change(buttonTableEdit.rowsRef.current, {
+			target: {value: -1},
+		});
+		Simulate.change(buttonTableEdit.colsRef.current, {
+			target: {value: 0},
+		});
+
+		var confirmButton = this.container.querySelector('button');
+		assert.ok(confirmButton);
+
+		Simulate.click(confirmButton);
+
+		var data = bender.tools.getData(this.nativeEditor, {
+			fixHtml: true,
+			compatHtml: true,
+		});
+
+		var expected = getFixture('1_by_1_table.html');
+
+		assert.strictEqual(data, expected);
+	});
+
 	it('should create a 3x3 table by default when clicking on the confirm button', function() {
 		var buttonTableEdit = this.render(
 			<ButtonTableEdit cancelExclusive={sinon.stub()} />,

--- a/test/ui/test/button-table-edit.jsx
+++ b/test/ui/test/button-table-edit.jsx
@@ -13,7 +13,7 @@ describe('ButtonTableEdit', function() {
 	beforeEach(Utils.createAlloyEditor);
 	afterEach(Utils.destroyAlloyEditor);
 
-	it('should create a 1x1 table by default when user selects a negative value for rows or columns', function() {
+	it('creates a 1x1 table by default when user selects a negative value for rows or columns', function() {
 		var buttonTableEdit = this.render(
 			<ButtonTableEdit cancelExclusive={sinon.stub()} />,
 			this.container
@@ -41,7 +41,7 @@ describe('ButtonTableEdit', function() {
 		assert.strictEqual(data, expected);
 	});
 
-	it('should create a 3x3 table by default when clicking on the confirm button', function() {
+	it('creates a 3x3 table by default when clicking on the confirm button', function() {
 		var buttonTableEdit = this.render(
 			<ButtonTableEdit cancelExclusive={sinon.stub()} />,
 			this.container
@@ -62,7 +62,7 @@ describe('ButtonTableEdit', function() {
 		assert.strictEqual(data, expected);
 	});
 
-	it('should create a 6 x 4 table based on the rows and cols inputs when clicking on the confirm button', function() {
+	it('creates a 6 x 4 table based on the rows and cols inputs when clicking on the confirm button', function() {
 		var buttonTableEdit = this.render(
 			<ButtonTableEdit cancelExclusive={sinon.stub()} />,
 			this.container
@@ -90,7 +90,7 @@ describe('ButtonTableEdit', function() {
 		assert.strictEqual(data, expected);
 	});
 
-	it('should create a 6 x 4 table based on the rows and cols inputs when pressing enter on the rows input', function() {
+	it('creates a 6 x 4 table based on the rows and cols inputs when pressing enter on the rows input', function() {
 		var buttonTableEdit = this.render(
 			<ButtonTableEdit cancelExclusive={sinon.stub()} />,
 			this.container
@@ -117,7 +117,7 @@ describe('ButtonTableEdit', function() {
 		assert.strictEqual(data, expected);
 	});
 
-	it('should create a 6 x 4 table based on the rows and cols inputs when pressing enter on the cols input', function() {
+	it('creates a 6 x 4 table based on the rows and cols inputs when pressing enter on the cols input', function() {
 		var buttonTableEdit = this.render(
 			<ButtonTableEdit cancelExclusive={sinon.stub()} />,
 			this.container
@@ -144,7 +144,7 @@ describe('ButtonTableEdit', function() {
 		assert.strictEqual(data, expected);
 	});
 
-	it('should not create a table and dismiss the ui when pressing escape on the rows input', function() {
+	it('not create a table and dismiss the ui when pressing escape on the rows input', function() {
 		var cancelExclusive = sinon.stub();
 
 		var buttonTableEdit = this.render(
@@ -168,7 +168,7 @@ describe('ButtonTableEdit', function() {
 		assert.strictEqual(1, cancelExclusive.callCount);
 	});
 
-	it('should not create a table and dismiss the ui when pressing escape on the cols input', function() {
+	it('not create a table and dismiss the ui when pressing escape on the cols input', function() {
 		var cancelExclusive = sinon.stub();
 
 		var buttonTableEdit = this.render(

--- a/test/ui/test/fixtures/1_by_1_table.html
+++ b/test/ui/test/fixtures/1_by_1_table.html
@@ -1,0 +1,8 @@
+<table border="1" cellpadding="0" cellspacing="0" style="width:100%;">
+	<tbody>
+		<tr>
+			<td>&nbsp;</td>
+		</tr>
+	</tbody>
+</table>
+<p>&nbsp;</p>


### PR DESCRIPTION
…`col` value when creating a table

### Test Case:

Run Demo Page:

Click on AE's plus Icon, add a Table with 0 for number of columns and -1 for number of rows

Currently AE allows the user for input negative values for cols/rows.

### What I did:

I restricted the user to set a value less than the minimum value for col/row defined on html element just preventing the user to type negative values from the keyboard. That was already defined to `-1`. See https://github.com/liferay/alloy-editor/compare/master...diegonvs:110423?expand=1&title=fix%3A+Don%27t+allow+users+to+input+a+value+less+than+a+minimum+%60row%60+or+%60col%60+value+when+creating+a+table#diff-4b5fe36c64a18eb8591a90632c092ee0L164

@drakonux, from a UX perspective, is it correct? An alternative can be providing a validation message.

Closes: https://issues.liferay.com/browse/LPS-110423