### PR TITLE
chore: config Yarn to use "pre" as preid

### DIFF
--- a/.yarnrc
+++ b/.yarnrc
@@ -1,3 +1,4 @@
 # Make `yarn version` produce the right commit message and tag for this package.
 version-tag-prefix "v"
 version-git-message "chore: prepare v%s release"
+--version.preid pre


### PR DESCRIPTION
So that we can create prerelease test releases like we do in liferay-js-themes-toolkit with `yarn version --prepatch` and so on:

- https://classic.yarnpkg.com/en/docs/cli/version/
- https://github.com/liferay/liferay-js-themes-toolkit/blob/cefa75c9c64/.yarnrc (ie. current master)

I used this to produce

- https://github.com/liferay/alloy-editor/releases/tag/v2.11.14-pre.0

And documented the process here:

- https://github.com/liferay/alloy-editor/wiki/Contributing/_compare/7f5484e35a...28f26cca11