### PR TITLE
fix: if we're locking the image attributes, use 'auto' for the height like we do in other browsers

### DIFF
--- a/src/plugins/dragresize_ie11.js
+++ b/src/plugins/dragresize_ie11.js
@@ -420,13 +420,16 @@
 					src: image.getAttribute('src'),
 					alt: image.getAttribute('alt') || '',
 					width: image.getAttribute('width') || '',
-					height: image.getAttribute('height') || '',
 
 					// Lock ratio is on by default (#10833).
 					lock: this.ready
 						? helpers.checkHasNaturalRatio(image)
 						: true,
 				};
+
+				data.height = data.lock
+					? null
+					: image.getAttribute('height') || '';
 
 				// If we used 'a' in widget#parts definition, it could happen that
 				// selected element is a child of widget.parts#caption. Since there's no clever
@@ -1249,7 +1252,10 @@
 	function setDimensions(widget) {
 		const data = widget.data;
 
-		const dimensions = {width: data.width, height: data.height};
+		const dimensions = {
+			width: data.width,
+			height: data.lock ? null : data.height,
+		};
 
 		const image = widget.parts.image;
 
@@ -1475,7 +1481,9 @@
 				// This is to prevent images to visually disappear.
 				if (newWidth >= 15 && newHeight >= 15) {
 					image.$.style.width = newWidth + 'px';
-					image.$.style.height = newHeight + 'px';
+					image.$.style.height = widget.data.lock
+						? 'auto'
+						: newHeight + 'px';
 
 					updateData = true;
 				} else {
@@ -1496,7 +1504,7 @@
 
 				if (updateData) {
 					widget.setData({
-						height: newHeight,
+						height: widget.data.lock ? null : newHeight,
 						width: newWidth,
 					});
 


### PR DESCRIPTION
From original issue:

**Do you want to request a _feature_ or report a _bug_?**
bug

**What is the current behavior?**
* resizing an image in IE11 sets the height attribute to an explicit pixel value even if dimensions are locked
* resizing an image in Chrome or Firefox does not set a height attribute and sets the height style to `auto`

**If the current behavior is a bug, please provide the steps to reproduce and if possible a minimal demo of the problem.**
1. Open Chrome, resize the image in the demo site `fullmoon.thumbnail.jpg` and inspect the element, noticing there is no height attribute, and the style is `height: auto`
2. Open Firefox, resize the image in the demo site `fullmoon.thumbnail.jpg` and inspect the element, noticing there is no height attribute, and the style is `height: auto`
3. Open IE11, resize the image in the demo site `fullmoon.thumbnail.jpg` and inspect the element, noticing there are is an explicit pixel value for height, both as an image attribute and as a style

**What is the expected behavior?**
1. Open Chrome, resize the image in the demo site `fullmoon.thumbnail.jpg` and inspect the element, noticing there is no height attribute, and the style is `height: auto`
2. Open Firefox, resize the image in the demo site `fullmoon.thumbnail.jpg` and inspect the element, noticing there is no height attribute, and the style is `height: auto`
2. Open IE11, resize the image in the demo site `fullmoon.thumbnail.jpg` and inspect the element, noticing there is no height attribute, and the style is `height: auto`

**Which versions of alloy-editor, and which browser / OS are affected by this issue? Did this work in previous versions?**
* ~Chrome and Firefox are affected by this issue.~
* This did not work in previous versions.