### PR TITLE
fix: modify the toolbar add button border to outline to avoid layout shift

### DIFF
--- a/src/assets/sass/components/ae-toolbar/skin.scss
+++ b/src/assets/sass/components/ae-toolbar/skin.scss
@@ -23,7 +23,7 @@
 
 .ae-toolbar-add {
     background-color: $toolbar-add-bg-color;
-    border-color: $toolbar-add-border-color;
+    outline-color: $toolbar-add-border-color;
     border-radius: $toolbar-add-border-radius;
     color: $toolbar-add-font-color;
 

--- a/src/assets/sass/components/ae-toolbar/structure.scss
+++ b/src/assets/sass/components/ae-toolbar/structure.scss
@@ -44,7 +44,7 @@
 }
 
 .ae-toolbar-add {
-    border: solid $toolbar-add-border-width transparent;
+    outline: solid $toolbar-add-border-width transparent;
     padding: $toolbar-add-padding;
 
     .ae-button {

--- a/src/assets/sass/skin/atlas/variables/structure.scss
+++ b/src/assets/sass/skin/atlas/variables/structure.scss
@@ -53,7 +53,7 @@ $dropdown-listbox-item-max-height: 44px;
 $dropdown-listbox-item-padding: 8px 12px;
 
 /** TOOLBAR **/
-$toolbar-add-border-width: 2px;
+$toolbar-add-border-width: 1px;
 $toolbar-add-height: 44px;
 $toolbar-add-width: 44px;
 


### PR DESCRIPTION
Hi @liferay-frontend Team,

When clicking on the plus icon of the repeatable HTML field, the layout is shifted on the first click and the new field is not added. I think this is caused by the border style of the toolbar add button. I removed the transparent border and modified the toolbar border width a bit, so the style of the toolbar button has remained the same.

https://github.com/liferay/alloy-editor/issues/1529
LPS: https://issues.liferay.com/browse/LPS-155757

**issue**:
![issue](https://user-images.githubusercontent.com/69793575/173059194-352dbdef-16dc-4190-a377-a92743cb89a5.gif)
style of the add button before the change:
![image](https://user-images.githubusercontent.com/69793575/173059778-b2a8a562-1b94-4108-9a0f-04fbc5335dbd.png)

**fix**:
![fix](https://user-images.githubusercontent.com/69793575/173059647-4956ca63-4cfc-401f-892b-b1bd5c9bc048.gif)
after:
![borderstyle-after](https://user-images.githubusercontent.com/69793575/173059665-865d9326-d714-4caf-ac0b-577f5dbb7e53.JPG)

Could you please review it?
Thank you.
