### PR TITLE
fix: Do not advance selection when editing a link

### DIFF
--- a/src/components/buttons/button-link-edit.jsx
+++ b/src/components/buttons/button-link-edit.jsx
@@ -402,7 +402,7 @@ class ButtonLinkEdit extends React.Component {
 		const selection = editor.getSelection();
 		const bookmarks = selection.createBookmarks();
 
-		linkUtils.remove(this.state.element, {advance: true});
+		linkUtils.remove(this.state.element, {advance: false});
 
 		selection.selectBookmarks(bookmarks);
 
@@ -444,7 +444,7 @@ class ButtonLinkEdit extends React.Component {
 		let linkAttrs = {
 			target: this.state.linkTarget || null,
 		};
-		const modifySelection = {advance: true};
+		const modifySelection = {advance: false};
 
 		if (this.state.linkHref) {
 			if (this.state.element) {


### PR DESCRIPTION
**Forwarded from [https://github.com/julien/alloy-editor/pull/10](https://github.com/julien/alloy-editor/pull/10)**

Original pull request message:

Hi @julien ,

These are the changes I believe we need to make to achieve what's been discussed in https://issues.liferay.com/browse/PTR-2196: keep the focus on the current element when we are editing a link. The toolbar will also remain open since the focus is still on a linked element (unless we remove the link).

There is also an open LPS to manage these change (increment alloyeditor version) within liferay-portal you can use:
https://issues.liferay.com/browse/LPS-126034

Please let us know if the modifications look good to you or if anything else is needed.

Thank you!

//cc @antonio-ortega @mariapicadoal

---

Test plan:

- Run `yarn start`
- Visit http://localhost:9000 in your favorite browser

Result:

![recording](https://user-images.githubusercontent.com/5572/106862925-15ca3d80-66c8-11eb-9fc6-7ef9d5948eb1.gif)

Fixes #1457 
