### PR TITLE
fix: avoid JS error computing selection position

### DIFF
--- a/src/selections/selection-position.js
+++ b/src/selections/selection-position.js
@@ -50,10 +50,15 @@ const centerToolbar = function(toolbar, rect) {
 	const ranges = caretPosition.getRanges();
 	let offsetHeight = 0;
 
-	if (ranges) {
-		const startContainer = ranges[0].startContainer;
-		const startContainerClientRect = startContainer.getClientRect();
-		offsetHeight = startContainerClientRect.y - rect.top;
+	if (ranges && ranges.length === 1) {
+		let startContainer = ranges[0].startContainer;
+		if (startContainer.$.nodeType !== Node.ELEMENT_NODE) {
+			startContainer = startContainer.getParent();
+		}
+		if (startContainer) {
+			const startContainerClientRect = startContainer.getClientRect();
+			offsetHeight = startContainerClientRect.y - rect.top;
+		}
 	}
 
 	const endPosition = [


### PR DESCRIPTION
Noticed while testing https://github.com/liferay/alloy-editor/pull/1414 a bunch of console spew coming from the `getClientRect()` calls in selection-position.js. These prevent the toolbar from being shown. I gather I am not the only one who sees this, because in @diegonvs's screencap gif on #1414 you can also see there is no toolbar.

![Screenshot 2020-07-24 -124412-ZHLamCxs@2x](https://user-images.githubusercontent.com/7074/88389294-7e01a380-cdb6-11ea-9eff-e199f990045d.png)

This looks like a regression introduced in bef3ce28. I don't know why we didn't catch it during initial testing; that made me think that it might actually be the subsequent CKEditor update that exposed the problem, but no, when I go back to bef3ce28 I can repro the error. You can see in @julien's [original PR](https://github.com/liferay/alloy-editor/pull/1404) a screencap gif of it working for him.

The problem is that `startContainer` may be a text node, which doesn't have a `getClientRect()` method on it:

https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_dom_text.html

So, this commit tries to get the parent element in that case, and if we have one, we proceed; elements do have the `getClientRect()` method:

https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_dom_element.html

Test plan:

Run demo (`yarn start`) and see that I can click in a cell to see the table-specific toolbar; I can select text in a cell to see text-specific toolbar.

![alloy](https://user-images.githubusercontent.com/7074/88389485-e486c180-cdb6-11ea-8590-3ece6a3b9102.gif)

Also run build and test it out in liferay-portal:

    yarn build

    # Use zsh trick...
    setopt extendedglob

    # ...to copy everything but node_modules and website:
    cp -R ^(node_modules|website) ~modules/node_modules/alloyeditor

    # ... cd to path frontend-editor-alloyeditor-web
    j alloy

    # ... deploy
    gradlew deploy -a

On master, I don't see the console spew or the missing toolbar (for some unknown reason).  With this PR, toolbar continues to appear correctly, so whatever we're doing here is compatible with the CKEditor version in liferay-portal.

But note that there is some very funky stuff going in master at the moment, where you can't click to move the cursor (you have to use the keyboard. No JS errors in the console. I am aware of some CKEditor-related work that is going on though that may already include an inbound fix for that.

Adding multiple reviewers because somebody might know what is going on with master at the moment (@diegonvs, @carloslancha, @markocikos... what the heck, may as well mention @mateomustapic as well — come and join the party!).