### PR TITLE
fix: correct toolbar misalignment when editor is rendered in modal and the uiNode is provided

### DIFF
--- a/src/components/base/toolbar-buttons.js
+++ b/src/components/base/toolbar-buttons.js
@@ -454,7 +454,9 @@ export default WrappedComponent =>
 					10
 				);
 				const totalWidth =
-					uiNodeMarginLeft + uiNode.clientWidth + uiNodeMarginRight;
+					uiNodeMarginLeft +
+					document.body.clientWidth +
+					uiNodeMarginRight;
 
 				const scrollTop =
 					uiNode.tagName !== 'BODY' ? uiNode.scrollTop : 0;


### PR DESCRIPTION
Hey,
Github issue: https://github.com/liferay/alloy-editor/issues/1424
[LPS-120361](https://issues.liferay.com/browse/LPS-120361)
Note in order to test in liferay [LPS-120360](https://issues.liferay.com/browse/LPS-120360) has to be applied

Also there is a discussion at [PTR-1918](https://issues.liferay.com/browse/PTR-1918) about why we decided we should fix this in AE.

Please review my change,

Thanks