### PR TITLE
fix: use `this.props.editor` instead of `this.context.editor`

### DIFF
--- a/src/components/base/button-command-active.js
+++ b/src/components/base/button-command-active.js
@@ -24,7 +24,7 @@ export default WrappedComponent =>
 		 * @return {Boolean} True if the command is active, false otherwise.
 		 */
 		isActive() {
-			const editor = this.context.editor.get('nativeEditor');
+			const editor = this.props.editor.get('nativeEditor');
 
 			const command = editor.getCommand(this.props.command);
 

--- a/src/components/base/button-style.js
+++ b/src/components/base/button-style.js
@@ -89,7 +89,7 @@ export default WrappedComponent =>
 		 * @return {Boolean} True if style is active, false otherwise.
 		 */
 		isActive() {
-			const editor = this.context.editor.get('nativeEditor');
+			const editor = this.props.editor.get('nativeEditor');
 			const elementPath = editor.elementPath();
 			return this.getStyle().checkActive(elementPath, editor);
 		}


### PR DESCRIPTION
When looking at [PTR-1914](https://issues.liferay.com/browse/PTR-1914),
`this.context.editor` was `undefined` in both of these `isActive`
functions.

I also spotted this
[comment](https://github.com/liferay/alloy-editor/blob/f3617e1e629fd13553c4a933efa547198eddbb2f/src/adapter/editor-context.js#L14-L21) which makes me think that this is a 
reasonable change 
(after having tested the change locally and seeing it not failing).