### PR TITLE
fix: Reset uibridge definitions each time we destroy and create and editor (#1537)

### DIFF
--- a/src/components/uibridge/button.jsx
+++ b/src/components/uibridge/button.jsx
@@ -146,6 +146,8 @@ if (!CKEDITOR.plugins.get('ae_buttonbridge')) {
 		 * @param {Object} editor The CKEditor instance being initialized
 		 */
 		beforeInit(editor) {
+			BUTTON_DEFS[editor.name] = {};
+
 			editor.ui.addButton = function(buttonName, buttonDefinition) {
 				this.add(buttonName, CKEDITOR.UI_BUTTON, buttonDefinition);
 			};

--- a/src/components/uibridge/menu-button.jsx
+++ b/src/components/uibridge/menu-button.jsx
@@ -194,6 +194,8 @@ if (!CKEDITOR.plugins.get('ae_menubuttonbridge')) {
 		 * @param {Object} editor The CKEditor instance being initialized
 		 */
 		beforeInit(editor) {
+			MENUBUTTON_DEFS[editor.name] = {};
+
 			editor.ui.addMenuButton = function(
 				menuButtonName,
 				menuButtonDefinition

--- a/src/components/uibridge/panel-menu-button.jsx
+++ b/src/components/uibridge/panel-menu-button.jsx
@@ -197,6 +197,8 @@ if (!CKEDITOR.plugins.get('ae_panelmenubuttonbridge')) {
 		 * @param {Object} editor The CKEditor instance being initialized
 		 */
 		beforeInit(editor) {
+			PANEL_MENU_DEFS[editor.name] = {};
+
 			editor.ui.addPanelMenuButton = function(
 				panelMenuButtonName,
 				panelMenuButtonDefinition

--- a/src/components/uibridge/richcombo.jsx
+++ b/src/components/uibridge/richcombo.jsx
@@ -235,6 +235,8 @@ if (!CKEDITOR.plugins.get('ae_richcombobridge')) {
 		 * @param {Object} editor The CKEditor instance being initialized
 		 */
 		beforeInit(editor) {
+			RICH_COMBO_DEFS[editor.name] = {};
+
 			editor.ui.addRichCombo = function(
 				richComboName,
 				richComboDefinition


### PR DESCRIPTION
fix: Reset uibridge definitions each time we destroy and create and editor (#1537)

We can use https://issues.liferay.com/browse/LPS-156925 to upgrade alloy-editor version in the portal.