### PR TITLE
fix: unbreak table drag-resizing by using fixed table layout

### DIFF
--- a/src/components/buttons/button-table-edit.jsx
+++ b/src/components/buttons/button-table-edit.jsx
@@ -32,7 +32,7 @@ class ButtonTableEdit extends React.Component {
 			border: 1,
 			cellPadding: 0,
 			cellSpacing: 0,
-			style: 'width: 100%',
+			style: 'table-layout: fixed; width: 100%;',
 		},
 	};
 


### PR DESCRIPTION
When inserting data, everything must be wrapped up on the cell and cell width couldn't expand.

It is impossible to use the drag ability to resize a column when other columns in the table have content which then pushes the empty columns together.

### How I fixed it: 

Based on https://github.com/ckeditor/ckeditor4/issues/3614#issuecomment-549410457 I just changed the table style directly on the table definition. 


### Before:
![fail](https://user-images.githubusercontent.com/7663513/88332660-438bfe00-cd05-11ea-964b-5b7d65220e04.gif)


### After:
![mammamia](https://user-images.githubusercontent.com/7663513/88332446-f60f9100-cd04-11ea-94d6-51194e05b8eb.gif)

#### Resize:

![resize](https://user-images.githubusercontent.com/7663513/88332907-bac19200-cd05-11ea-8f81-318ff5e04ecd.gif)


Fixes: https://issues.liferay.com/browse/LPS-114429
