### PR TITLE
fix: Toolbar is not correctly positioned when editing tables and images within a modal window

### DIFF
--- a/src/selections/selection-position.js
+++ b/src/selections/selection-position.js
@@ -61,13 +61,16 @@ const centerToolbar = function(toolbar, rect) {
 		}
 	}
 
+	const scrollTop = uiNode ? uiNode.scrollTop : 0;
+
 	const endPosition = [
 		rect.left + rect.width / 2 - halfNodeWidth - scrollPosition.x,
 		rect.top +
 			offsetHeight -
 			toolbarNode.offsetHeight +
 			scrollPosition.y -
-			gutter.top,
+			gutter.top +
+			scrollTop,
 	];
 
 	if (endPosition[0] < 0) {


### PR DESCRIPTION
Hey guys,

Can you have review this pull request, please?

It is just one more time the case when we need to consider the scroll from top of the uiNode we are passing to the editor.

Closes: https://github.com/liferay/alloy-editor/issues/1466

Thanks.

Regards.

/cc @crodriguezy 