### PR TITLE
use defaultLinkTarget when creating a link, fixes autolink

### DIFF
--- a/src/core/link.js
+++ b/src/core/link.js
@@ -90,6 +90,14 @@ Link.prototype = {
 			attrs
 		);
 
+		if (!linkAttrs.target) {
+			const linkCfg = this._editor.config.linkCfg || {};
+			const defaultTarget = linkCfg && linkCfg.defaultTarget;
+			if (defaultTarget) {
+				linkAttrs.target = defaultTarget;
+			}
+		}
+
 		const style = new CKEDITOR.style({
 			attributes: linkAttrs,
 			element: 'a',

--- a/test/core/test/link.js
+++ b/test/core/test/link.js
@@ -606,5 +606,29 @@ describe('Link', function() {
 				'<p>update the url of a <a href="test.com" rel="noopener noreferrer" target="_blank">link</a>.</p>'
 			);
 		});
+
+		it('should create a link with a default target, when no target is given', function() {
+			this.nativeEditor.config.linkCfg = {
+				defaultTarget: '_blank',
+			};
+			var link = new CKEDITOR.Link(this.nativeEditor);
+
+			bender.tools.selection.setWithHtml(
+				this.nativeEditor,
+				'set a {selection} and then convert it to a link.'
+			);
+
+			link.create('http://test.com');
+
+			var data = bender.tools.getData(this.nativeEditor, {
+				fixHtml: true,
+				compatHtml: true,
+			});
+
+			assert.strictEqual(
+				data,
+				'<p>set a <a href="http://test.com" rel="noopener noreferrer" target="_blank">selection</a> and then convert it to a link.</p>'
+			);
+		});
 	});
 });

--- a/test/plugins/test/autolink.js
+++ b/test/plugins/test/autolink.js
@@ -251,6 +251,18 @@ describe('AutoLink', function() {
 		testLinkAtEnd.call(this, KEY_ENTER);
 	});
 
+	it('should create a link with default target when pressing SPACE', function() {
+		this.nativeEditor.config.linkCfg = {
+			defaultTarget: '_blank',
+		};
+		testLink.call(this, {
+			expected:
+				'<p>link <a href="http://www.liferay.com" rel="noopener noreferrer" target="_blank">www.liferay.com</a></p>',
+			html: '<p>link www.liferay.com { }</p>',
+			keyCode: KEY_SPACE,
+		});
+	});
+
 	function testLink(config) {
 		bender.tools.selection.setWithHtml(this.nativeEditor, config.html);
 
@@ -280,7 +292,7 @@ describe('AutoLink', function() {
 
 		assert.doesNotThrow(
 			function() {
-				happen.keyup(this._editable, {keyCode: keyCode});
+				happen.keyup(this._editable, {keyCode});
 			}.bind(this)
 		);
 	}


### PR DESCRIPTION
fixes https://github.com/liferay/alloy-editor/issues/1534

followup on https://github.com/liferay/alloy-editor/pull/1535

@bettysteger This is what I had in mind with 'squash and split code into two commits', in https://github.com/liferay/alloy-editor/pull/1535#pullrequestreview-1034129536. I don't want to waste any more of your time, so I molded commits and pushed to this PR. I still set you as the author on commits, credit where it's due :slightly_smiling_face: 