### PR TITLE
fix: #1524 indent and outdent icons are switched

### DIFF
--- a/src/components/buttons/button-indent-block.jsx
+++ b/src/components/buttons/button-indent-block.jsx
@@ -61,7 +61,7 @@ class ButtonIndentBlock extends React.Component {
 				onClick={this.execCommand}
 				tabIndex={this.props.tabIndex}
 				title={AlloyEditor.Strings.indent}>
-				<ButtonIcon symbol="indent-less" />
+				<ButtonIcon symbol="indent-more" />
 			</button>
 		);
 	}

--- a/src/components/buttons/button-outdent-block.jsx
+++ b/src/components/buttons/button-outdent-block.jsx
@@ -61,7 +61,7 @@ class ButtonOutdentBlock extends React.Component {
 				onClick={this.execCommand}
 				tabIndex={this.props.tabIndex}
 				title={AlloyEditor.Strings.outdent}>
-				<ButtonIcon symbol="indent-more" />
+				<ButtonIcon symbol="indent-less" />
 			</button>
 		);
 	}


### PR DESCRIPTION
https://github.com/liferay/alloy-editor/issues/1524
https://issues.liferay.com/browse/LPS-152668

The indent and outdent icons are switched.

Let me know if there are any questions or comments about this.
Thank you.