### PR TITLE
fix: add 'rel' attribute to the generated links

### DIFF
--- a/src/core/link.js
+++ b/src/core/link.js
@@ -85,6 +85,7 @@ Link.prototype = {
 			{
 				'data-cke-saved-href': URI,
 				href: URI,
+				'rel': 'noopener noreferrer',
 			},
 			attrs
 		);


### PR DESCRIPTION
Hello,
fix: automatically add 'rel' attribute to the generated links to prevent tabnabbing security vulnerability
issue: https://github.com/liferay/alloy-editor/issues/1521

I have added "noreferrer" value as well since "noopener" is not compatible with IE11 and earlier Liferay versions (<7.4) support IE11 browser as well.

Related tickets:
- https://issues.liferay.com/browse/LPS-151771
- https://issues.liferay.com/browse/PTR-3001

Could you please review it? 
cc. @antonio-ortega 
Thanks.