### PR TITLE
fix: use `ALLOYEDITOR_BASEPATH` in spritemap default value

### DIFF
--- a/src/adapter/core.js
+++ b/src/adapter/core.js
@@ -654,7 +654,9 @@ extend(
 			 */
 			spritemap: {
 				validator: Lang.isString,
-				value: 'alloy-editor/assets/icons/icons.svg',
+				value:
+					(window.ALLOYEDITOR_BASEPATH || 'alloy-editor/') +
+					'assets/icons/icons.svg',
 				writeOnce: true,
 			},
 


### PR DESCRIPTION
fixes #1489