### PR TITLE
fix: set width and height attributes for firefox and chrome (#1412)

### DIFF
--- a/src/plugins/dragresize.js
+++ b/src/plugins/dragresize.js
@@ -555,16 +555,22 @@ if (!CKEDITOR.plugins.get('ae_dragresize')) {
 	function resizeElement(el, width, height) {
 		const imageScaleResize = this.editor.config.imageScaleResize;
 		if (imageScaleResize === 'both') {
+			el.setAttribute('width', String(width));
 			el.style.width = String(width) + 'px';
+			el.setAttribute('height', String(height));
 			el.style.height = String(height) + 'px';
 		} else if (
 			imageScaleResize === 'width' ||
 			imageScaleResize === 'scale'
 		) {
+			el.removeAttribute('height');
 			el.style.height = 'auto';
+			el.setAttribute('width', String(width));
 			el.style.width = String(width) + 'px';
 		} else if (imageScaleResize === 'height') {
+			el.setAttribute('height', String(height));
 			el.style.height = String(height) + 'px';
+			el.removeAttribute('width');
 			el.style.width = 'auto';
 		}
 	}


### PR DESCRIPTION
From original issue:

**Do you want to request a _feature_ or report a _bug_?**
bug

**What is the current behavior?**
* resizing an image in IE11 sets the style, height, and width attributes
* resizing an image in Chrome or Firefox sets only the style attribute

**If the current behavior is a bug, please provide the steps to reproduce and if possible a minimal demo of the problem.**
1. Open Chrome, resize the image in the demo site `fullmoon.thumbnail.jpg` and inspect the element, noticing there are no width and height attributes
2. Open Firefox, resize the image in the demo site `fullmoon.thumbnail.jpg` and inspect the element, noticing there are no width and height attributes
3. Open Firefox, resize the image in the demo site `fullmoon.thumbnail.jpg` and inspect the element, noticing there are width and height attributes

**What is the expected behavior?**
1. Open Chrome, resize the image in the demo site `fullmoon.thumbnail.jpg` and inspect the element, noticing there are width and height attributes
2. Open Firefox, resize the image in the demo site `fullmoon.thumbnail.jpg` and inspect the element, noticing there are width and height attributes
3. Open Firefox, resize the image in the demo site `fullmoon.thumbnail.jpg` and inspect the element, noticing there are width and height attributes

**Which versions of alloy-editor, and which browser / OS are affected by this issue? Did this work in previous versions?**
* Chrome and Firefox are affected by this issue.
* This did not work in previous versions.
* We attempted to fix this by making IE11 _not_ have width and height attributes in https://github.com/liferay/alloy-editor/pull/923 but it was reverted in order to resolve https://github.com/liferay/alloy-editor/pull/1060