### PR TITLE
fix: Avoids blocking user input when settling a minimal input value

### DIFF
--- a/src/components/buttons/button-table-edit.jsx
+++ b/src/components/buttons/button-table-edit.jsx
@@ -100,8 +100,8 @@ class ButtonTableEdit extends React.Component {
 
 		tableUtils.create({
 			attrs: this.props.tableAttributes,
-			cols: cols < MINIMUM_GRID_VALUE ? MINIMUM_GRID_VALUE : cols,
-			rows: rows < MINIMUM_GRID_VALUE ? MINIMUM_GRID_VALUE : rows,
+			cols: Math.max(MINIMUM_GRID_VALUE, cols),
+			rows: Math.max(MINIMUM_GRID_VALUE, rows),
 		});
 
 		this.props.cancelExclusive();

--- a/src/components/buttons/button-table-edit.jsx
+++ b/src/components/buttons/button-table-edit.jsx
@@ -96,11 +96,12 @@ class ButtonTableEdit extends React.Component {
 	_createTable = () => {
 		const editor = this.context.editor.get('nativeEditor');
 		const tableUtils = new CKEDITOR.Table(editor);
+		const {cols, rows} = this.state;
 
 		tableUtils.create({
 			attrs: this.props.tableAttributes,
-			cols: this.state.cols,
-			rows: this.state.rows,
+			cols: cols < MINIMUM_GRID_VALUE ? MINIMUM_GRID_VALUE : cols,
+			rows: rows < MINIMUM_GRID_VALUE ? MINIMUM_GRID_VALUE : rows,
 		});
 
 		this.props.cancelExclusive();
@@ -121,11 +122,7 @@ class ButtonTableEdit extends React.Component {
 	_handleChange = (inputName, event) => {
 		const state = {};
 
-		if (inputName === INPUT_NAMES.COLS || inputName === INPUT_NAMES.ROWS) {
-			state[inputName] = Math.min(event.target.value, MINIMUM_GRID_VALUE);
-		} else {
-			state[inputName] = event.target.value;
-		}
+		state[inputName] = event.target.value;
 
 		this.setState(state);
 	};

--- a/src/components/buttons/button-table-edit.jsx
+++ b/src/components/buttons/button-table-edit.jsx
@@ -120,11 +120,9 @@ class ButtonTableEdit extends React.Component {
 	 * @protected
 	 */
 	_handleChange = (inputName, event) => {
-		const state = {};
-
-		state[inputName] = event.target.value;
-
-		this.setState(state);
+		this.setState({
+			[inputName]: event.target.value,
+		});
 	};
 
 	/**


### PR DESCRIPTION
### Test Case

1. Open "Advanced Editing Demo" from the current master
2. Click on the add button for adding a grid
3. Try to type the number `22` cleaning the current value and just typing `22`

It's not possible settling this number because the onChange event is being triggered for every keyboard input like `delete`.

![before](https://user-images.githubusercontent.com/7663513/89839953-5e53d480-db45-11ea-9e9c-977146f1edd8.gif)

### Behavior changed

I tried to fix it changing from `onChange` to `onInput` but I didn't get success, also, I tried to use `onBlur` for just updating the input when the input is blurred but no success. The only alternative that I've found was when submitting the value from the inputs, validate, and then just changing the minimum value if received an invalid value.

After the mentioned changes:

![after](https://user-images.githubusercontent.com/7663513/89840515-c7881780-db46-11ea-8d5f-9e91cc37ac14.gif)
