### PR TITLE
fix: avoid accessing this.context outside of render and lifecycle methods

### DIFF
--- a/src/components/base/button-action-style.js
+++ b/src/components/base/button-action-style.js
@@ -33,7 +33,7 @@ export default WrappedComponent =>
 				Lang.isFunction(this.isActive) &&
 				Lang.isFunction(this.getStyle)
 			) {
-				const editor = this.context.editor.get('nativeEditor');
+				const editor = this.props.editor.get('nativeEditor');
 
 				editor.getSelection().lock();
 

--- a/src/components/base/button-command-active.js
+++ b/src/components/base/button-command-active.js
@@ -24,7 +24,7 @@ export default WrappedComponent =>
 		 * @return {Boolean} True if the command is active, false otherwise.
 		 */
 		isActive() {
-			const editor = this.context.editor.get('nativeEditor');
+			const editor = this.props.editor.get('nativeEditor');
 
 			const command = editor.getCommand(this.props.command);
 

--- a/src/components/base/button-command.js
+++ b/src/components/base/button-command.js
@@ -23,7 +23,7 @@ export default WrappedComponent =>
 		 * @method execCommand
 		 */
 		execCommand = data => {
-			const editor = this.context.editor.get('nativeEditor');
+			const editor = this.props.editor.get('nativeEditor');
 
 			editor.execCommand(this.props.command, data);
 

--- a/src/components/base/button-props.js
+++ b/src/components/base/button-props.js
@@ -27,7 +27,7 @@ export default WrappedComponent =>
 		 * @return {Object} The merged properties
 		 */
 		mergeButtonCfgProps(props = this.props) {
-			const nativeEditor = this.context.editor.get('nativeEditor');
+			const nativeEditor = this.props.editor.get('nativeEditor');
 			const buttonCfg = nativeEditor.config.buttonCfg || {};
 			return CKEDITOR.tools.merge(props, buttonCfg['linkEdit']);
 		}

--- a/src/components/base/button-style.js
+++ b/src/components/base/button-style.js
@@ -89,7 +89,7 @@ export default WrappedComponent =>
 		 * @return {Boolean} True if style is active, false otherwise.
 		 */
 		isActive() {
-			const editor = this.context.editor.get('nativeEditor');
+			const editor = this.props.editor.get('nativeEditor');
 			const elementPath = editor.elementPath();
 			return this.getStyle().checkActive(elementPath, editor);
 		}

--- a/src/components/base/toolbar-buttons.js
+++ b/src/components/base/toolbar-buttons.js
@@ -383,7 +383,7 @@ export default WrappedComponent =>
 		 */
 		show() {
 			const domNode = ReactDOM.findDOMNode(this);
-			const uiNode = this.context.editor.get('uiNode');
+			const uiNode = this.props.editor.get('uiNode');
 
 			const scrollTop = uiNode ? uiNode.scrollTop : 0;
 
@@ -443,7 +443,7 @@ export default WrappedComponent =>
 
 			if (interactionPoint && domNode) {
 				const uiNode =
-					this.context.editor.get('uiNode') || document.body;
+					this.props.editor.get('uiNode') || document.body;
 				const uiNodeStyle = getComputedStyle(uiNode);
 				const uiNodeMarginLeft = parseInt(
 					uiNodeStyle.getPropertyValue('margin-left'),
@@ -520,7 +520,7 @@ export default WrappedComponent =>
 		getToolbarButtons(buttons, additionalProps) {
 			const buttonProps = {};
 
-			const nativeEditor = this.context.editor.get('nativeEditor');
+			const nativeEditor = this.props.editor.get('nativeEditor');
 			const buttonCfg = nativeEditor.config.buttonCfg || {};
 
 			if (Lang.isFunction(buttons)) {
@@ -555,7 +555,7 @@ export default WrappedComponent =>
 			).map(function(button, index) {
 				let props = this.mergeExclusiveProps(
 					{
-						editor: this.context.editor,
+						editor: this.props.editor,
 						key:
 							button.key !== 'separator'
 								? button.key


### PR DESCRIPTION
Detailed discussion that led to this change can be found here:
https://issues.liferay.com/browse/PTR-1914 .

According to the official docs this.context should only be accessed in
lifecycle methods including the render function.
https://reactjs.org/docs/context.html#classcontexttype

I also go into more detail why I decided to apply these changes here:
https://issues.liferay.com/browse/PTR-1914?focusedCommentId=2278112&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-2278112

