### PR TITLE
fix: Two functions have the same icon in the same toolbar (#1495)

### DIFF
--- a/src/components/buttons/button-item-selector-video.jsx
+++ b/src/components/buttons/button-item-selector-video.jsx
@@ -28,7 +28,7 @@ class ButtonItemSelectorVideo extends React.Component {
 				onClick={this._handleClick}
 				tabIndex={this.props.tabIndex}
 				title={AlloyEditor.Strings.video}>
-				<ButtonIcon symbol="video" />
+				<ButtonIcon symbol="document-multimedia" />
 			</button>
 		);
 	}


### PR DESCRIPTION
Hi!

This is fixing https://github.com/liferay/alloy-editor/issues/1495 , two functions have the same icon on the same toolbar, which is confusing.

Please review!

Thanks!

(Additional info can be found in the comment section of https://issues.liferay.com/browse/PTR-2571 )