### PR TITLE
fix: avoid null on init and destroy the editor too fast makes the DOM is not loaded

### DIFF
--- a/src/adapter/core.js
+++ b/src/adapter/core.js
@@ -171,13 +171,15 @@ extend(
 			const nativeEditor = this.get('nativeEditor');
 			const isMSSelection = typeof window.getSelection != 'function';
 
-			if (isMSSelection) {
-				nativeEditor.document.$.selection.empty();
-			} else {
-				nativeEditor.document
-					.getWindow()
-					.$.getSelection()
-					.removeAllRanges();
+			if (nativeEditor.document) {
+				if (isMSSelection) {
+					nativeEditor.document.$.selection.empty();
+				} else {
+					nativeEditor.document
+						.getWindow()
+						.$.getSelection()
+						.removeAllRanges();
+				}
 			}
 		},
 


### PR DESCRIPTION
Related ticket: https://issues.liferay.com/browse/LPS-166754
The root cause is when switch too fast between the cards the editor DOM objects are not loaded, so it could be null on [core.js](https://github.com/liferay/alloy-editor/blob/master/src/adapter/core.js#L177,%20L180)
then the editor is failed to destroy while all the listeners are removed. When the destroy() method is invoked again it gets null when accessing the length of event handlers [EditableRichTextFragmentProcessor.es.js](https://github.com/liferay/liferay-portal-ee/blob/7.2.x/modules/apps/layout/layout-content-%20page-editor-web/src/main/resources/META-INF/resources/js/components/fragment_processors/EditableRichTextFragmentProcessor.es.js#L38,L45)